### PR TITLE
Parse authentication errors when requesting token

### DIFF
--- a/Source/RestKit/RestToken.swift
+++ b/Source/RestKit/RestToken.swift
@@ -28,6 +28,7 @@ public class RestToken {
     
     private var tokenURL: String
     private var credentials: Credentials
+    private let domain = "com.ibm.watson.developer-cloud.RestKit"
     
     /**
      Create a `RestToken`.
@@ -57,8 +58,7 @@ public class RestToken {
             credentials: credentials,
             headerParameters: [:])
         
-        // TODO - validate request
-        request.responseString(responseToError: nil) { response in
+        request.responseString(responseToError: responseToError) { response in
             switch response.result {
             case .success(let token):
                 self.token = token
@@ -68,4 +68,41 @@ public class RestToken {
             }
         }
     }
+    
+    /**
+     Returns an NSError if the response/data represents an error. Otherwise, returns nil.
+     
+     - parameter response: an http response from the token url
+     - parameter data: raw body data from the token url response
+     */
+    private func responseToError(response: HTTPURLResponse?, data: Data?) -> NSError? {
+        
+        // fail if no response from token url
+        guard let response = response else {
+            let description = "Token authentication failed. No response from token url."
+            let userInfo = [NSLocalizedDescriptionKey: description]
+            return NSError(domain: domain, code: 400, userInfo: userInfo)
+        }
+        
+        // succeed if status code indicates success
+        if (200..<300).contains(response.statusCode) {
+            return nil
+        }
+        
+        // default error description
+        let code = response.statusCode
+        var userInfo = [NSLocalizedDescriptionKey: "Token authentication failed."]
+        
+        // update error description, if available
+        if let data = data {
+            do {
+                let json = try JSON(data: data)
+                let description = try json.getString(at: "description")
+                userInfo[NSLocalizedDescriptionKey] = description
+            } catch { /* no need to catch -- falls back to default description */ }
+        }
+        
+        return NSError(domain: domain, code: code, userInfo: userInfo)
+    }
+
 }

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -650,6 +650,30 @@ class SpeechToTextTests: XCTestCase {
         }
         waitForExpectations()
     }
+    
+    // MARK: - Token Authentication
+    
+    func testInvalidCredentials() {
+        let description = "Test invalid credentials."
+        let expectation = self.expectation(description: description)
+        
+        let bundle = Bundle(for: type(of: self))
+        guard let file = bundle.url(forResource: "SpeechSample", withExtension: "wav") else {
+            XCTFail("Unable to locate SpeechSample.wav.")
+            return
+        }
+        
+        let speechToText = SpeechToText(username: "invalid", password: "invalid")
+        let settings = RecognitionSettings(contentType: .wav)
+        let failure = { (error: Error) in
+            if error.localizedDescription.contains("Please confirm that your credentials match") {
+                expectation.fulfill()
+            }
+        }
+        
+        speechToText.recognize(audio: file, settings: settings, failure: failure, success: failWithResult)
+        waitForExpectations()
+    }
 
     // MARK: - Transcribe File, Default Settings
 


### PR DESCRIPTION
Fixes a bug with Speech to Text token authentication.

Previously, users who entered invalid credentials would get a nonsense token. The token was rejected by the Speech to Text service, resulting in a "403 - Invalid HTTP Upgrade" error message. This update ensures that the response from the token url is verified, resulting in a more descriptive error message for invalid credentials.

We may need to communicate this change to other folks working on RestKit.

Closes #655.