### PR TITLE
Add response methods that support for responseToError functions

### DIFF
--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -120,14 +120,48 @@ public struct RestRequest {
             completionHandler(dataResponse)
         }
     }
-    
+
+    fileprivate func dataToErrorWrapper(dataToError: ((Data) -> Error?)? = nil) -> ((HTTPURLResponse?, Data?) -> Error?)?
+    {
+        return { response, data in
+            // ensure data is not nil
+            guard let data = data else {
+                return RestError.noData
+            }
+
+            // can the data be parsed as an error?
+            if let dataToError = dataToError,
+                let error = dataToError(data) {
+                return error
+            }
+
+            return nil
+        }
+    }
+
     public func responseObject<T: JSONDecodable>(
         dataToError: ((Data) -> Error?)? = nil,
         path: [JSONPathType]? = nil,
         completionHandler: @escaping (RestResponse<T>) -> Void)
     {
+        responseObject(responseToError: dataToErrorWrapper(dataToError: dataToError), path: path, completionHandler: completionHandler)
+    }
+
+    public func responseObject<T: JSONDecodable>(
+        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
+        path: [JSONPathType]? = nil,
+        completionHandler: @escaping (RestResponse<T>) -> Void)
+    {
         response() { data, response, error in
             
+            if let responseToError = responseToError,
+                let error = responseToError(response, data) {
+                let result = Result<T>.failure(error)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                completionHandler(dataResponse)
+                return
+            }
+
             // ensure data is not nil
             guard let data = data else {
                 let result = Result<T>.failure(RestError.noData)
@@ -135,15 +169,7 @@ public struct RestRequest {
                 completionHandler(dataResponse)
                 return
             }
-            
-            // can the data be parsed as an error?
-            if let dataToError = dataToError, let error = dataToError(data) {
-                let result = Result<T>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
-                completionHandler(dataResponse)
-                return
-            }
-            
+
             // parse json object
             let result: Result<T>
             do {
@@ -178,8 +204,24 @@ public struct RestRequest {
         path: [JSONPathType]? = nil,
         completionHandler: @escaping (RestResponse<[T]>) -> Void)
     {
+        responseArray(responseToError: dataToErrorWrapper(dataToError: dataToError), path: path, completionHandler: completionHandler)
+    }
+
+    public func responseArray<T: JSONDecodable>(
+        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
+        path: [JSONPathType]? = nil,
+        completionHandler: @escaping (RestResponse<[T]>) -> Void)
+    {
         response() { data, response, error in
-            
+
+            if let responseToError = responseToError,
+                let error = responseToError(response, data) {
+                let result = Result<[T]>.failure(error)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                completionHandler(dataResponse)
+                return
+            }
+
             // ensure data is not nil
             guard let data = data else {
                 let result = Result<[T]>.failure(RestError.noData)
@@ -187,15 +229,7 @@ public struct RestRequest {
                 completionHandler(dataResponse)
                 return
             }
-            
-            // can the data be parsed as an error?
-            if let dataToError = dataToError, let error = dataToError(data) {
-                let result = Result<[T]>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
-                completionHandler(dataResponse)
-                return
-            }
-            
+
             // parse json object
             let result: Result<[T]>
             do {
@@ -225,13 +259,28 @@ public struct RestRequest {
             completionHandler(dataResponse)
         }
     }
-    
+
     public func responseString(
         dataToError: ((Data) -> Error?)? = nil,
         completionHandler: @escaping (RestResponse<String>) -> Void)
     {
+        responseString(responseToError: dataToErrorWrapper(dataToError: dataToError), completionHandler: completionHandler)
+    }
+
+    public func responseString(
+        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
+        completionHandler: @escaping (RestResponse<String>) -> Void)
+    {
         response() { data, response, error in
-            
+
+            if let responseToError = responseToError,
+                let error = responseToError(response, data) {
+                let result = Result<String>.failure(error)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                completionHandler(dataResponse)
+                return
+            }
+
             // ensure data is not nil
             guard let data = data else {
                 let result = Result<String>.failure(RestError.noData)
@@ -239,15 +288,7 @@ public struct RestRequest {
                 completionHandler(dataResponse)
                 return
             }
-            
-            // can the data be parsed as an error?
-            if let dataToError = dataToError, let error = dataToError(data) {
-                let result = Result<String>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
-                completionHandler(dataResponse)
-                return
-            }
-            
+
             // parse data as a string
             guard let string = String(data: data, encoding: .utf8) else {
                 let result = Result<String>.failure(RestError.serializationError)

--- a/Source/RestKit/RestToken.swift
+++ b/Source/RestKit/RestToken.swift
@@ -58,7 +58,7 @@ public class RestToken {
             headerParameters: [:])
         
         // TODO - validate request
-        request.responseString { response in
+        request.responseString(dataToError: nil) { response in
             switch response.result {
             case .success(let token):
                 self.token = token


### PR DESCRIPTION
### Summary

This PR adds response methods to RestKit that accept a responseToError function parameter, in place of the dataToError function parameter.  The existing methods with the dataToError function parameter have been retained for compatibility but reimplemented using the new (more general) methods.

The purpose for this change is to allow SDKs to use information from both the response and data objects to identify and describe errors reported by the service. For example, the ErrorResponse (data) for the Conversation service does not contain the HTTP status code, so the Conversation service can now use the responseToError function to extract the HTTP status code from the response for the Error object.

### Other Information
