### PR TITLE
Add responseVoid method to RestKit

### DIFF
--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -310,24 +310,15 @@ public struct RestRequest {
     {
         response() { data, response, error in
 
-            if let responseToError = responseToError,
-                let error = responseToError(response, data) {
+            if let responseToError = responseToError, let error = responseToError(response, data) {
                 let result = Result<Void>.failure(error)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
             }
 
-            // ensure data is not nil
-            guard let data = data else {
-                let result = Result<Void>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
-                completionHandler(dataResponse)
-                return
-            }
-
             // execute callback
-            let result = Result<Void>.success(())
+            let result = Result<Void>.success()
             let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
             completionHandler(dataResponse)
         }

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -303,7 +303,36 @@ public struct RestRequest {
             completionHandler(dataResponse)
         }
     }
-    
+
+    public func responseVoid(
+        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
+        completionHandler: @escaping (RestResponse<Void>) -> Void)
+    {
+        response() { data, response, error in
+
+            if let responseToError = responseToError,
+                let error = responseToError(response, data) {
+                let result = Result<Void>.failure(error)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                completionHandler(dataResponse)
+                return
+            }
+
+            // ensure data is not nil
+            guard let data = data else {
+                let result = Result<Void>.failure(RestError.noData)
+                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                completionHandler(dataResponse)
+                return
+            }
+
+            // execute callback
+            let result = Result<Void>.success(())
+            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            completionHandler(dataResponse)
+        }
+    }
+
     public func download(to destination: URL, completionHandler: @escaping (HTTPURLResponse?, Error?) -> Void) {
         let task = session.downloadTask(with: request) { (source, response, error) in
             guard let source = source else {


### PR DESCRIPTION
### Summary

Add a method to RestKit that returns Void on success.  Some APIs (primarily deletes) return no data -- just a status code indicating success.  The corresponding methods in the SDK should return Void, and this change provides the RestKit support for this.