### PR TITLE
Update link to NLC docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ naturalLanguageClassifier.classify(text, withClassifierID: classifierID, failure
 The following links provide more information about the Natural Language Classifier service:
 
 * [IBM Watson Natural Language Classifier - Service Page](http://www.ibm.com/watson/developercloud/nl-classifier.html)
-* [IBM Watson Natural Language Classifier - Documentation](http://www.ibm.com/watson/developercloud/doc/nl-classifier)
+* [IBM Watson Natural Language Classifier - Documentation](http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html)
 * [IBM Watson Natural Language Classifier - Demo](https://natural-language-classifier-demo.mybluemix.net/)
 
 ## Personality Insights

--- a/docs/swift-api/services/AlchemyDataNewsV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/AlchemyDataNewsV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -643,7 +643,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/AlchemyDataNewsV1/index.html
+++ b/docs/swift-api/services/AlchemyDataNewsV1/index.html
@@ -643,7 +643,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/AlchemyLanguageV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/AlchemyLanguageV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -681,7 +681,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/AlchemyLanguageV1/index.html
+++ b/docs/swift-api/services/AlchemyLanguageV1/index.html
@@ -681,7 +681,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/AlchemyVisionV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/AlchemyVisionV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -616,7 +616,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/AlchemyVisionV1/index.html
+++ b/docs/swift-api/services/AlchemyVisionV1/index.html
@@ -616,7 +616,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/ConversationV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/ConversationV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -609,7 +609,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/ConversationV1/index.html
+++ b/docs/swift-api/services/ConversationV1/index.html
@@ -609,7 +609,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/DialogV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/DialogV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -614,7 +614,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/DialogV1/index.html
+++ b/docs/swift-api/services/DialogV1/index.html
@@ -614,7 +614,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/DocumentConversionV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/DocumentConversionV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -597,7 +597,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/DocumentConversionV1/index.html
+++ b/docs/swift-api/services/DocumentConversionV1/index.html
@@ -597,7 +597,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/LanguageTranslatorV2/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/LanguageTranslatorV2/docsets/.docset/Contents/Resources/Documents/index.html
@@ -600,7 +600,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/LanguageTranslatorV2/index.html
+++ b/docs/swift-api/services/LanguageTranslatorV2/index.html
@@ -600,7 +600,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/NaturalLanguageClassifierV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/NaturalLanguageClassifierV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -594,7 +594,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/NaturalLanguageClassifierV1/index.html
+++ b/docs/swift-api/services/NaturalLanguageClassifierV1/index.html
@@ -594,7 +594,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/PersonalityInsightsV2/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/PersonalityInsightsV2/docsets/.docset/Contents/Resources/Documents/index.html
@@ -583,7 +583,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/PersonalityInsightsV2/index.html
+++ b/docs/swift-api/services/PersonalityInsightsV2/index.html
@@ -583,7 +583,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/PersonalityInsightsV3/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/PersonalityInsightsV3/docsets/.docset/Contents/Resources/Documents/index.html
@@ -595,7 +595,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/PersonalityInsightsV3/index.html
+++ b/docs/swift-api/services/PersonalityInsightsV3/index.html
@@ -595,7 +595,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/RelationshipExtractionV1Beta/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/RelationshipExtractionV1Beta/docsets/.docset/Contents/Resources/Documents/index.html
@@ -633,7 +633,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/RelationshipExtractionV1Beta/index.html
+++ b/docs/swift-api/services/RelationshipExtractionV1Beta/index.html
@@ -633,7 +633,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/RetrieveAndRankV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/RetrieveAndRankV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -629,7 +629,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/RetrieveAndRankV1/index.html
+++ b/docs/swift-api/services/RetrieveAndRankV1/index.html
@@ -629,7 +629,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/SpeechToTextV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/SpeechToTextV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -654,7 +654,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/SpeechToTextV1/index.html
+++ b/docs/swift-api/services/SpeechToTextV1/index.html
@@ -654,7 +654,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/TextToSpeechV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/TextToSpeechV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -612,7 +612,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/TextToSpeechV1/index.html
+++ b/docs/swift-api/services/TextToSpeechV1/index.html
@@ -612,7 +612,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/ToneAnalyzerV3/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/ToneAnalyzerV3/docsets/.docset/Contents/Resources/Documents/index.html
@@ -586,7 +586,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/ToneAnalyzerV3/index.html
+++ b/docs/swift-api/services/ToneAnalyzerV3/index.html
@@ -586,7 +586,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/TradeoffAnalyticsV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/TradeoffAnalyticsV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -630,7 +630,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/TradeoffAnalyticsV1/index.html
+++ b/docs/swift-api/services/TradeoffAnalyticsV1/index.html
@@ -630,7 +630,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/VisualRecognitionV3/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/VisualRecognitionV3/docsets/.docset/Contents/Resources/Documents/index.html
@@ -634,7 +634,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>

--- a/docs/swift-api/services/VisualRecognitionV3/index.html
+++ b/docs/swift-api/services/VisualRecognitionV3/index.html
@@ -634,7 +634,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/nl-classifier">IBM Watson Natural Language Classifier - Documentation</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html">IBM Watson Natural Language Classifier - Documentation</a></li>
 <li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <a href='#personality-insights' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='personality-insights'>Personality Insights</h2>


### PR DESCRIPTION
Natural Language Classifier docs have new url after conversion to Markdown.