### PR TITLE
Updating conversation doc and service landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ conversation.message(withWorkspace: workspaceID, request: request, failure: fail
 
 The following links provide more information about the IBM Conversation service:
 
-* [IBM Watson Conversation - Service Page](http://www.ibm.com/watson/developercloud/conversation.html)
-* [IBM Watson Conversation - Documentation](http://www.ibm.com/watson/developercloud/doc/conversation/overview.shtml)
+* [IBM Watson Conversation - Service Page](https://www.ibm.com/watson/services/conversation/)
+* [IBM Watson Conversation - Documentation](https://console.bluemix.net/docs/services/conversation/index.html#about)
 
 ## Discovery
 

--- a/docs/swift-api/services/ConversationV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/ConversationV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -460,8 +460,8 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Conversation service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/conversation.html">IBM Watson Conversation - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/conversation/overview.shtml">IBM Watson Conversation - Documentation</a></li>
+<li><a href="https://www.ibm.com/watson/services/conversation/">IBM Watson Conversation - Service Page</a></li>
+<li><a href="https://console.bluemix.net/docs/services/conversation/index.html#about">IBM Watson Conversation - Documentation</a></li>
 </ul>
 <a href='#discovery' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='discovery'>Discovery</h2>
 

--- a/docs/swift-api/services/ConversationV1/index.html
+++ b/docs/swift-api/services/ConversationV1/index.html
@@ -460,8 +460,8 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Conversation service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/conversation.html">IBM Watson Conversation - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/conversation/overview.shtml">IBM Watson Conversation - Documentation</a></li>
+<li><a href="https://www.ibm.com/watson/services/conversation/">IBM Watson Conversation - Service Page</a></li>
+<li><a href="https://console.bluemix.net/docs/services/conversation/index.html#about">IBM Watson Conversation - Documentation</a></li>
 </ul>
 <a href='#discovery' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='discovery'>Discovery</h2>
 

--- a/docs/swift-api/services/DialogV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/DialogV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -402,8 +402,8 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Conversation service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/conversation.html">IBM Watson Conversation - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/conversation/overview.shtml">IBM Watson Conversation - Documentation</a></li>
+<li><a href="https://www.ibm.com/watson/services/conversation/">IBM Watson Conversation - Service Page</a></li>
+<li><a href="https://console.bluemix.net/docs/services/conversation/index.html#about">IBM Watson Conversation - Documentation</a></li>
 </ul>
 <a href='#discovery' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='discovery'>Discovery</h2>
 

--- a/docs/swift-api/services/DialogV1/index.html
+++ b/docs/swift-api/services/DialogV1/index.html
@@ -402,8 +402,8 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Conversation service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/conversation.html">IBM Watson Conversation - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/conversation/overview.shtml">IBM Watson Conversation - Documentation</a></li>
+<li><a href="https://www.ibm.com/watson/services/conversation/">IBM Watson Conversation - Service Page</a></li>
+<li><a href="https://console.bluemix.net/docs/services/conversation/index.html#about">IBM Watson Conversation - Documentation</a></li>
 </ul>
 <a href='#discovery' class='anchor' aria-hidden=true><span class="header-anchor"></span></a><h2 id='discovery'>Discovery</h2>
 


### PR DESCRIPTION
### Summary

Updating links to the WDC site for the Conversation service documentation. It has moved to the Bluemix Docs site. The service landing page also changed. Only updated the index.html pages related to Conversation and Dialog services (not all of them).