### PR TITLE
Set default headers in tests to disable stats collection

### DIFF
--- a/Tests/AlchemyDataNewsV1Tests/AlchemyDataNewsTests.swift
+++ b/Tests/AlchemyDataNewsV1Tests/AlchemyDataNewsTests.swift
@@ -35,8 +35,10 @@ class AlchemyDataNewsTests: XCTestCase {
     override func setUp() {
         super.setUp()
         alchemyDataNews = AlchemyDataNews(apiKey: Credentials.AlchemyAPIKey)
+        alchemyDataNews.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        alchemyDataNews.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Fail false negatives. */
     func failWithError(error: Error) {
         XCTFail("Positive test failed with error: \(error)")

--- a/Tests/AlchemyLanguageV1Tests/AlchemyLanguageTests.swift
+++ b/Tests/AlchemyLanguageV1Tests/AlchemyLanguageTests.swift
@@ -28,8 +28,10 @@ class AlchemyLanguageTests: XCTestCase {
     override func setUp() {
         super.setUp()
         alchemyLanguage = AlchemyLanguage(apiKey: Credentials.AlchemyAPIKey)
+        alchemyLanguage.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        alchemyLanguage.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     static var allTests : [(String, (AlchemyLanguageTests) -> () throws -> Void)] {
         return [
             ("testGetAuthorsURL", testGetAuthorsURL),

--- a/Tests/AlchemyVisionV1Tests/AlchemyVisionTests.swift
+++ b/Tests/AlchemyVisionV1Tests/AlchemyVisionTests.swift
@@ -81,8 +81,10 @@ class AlchemyVisionTests: XCTestCase {
     func instantiateAlchemyVision() {
         let apiKey = Credentials.AlchemyAPIKey
         alchemyVision = AlchemyVision(apiKey: apiKey)
+        alchemyVision.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        alchemyVision.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Load image files with class examples and test images. */
     func loadResources() {
         let bundle = Bundle(for: type(of: self))

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -48,6 +48,8 @@ class ConversationTests: XCTestCase {
         let password = Credentials.ConversationPassword
         let version = "2017-02-03"
         conversation = Conversation(username: username, password: password, version: version)
+        conversation.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        conversation.defaultHeaders["X-Watson-Test"] = "true"
     }
 
     /** Fail false negatives. */

--- a/Tests/DialogV1Tests/DialogTests.swift
+++ b/Tests/DialogV1Tests/DialogTests.swift
@@ -90,6 +90,8 @@ class DialogTests: XCTestCase {
         let username = Credentials.DialogUsername
         let password = Credentials.DialogPassword
         dialog = Dialog(username: username, password: password)
+        dialog.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        dialog.defaultHeaders["X-Watson-Test"] = "true"
     }
 
     /** Look up (or create) the test dialog application. */

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -54,6 +54,8 @@ class DiscoveryTests: XCTestCase {
         }
         
         let discovery = Discovery(username: Credentials.DiscoveryUsername, password: Credentials.DiscoveryPassword, version: "2016-12-01")
+        discovery.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        discovery.defaultHeaders["X-Watson-Test"] = "true"
         var trainedEnvironmentID: String?
         
         let description1 = "Get trained environment ID."
@@ -78,8 +80,10 @@ class DiscoveryTests: XCTestCase {
         let password = Credentials.DiscoveryPassword
         let version = "2016-12-01"
         discovery = Discovery(username: username, password: password, version: version)
+        discovery.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        discovery.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Look up (or create) environment. */
     func lookupEnvironment() {
         let description = "Look up (or create) the environment."

--- a/Tests/DocumentConversionV1Tests/DocumentConversionTests.swift
+++ b/Tests/DocumentConversionV1Tests/DocumentConversionTests.swift
@@ -53,8 +53,10 @@ class DocumentConversionTests: XCTestCase {
         let password = Credentials.DocumentConversionPassword
         let version = "2015-12-15"
         documentConversion = DocumentConversion(username: username, password: password, version: version)
+        documentConversion.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        documentConversion.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     func loadResources() {
         #if os(iOS)
             let bundle = Bundle(for: type(of: self))

--- a/Tests/LanguageTranslatorV2Tests/LanguageTranslatorTests.swift
+++ b/Tests/LanguageTranslatorV2Tests/LanguageTranslatorTests.swift
@@ -56,8 +56,10 @@ class LanguageTranslatorTests: XCTestCase {
         let username = Credentials.LanguageTranslatorUsername
         let password = Credentials.LanguageTranslatorPassword
         languageTranslator = LanguageTranslator(username: username, password: password)
+        languageTranslator.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        languageTranslator.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Delete any stale custom models that were previously created by unit tests. */
     func deleteStaleCustomModels() {
         let description = "Delete any stale custom models previously created by unit tests."

--- a/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
+++ b/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
@@ -53,8 +53,10 @@ class NaturalLanguageClassifierTests: XCTestCase {
         let username = Credentials.NaturalLanguageClassifierUsername
         let password = Credentials.NaturalLanguageClassifierPassword
         naturalLanguageClassifier = NaturalLanguageClassifier(username: username, password: password)
+        naturalLanguageClassifier.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        naturalLanguageClassifier.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Fail false negatives. */
     func failWithError(error: Error) {
         XCTFail("Positive test failed with error: \(error)")

--- a/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
+++ b/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
@@ -56,8 +56,10 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
         let username = Credentials.NaturalLanguageUnderstandingUsername
         let password = Credentials.NaturalLanguageUnderstandingPassword
         naturalLanguageUnderstanding = NaturalLanguageUnderstanding(username: username, password: password, version: "2016-05-17")
+        naturalLanguageUnderstanding.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        naturalLanguageUnderstanding.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Fail false negatives. */
     func failWithError(error: Error) {
         XCTFail("Positive test failed with error: \(error)")

--- a/Tests/PersonalityInsightsV2Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV2Tests/PersonalityInsightsTests.swift
@@ -49,8 +49,10 @@ class PersonalityInsightsTests: XCTestCase {
         let username = Credentials.PersonalityInsightsUsername
         let password = Credentials.PersonalityInsightsPassword
         personalityInsights = PersonalityInsights(username: username, password: password)
+        personalityInsights.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        personalityInsights.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Load "MobyDickIntro.txt". */
     func loadMobyDickIntro() {
         let bundle = Bundle(for: type(of: self))

--- a/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
@@ -51,6 +51,8 @@ class PersonalityInsightsTests: XCTestCase {
         let username = Credentials.PersonalityInsightsV3Username
         let password = Credentials.PersonalityInsightsV3Password
         personalityInsights = PersonalityInsights(username: username, password: password, version: version)
+        personalityInsights.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        personalityInsights.defaultHeaders["X-Watson-Test"] = "true"
     }
 
     /** Load external files to test. Fails if unable to locate file. */

--- a/Tests/RelationshipExtractionV1BetaTests/RelationshipExtractionTests.swift
+++ b/Tests/RelationshipExtractionV1BetaTests/RelationshipExtractionTests.swift
@@ -48,8 +48,10 @@ class RelationshipExtractionTests: XCTestCase {
         let username = Credentials.RelationshipExtractionUsername
         let password = Credentials.RelationshipExtractionPassword
         relationshipExtraction = RelationshipExtraction(username: username, password: password)
+        relationshipExtraction.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        relationshipExtraction.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Fail false negatives. */
     func failWithError(error: Error) {
         XCTFail("Positive test failed with error: \(error)")

--- a/Tests/RetrieveAndRankV1Tests/RetrieveAndRankTests.swift
+++ b/Tests/RetrieveAndRankV1Tests/RetrieveAndRankTests.swift
@@ -81,8 +81,10 @@ class RetrieveAndRankTests: XCTestCase {
         let username = Credentials.RetrieveAndRankUsername
         let password = Credentials.RetrieveAndRankPassword
         retrieveAndRank = RetrieveAndRank(username: username, password: password)
+        retrieveAndRank.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        retrieveAndRank.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Fail false negatives. */
     func failWithError(error: Error) {
         XCTFail("Positive test failed with error: \(error)")

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -73,8 +73,10 @@ class SpeechToTextTests: XCTestCase {
         let username = Credentials.SpeechToTextUsername
         let password = Credentials.SpeechToTextPassword
         speechToText = SpeechToText(username: username, password: password)
+        speechToText.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        speechToText.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Fail false negatives. */
     func failWithError(error: Error) {
         XCTFail("Positive test failed with error: \(error)")

--- a/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
@@ -44,8 +44,10 @@ class TextToSpeechPlaybackTests: XCTestCase {
         let username = Credentials.TextToSpeechUsername
         let password = Credentials.TextToSpeechPassword
         textToSpeech = TextToSpeech(username: username, password: password)
+        textToSpeech.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        textToSpeech.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Fail false negatives. */
     func failWithError(error: Error) {
         XCTFail("Positive test failed with error: \(error)")

--- a/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
@@ -80,8 +80,10 @@ class TextToSpeechTests: XCTestCase {
         let username = Credentials.TextToSpeechUsername
         let password = Credentials.TextToSpeechPassword
         textToSpeech = TextToSpeech(username: username, password: password)
+        textToSpeech.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        textToSpeech.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Delete all customizations. */
     func deleteCustomizations() {
         let description = "Delete all customizations."

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -51,8 +51,10 @@ class ToneAnalyzerTests: XCTestCase {
         let username = Credentials.ToneAnalyzerUsername
         let password = Credentials.ToneAnalyzerPassword
         toneAnalyzer = ToneAnalyzer(username: username, password: password, version: "2016-05-10")
+        toneAnalyzer.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        toneAnalyzer.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Fail false negatives. */
     func failWithError(error: Error) {
         XCTFail("Positive test failed with error: \(error)")

--- a/Tests/TradeoffAnalyticsV1Tests/TradeoffAnalyticsTests.swift
+++ b/Tests/TradeoffAnalyticsV1Tests/TradeoffAnalyticsTests.swift
@@ -45,8 +45,10 @@ class TradeoffAnalyticsTests: XCTestCase {
         let username = Credentials.TradeoffAnalyticsUsername
         let password = Credentials.TradeoffAnalyticsPassword
         tradeoffAnalytics = TradeoffAnalytics(username: username, password: password)
+        tradeoffAnalytics.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        tradeoffAnalytics.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Fail false negatives. */
     func failWithError(error: Error) {
         XCTFail("Positive test failed with error: \(error)")

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -101,8 +101,10 @@ class VisualRecognitionTests: XCTestCase {
         let apiKey = Credentials.VisualRecognitionAPIKey
         let version = "2016-11-04"
         visualRecognition = VisualRecognition(apiKey: apiKey, version: version)
+        visualRecognition.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
+        visualRecognition.defaultHeaders["X-Watson-Test"] = "true"
     }
-    
+
     /** Load image files with class examples and test images. */
     func loadImageFiles() {
         


### PR DESCRIPTION
This PR sets the default headers in all integration test files so that Swift SDK test activity is not included in usage statistics for Watson services.