### PR TITLE
Refactor our travis.yml file and update Discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,52 +11,13 @@ branches:
 env:
   global:
     - IOS_SDK="iphonesimulator10.3"
-    - IOS10_DESTINATION="OS=10.3,name=iPhone 7"
+    - IOS_DESTINATION="OS=10.3.1,name=iPhone 7"
 before_install:
   - openssl aes-256-cbc -K $encrypted_a31ce544e168_key -iv $encrypted_a31ce544e168_iv -in Source/SupportingFiles/Credentials.swift.enc -out Source/SupportingFiles/Credentials.swift -d
   - for D in `find Tests -type d -maxdepth 1 -mindepth 1`; do echo "cp SupportingFiles/Credentials.swift $D/"; done
 script:
   # build and test for iOS 10
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then set -o pipefail ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild build -scheme "RestKit" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "AlchemyDataNewsV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "AlchemyLanguageV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "AlchemyVisionV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "ConversationV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "DialogV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "DiscoveryV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "DocumentConversionV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "LanguageTranslatorV2" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "NaturalLanguageClassifierV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "NaturalLanguageUnderstandingV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "PersonalityInsightsV2" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "PersonalityInsightsV3" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "RelationshipExtractionV1Beta" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "RetrieveAndRankV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "SpeechToTextV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "TextToSpeechV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "ToneAnalyzerV3" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "TradeoffAnalyticsV1" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" | xcpretty ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild test -scheme "VisualRecognitionV3" -sdk "$IOS_SDK" -destination "$IOS10_DESTINATION" -enableCodeCoverage "YES" ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash <(curl -s https://codecov.io/bash) ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./Scripts/run-tests.sh ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -y ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://swift.org/builds/swift-3.1-release/ubuntu1404/swift-3.1-RELEASE/swift-3.1-RELEASE-ubuntu14.04.tar.gz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xzvf swift-3.1-RELEASE-ubuntu14.04.tar.gz ; fi

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -o pipefail
+exitCode=0
+IOS_SDK=${IOS_SDK:-"iphonesimulator10.3"}
+IOS_DESTINATION=${IOS_DESTINATION:-"OS=10.3.1,name=iPhone 7"}
+
+function checkStatus {
+    if [[ $exitCode == 0 && $1 != 0 ]]; then
+        exitCode=$1
+    fi
+}
+
+function uploadCodecov {
+    bash <(curl -s https://codecov.io/bash)
+}
+
+xcodebuild build -scheme "RestKit" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" | xcpretty
+checkStatus $?
+xcodebuild test -scheme "AlchemyDataNewsV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "AlchemyLanguageV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "AlchemyVisionV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "ConversationV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "DialogV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "DiscoveryV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "DocumentConversionV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "LanguageTranslatorV2" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "NaturalLanguageClassifierV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "NaturalLanguageUnderstandingV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "PersonalityInsightsV2" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "PersonalityInsightsV3" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "RelationshipExtractionV1Beta" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "RetrieveAndRankV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "SpeechToTextV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "TextToSpeechV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "ToneAnalyzerV3" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "TradeoffAnalyticsV1" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES" | xcpretty
+checkStatus $? && uploadCodecov
+xcodebuild test -scheme "VisualRecognitionV3" -sdk "$IOS_SDK" -destination "$IOS_DESTINATION" -enableCodeCoverage "YES"
+checkStatus $? && uploadCodecov
+
+exit $exitCode

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -22,15 +22,15 @@ import DiscoveryV1
 class DiscoveryTests: XCTestCase {
     
     private var discovery: Discovery!
-    private let timeout: TimeInterval = 20.0
-    private let environmentName: String = "swift-sdk-unit-test-environment"
-    private let testDescription: String = "For testing"
+    private let timeout = 20.0
+    private let environmentName = "swift-sdk-unit-test-environment"
+    private let testDescription = "For testing"
     private var environmentID: String?
-    private let newsEnvironmentName: String = "Watson News Environment"
+    private let newsEnvironmentName = "Watson News Environment"
     private var newsEnvironmentID: String?
-    private let newsCollectionName: String = "watson_news"
+    private let newsCollectionName = "watson_news"
     private var newsCollectionID: String?
-    private let collectionName: String = "swift-sdk-unit-test-collection"
+    private let collectionName = "swift-sdk-unit-test-collection"
     private var collectionID: String?
     private var configurationID: String?
     private var documentID: String?
@@ -46,6 +46,30 @@ class DiscoveryTests: XCTestCase {
         lookupConfiguration()
         lookupCollection()
         addDocumentToCollection()
+    }
+    
+    override class func tearDown() {
+        let failure = { (error: Error) in
+            XCTFail("Failed with error: \(error)")
+        }
+        
+        let discovery = Discovery(username: Credentials.DiscoveryUsername, password: Credentials.DiscoveryPassword, version: "2016-12-01")
+        var trainedEnvironmentID: String?
+        
+        let description1 = "Get trained environment ID."
+        let expectation1 = XCTestExpectation(description: description1)
+        discovery.getEnvironments(withName: "swift-sdk-unit-test-environment", failure: failure) { environment in
+            trainedEnvironmentID = environment.first?.environmentID
+            expectation1.fulfill()
+        }
+        XCTWaiter.wait(for: [expectation1], timeout: 20)
+        
+        let description2 = "Delete the trained environment."
+        let expectation2 = XCTestExpectation(description: description2)
+        discovery.deleteEnvironment(withID: trainedEnvironmentID!, failure: failure) { environment in
+            expectation2.fulfill()
+        }
+        XCTWaiter.wait(for: [expectation2], timeout: 20)
     }
     
     /** Instantiate Discovery instance. */
@@ -97,6 +121,8 @@ class DiscoveryTests: XCTestCase {
                 return
         }
         waitForExpectations()
+        
+        sleep(30)
     }
     
     /** Lookup default configuration for environment created. */


### PR DESCRIPTION
3 main changes are included in this PR:

1. Pulled out the `xcodebuild` commands from the `travis.yml` file into a separate `run-tests.sh` script.
2. Updated the iOS10_destination in the travis.yml since the xcode8.3 image on Travis has been updated to xcode 8.3.3, and 10.3.1 is the default iOS 10 version.
3. Updated the Discovery tests to add a class teardown function which deletes the trained environment when all tests finish. This way, the Swift SDK and .NET SDK can properly share credentials for the Discovery service.