### PR TITLE
Remove CVarArg for travis to build.

### DIFF
--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -1161,9 +1161,8 @@ public class VisualRecognition {
         // create a globally unique file name in a temporary directory
         let suffix = "VisualRecognitionParameters.json"
         
-        let arg1:CVarArg = UUID().uuidString as CVarArg
-        let arg2:CVarArg = suffix as CVarArg
-        let fileName = String(format: "%@_%@", arg1, arg2)
+        let uuid = UUID().uuidString
+        let fileName = "\(uuid)_\(suffix)"
         let directoryURL = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let fileURL = directoryURL.appendingPathComponent(fileName)!
         


### PR DESCRIPTION
Removing CVarArg due to Travis complaints, preventing Travis builds to build properly.