### PR TITLE
Update libogg and libopus

### DIFF
--- a/Scripts/build-libogg.sh
+++ b/Scripts/build-libogg.sh
@@ -19,11 +19,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+
+# Forked from: https://github.com/chrisballinger/Opus-iOS
+
 ###########################################################################
 #  Choose your libogg version and your currently-installed iOS SDK version:
 #
 VERSION="1.3.2"
-SDKVERSION="9.3"
+SDKVERSION="11.0"
 MINIOSVERSION="8.0"
 
 ###########################################################################
@@ -104,7 +107,7 @@ do
     if [ "${ARCH}" == "i386" ] || [ "${ARCH}" == "x86_64" ]; then
         PLATFORM="iPhoneSimulator"
         EXTRA_CFLAGS="-arch ${ARCH}"
-        EXTRA_CONFIG=""
+        EXTRA_CONFIG="--host=x86_64-apple-darwin"
     else
         PLATFORM="iPhoneOS"
         EXTRA_CFLAGS="-arch ${ARCH}"

--- a/Scripts/build-libopus.sh
+++ b/Scripts/build-libopus.sh
@@ -19,11 +19,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+
+# Forked from: https://github.com/chrisballinger/Opus-iOS
+
 ###########################################################################
 #  Choose your libopus version and your currently-installed iOS SDK version:
 #
-VERSION="1.1.2"
-SDKVERSION="9.2"
+VERSION="1.1.3"
+SDKVERSION="11.0"
 MINIOSVERSION="8.0"
 
 ###########################################################################
@@ -104,7 +107,7 @@ do
     if [ "${ARCH}" == "i386" ] || [ "${ARCH}" == "x86_64" ]; then
         PLATFORM="iPhoneSimulator"
         EXTRA_CFLAGS="-arch ${ARCH}"
-        EXTRA_CONFIG=""
+        EXTRA_CONFIG="--host=x86_64-apple-darwin"
     else
         PLATFORM="iPhoneOS"
         EXTRA_CFLAGS="-arch ${ARCH}"


### PR DESCRIPTION
This pull request updates the build scripts for libogg and libopus. The updated `build-libopus.sh` script was used to build the latest v1.1.3 release of the opus library. The ogg library does not need to be updated, since there has not been a recent release.