### PR TITLE
Update RestKit

### DIFF
--- a/Source/RestKit/CodableExtensions.swift
+++ b/Source/RestKit/CodableExtensions.swift
@@ -73,13 +73,6 @@ internal extension KeyedDecodingContainer where Key == DynamicKeys {
         return object
     }
 
-    /// Decode additional properties, if present.
-    internal func decodeIfPresent(_ type: [String: JSON].Type, excluding keys: [CodingKey]) throws -> [String: JSON]? {
-        let additionalProperties = try decode([String: JSON].self, excluding: keys)
-        guard additionalProperties.count > 0 else { return nil }
-        return additionalProperties
-    }
-
 }
 
 //===----------------------------------------------------------------------===//

--- a/Tests/RestKitTests/CodableExtensionsTests.swift
+++ b/Tests/RestKitTests/CodableExtensionsTests.swift
@@ -51,7 +51,7 @@ class CodableExtensionsTests: XCTestCase {
     }
 
     func testEncodeMetadata() {
-        let metadata: [String: JSONValue] = [
+        let metadata: [String: JSON] = [
             "null": .null,
             "bool": .boolean(true),
             "int": .int(1),
@@ -101,7 +101,7 @@ class CodableExtensionsTests: XCTestCase {
             array: [1, 2, 3],
             object: ["x": 1]
         )
-        let metadata = ["custom": try! JSONValue(from: custom)]
+        let metadata = ["custom": try! JSON(from: custom)]
         let model = ServiceModel(name: "name", metadata: metadata, additionalProperties: [:])
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
@@ -135,7 +135,7 @@ class CodableExtensionsTests: XCTestCase {
     }
     
     func testEncodeAdditionalProperties() {
-        let additionalProperties: [String: JSONValue] = [
+        let additionalProperties: [String: JSON] = [
             "null": .null,
             "bool": .boolean(true),
             "int": .int(1),
@@ -177,7 +177,7 @@ class CodableExtensionsTests: XCTestCase {
     }
     
     func testEncodeOptional() {
-        let metadata: [String: JSONValue] = [
+        let metadata: [String: JSON] = [
             "null": .null,
             "bool": .boolean(true),
             "int": .int(1),
@@ -186,7 +186,7 @@ class CodableExtensionsTests: XCTestCase {
             "array": .array([.int(1), .int(2), .int(3)]),
             "object": .object(["x": .int(1)])
         ]
-        let additionalProperties: [String: JSONValue] = [
+        let additionalProperties: [String: JSON] = [
             "null": .null,
             "bool": .boolean(true),
             "int": .int(1),
@@ -417,10 +417,10 @@ class CodableExtensionsTests: XCTestCase {
 
 private struct ServiceModel: Codable {
     let name: String
-    let metadata: [String: JSONValue]
-    let additionalProperties: [String: JSONValue]
+    let metadata: [String: JSON]
+    let additionalProperties: [String: JSON]
 
-    init(name: String, metadata: [String: JSONValue], additionalProperties: [String: JSONValue]) {
+    init(name: String, metadata: [String: JSON], additionalProperties: [String: JSON]) {
         self.name = name
         self.metadata = metadata
         self.additionalProperties = additionalProperties
@@ -436,8 +436,8 @@ private struct ServiceModel: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let dynamic = try decoder.container(keyedBy: DynamicKeys.self)
         name = try container.decode(String.self, forKey: .name)
-        metadata = try container.decode([String: JSONValue].self, forKey: .metadata)
-        additionalProperties = try dynamic.decode([String: JSONValue].self, excluding: CodingKeys.allValues)
+        metadata = try container.decode([String: JSON].self, forKey: .metadata)
+        additionalProperties = try dynamic.decode([String: JSON].self, excluding: CodingKeys.allValues)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -455,10 +455,10 @@ private struct ServiceModel: Codable {
 
 private struct ServiceModelOptional: Codable {
     let name: String?
-    let metadata: [String: JSONValue]?
-    let additionalProperties: [String: JSONValue]?
+    let metadata: [String: JSON]?
+    let additionalProperties: [String: JSON]?
 
-    init(name: String?, metadata: [String: JSONValue]?, additionalProperties: [String: JSONValue]?) {
+    init(name: String?, metadata: [String: JSON]?, additionalProperties: [String: JSON]?) {
         self.name = name
         self.metadata = metadata
         self.additionalProperties = additionalProperties
@@ -474,8 +474,8 @@ private struct ServiceModelOptional: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let dynamic = try decoder.container(keyedBy: DynamicKeys.self)
         name = try container.decodeIfPresent(String.self, forKey: .name)
-        metadata = try container.decodeIfPresent([String: JSONValue].self, forKey: .metadata)
-        additionalProperties = try dynamic.decodeIfPresent([String: JSONValue].self, excluding: CodingKeys.allValues)
+        metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
+        additionalProperties = try dynamic.decodeIfPresent([String: JSON].self, excluding: CodingKeys.allValues)
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Tests/RestKitTests/CodableExtensionsTests.swift
+++ b/Tests/RestKitTests/CodableExtensionsTests.swift
@@ -33,6 +33,7 @@ class CodableExtensionsTests: XCTestCase {
         ("testEncodeOptional", testEncodeOptional),
         ("testEncodeOptionalEmpty", testEncodeOptionalEmpty),
         ("testEncodeOptionalNil", testEncodeOptionalNil),
+        ("testDecodeSimpleModel", testDecodeSimpleModel),
         ("testDecodeMetadata", testDecodeMetadata),
         ("testDecodeCustom", testDecodeCustom),
         ("testDecodeAdditionalProperties", testDecodeAdditionalProperties),
@@ -257,6 +258,18 @@ class CodableExtensionsTests: XCTestCase {
         XCTAssertEqual(json.sorted(), expected.sorted())
     }
 
+    func testDecodeSimpleModel() {
+        let json = """
+            {
+                "name": "name",
+                "newField": "newField"
+            }
+            """
+        let data = json.data(using: .utf8)!
+        let model = try! JSONDecoder().decode(SimpleModel.self, from: data)
+        XCTAssertEqual(model.name, "name")
+    }
+
     func testDecodeMetadata() {
         let json = """
             {
@@ -408,6 +421,18 @@ class CodableExtensionsTests: XCTestCase {
         XCTAssertNil(model.name)
         XCTAssertNil(model.metadata)
         XCTAssertNil(model.additionalProperties)
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// SimpleModel
+//===----------------------------------------------------------------------===//
+
+private struct SimpleModel: Codable {
+    let name: String
+
+    init(name: String) {
+        self.name = name
     }
 }
 

--- a/Tests/RestKitTests/CodableExtensionsTests.swift
+++ b/Tests/RestKitTests/CodableExtensionsTests.swift
@@ -250,7 +250,7 @@ class CodableExtensionsTests: XCTestCase {
     }
     
     func testEncodeOptionalNil() {
-        let model = ServiceModelOptional(name: nil, metadata: nil, additionalProperties: nil)
+        let model = ServiceModelOptional(name: nil, metadata: nil, additionalProperties: [:])
         let encoder = JSONEncoder()
         let data = try! encoder.encode(model)
         let json = String(data: data, encoding: .utf8)!
@@ -387,7 +387,7 @@ class CodableExtensionsTests: XCTestCase {
         let data = json.data(using: .utf8)!
         let model = try! JSONDecoder().decode(ServiceModelOptional.self, from: data)
         let metadata = model.metadata!
-        let additionalProperties = model.additionalProperties!
+        let additionalProperties = model.additionalProperties
         XCTAssertEqual(model.name!, "name")
         XCTAssertEqual(metadata["null"], .null)
         XCTAssertEqual(metadata["bool"], .boolean(true))
@@ -411,7 +411,7 @@ class CodableExtensionsTests: XCTestCase {
         let model = try! JSONDecoder().decode(ServiceModelOptional.self, from: data)
         XCTAssertEqual(model.name, "")
         XCTAssertNil(model.metadata)
-        XCTAssertNil(model.additionalProperties)
+        XCTAssertTrue(model.additionalProperties.isEmpty)
     }
 
     func testDecodeOptionalNil() {
@@ -420,7 +420,7 @@ class CodableExtensionsTests: XCTestCase {
         let model = try! JSONDecoder().decode(ServiceModelOptional.self, from: data)
         XCTAssertNil(model.name)
         XCTAssertNil(model.metadata)
-        XCTAssertNil(model.additionalProperties)
+        XCTAssertTrue(model.additionalProperties.isEmpty)
     }
 }
 
@@ -481,9 +481,9 @@ private struct ServiceModel: Codable {
 private struct ServiceModelOptional: Codable {
     let name: String?
     let metadata: [String: JSON]?
-    let additionalProperties: [String: JSON]?
+    let additionalProperties: [String: JSON]
 
-    init(name: String?, metadata: [String: JSON]?, additionalProperties: [String: JSON]?) {
+    init(name: String?, metadata: [String: JSON]?, additionalProperties: [String: JSON]) {
         self.name = name
         self.metadata = metadata
         self.additionalProperties = additionalProperties
@@ -500,7 +500,7 @@ private struct ServiceModelOptional: Codable {
         let dynamic = try decoder.container(keyedBy: DynamicKeys.self)
         name = try container.decodeIfPresent(String.self, forKey: .name)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
-        additionalProperties = try dynamic.decodeIfPresent([String: JSON].self, excluding: CodingKeys.allValues)
+        additionalProperties = try dynamic.decode([String: JSON].self, excluding: CodingKeys.allValues)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -508,7 +508,7 @@ private struct ServiceModelOptional: Codable {
         var dynamic = encoder.container(keyedBy: DynamicKeys.self)
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(metadata, forKey: .metadata)
-        try dynamic.encodeIfPresent(additionalProperties)
+        try dynamic.encode(additionalProperties)
     }
 }
 

--- a/Tests/RestKitTests/JSONValueTests.swift
+++ b/Tests/RestKitTests/JSONValueTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-class JSONValueTests: XCTestCase {
+class JSONTests: XCTestCase {
 
     // Note: When encoding a JSON object to a string, Mac and Linux produce different key orderings.
     // This is valid, since there is no required order for the keys in a Swift Dictionary or JSON object.
@@ -56,39 +56,39 @@ class JSONValueTests: XCTestCase {
 
     func testEquality() {
         // equal values
-        XCTAssertEqual(JSONValue.null, JSONValue.null)
-        XCTAssertEqual(JSONValue.boolean(true), JSONValue.boolean(true))
-        XCTAssertEqual(JSONValue.string("hello"), JSONValue.string("hello"))
-        XCTAssertEqual(JSONValue.int(1), JSONValue.int(1))
-        XCTAssertEqual(JSONValue.double(0.5), JSONValue.double(0.5))
-        XCTAssertEqual(JSONValue.array([JSONValue.int(1), JSONValue.int(2)]),
-                       JSONValue.array([JSONValue.int(1), JSONValue.int(2)]))
-        XCTAssertEqual(JSONValue.object(["x": JSONValue.int(1), "y": JSONValue.int(2)]),
-                       JSONValue.object(["y": JSONValue.int(2), "x": JSONValue.int(1)]))
+        XCTAssertEqual(JSON.null, JSON.null)
+        XCTAssertEqual(JSON.boolean(true), JSON.boolean(true))
+        XCTAssertEqual(JSON.string("hello"), JSON.string("hello"))
+        XCTAssertEqual(JSON.int(1), JSON.int(1))
+        XCTAssertEqual(JSON.double(0.5), JSON.double(0.5))
+        XCTAssertEqual(JSON.array([JSON.int(1), JSON.int(2)]),
+                       JSON.array([JSON.int(1), JSON.int(2)]))
+        XCTAssertEqual(JSON.object(["x": JSON.int(1), "y": JSON.int(2)]),
+                       JSON.object(["y": JSON.int(2), "x": JSON.int(1)]))
 
         // unequal values
-        XCTAssertNotEqual(JSONValue.boolean(true), JSONValue.boolean(false))
-        XCTAssertNotEqual(JSONValue.string("hello"), JSONValue.string("world"))
-        XCTAssertNotEqual(JSONValue.int(1), JSONValue.int(2))
-        XCTAssertNotEqual(JSONValue.double(3.14), JSONValue.double(2.72))
-        XCTAssertNotEqual(JSONValue.double(3.14), JSONValue.double(2.72))
-        XCTAssertNotEqual(JSONValue.array([JSONValue.int(1), JSONValue.int(2)]),
-                          JSONValue.array([JSONValue.int(2), JSONValue.int(1)]))
-        XCTAssertNotEqual(JSONValue.object(["x": JSONValue.int(1), "y": JSONValue.int(2)]),
-                          JSONValue.object(["x": JSONValue.int(2), "y": JSONValue.int(1)]))
+        XCTAssertNotEqual(JSON.boolean(true), JSON.boolean(false))
+        XCTAssertNotEqual(JSON.string("hello"), JSON.string("world"))
+        XCTAssertNotEqual(JSON.int(1), JSON.int(2))
+        XCTAssertNotEqual(JSON.double(3.14), JSON.double(2.72))
+        XCTAssertNotEqual(JSON.double(3.14), JSON.double(2.72))
+        XCTAssertNotEqual(JSON.array([JSON.int(1), JSON.int(2)]),
+                          JSON.array([JSON.int(2), JSON.int(1)]))
+        XCTAssertNotEqual(JSON.object(["x": JSON.int(1), "y": JSON.int(2)]),
+                          JSON.object(["x": JSON.int(2), "y": JSON.int(1)]))
 
         // unequal types
-        XCTAssertNotEqual(JSONValue.null, JSONValue.boolean(true))
-        XCTAssertNotEqual(JSONValue.boolean(true), JSONValue.string("true"))
-        XCTAssertNotEqual(JSONValue.string("true"), JSONValue.int(1))
-        XCTAssertNotEqual(JSONValue.int(1), JSONValue.double(1.0))
-        XCTAssertNotEqual(JSONValue.double(1.0), JSONValue.array([JSONValue.double(1.0)]))
-        XCTAssertNotEqual(JSONValue.array([JSONValue.double(1.0)]),
-                          JSONValue.object(["x": JSONValue.double(1.0)]))
+        XCTAssertNotEqual(JSON.null, JSON.boolean(true))
+        XCTAssertNotEqual(JSON.boolean(true), JSON.string("true"))
+        XCTAssertNotEqual(JSON.string("true"), JSON.int(1))
+        XCTAssertNotEqual(JSON.int(1), JSON.double(1.0))
+        XCTAssertNotEqual(JSON.double(1.0), JSON.array([JSON.double(1.0)]))
+        XCTAssertNotEqual(JSON.array([JSON.double(1.0)]),
+                          JSON.object(["x": JSON.double(1.0)]))
     }
 
     func testEncodeNull() {
-        let object: [String: JSONValue] = ["key": .null]
+        let object: [String: JSON] = ["key": .null]
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{\"key\":null}"
@@ -96,7 +96,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeBool() {
-        let object: [String: JSONValue] = ["key": .boolean(true)]
+        let object: [String: JSON] = ["key": .boolean(true)]
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{\"key\":true}"
@@ -104,7 +104,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeInt() {
-        let object: [String: JSONValue] = ["key": .int(1)]
+        let object: [String: JSON] = ["key": .int(1)]
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{\"key\":1}"
@@ -112,7 +112,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeDouble() {
-        let object: [String: JSONValue] = ["key": .double(0.5)]
+        let object: [String: JSON] = ["key": .double(0.5)]
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{\"key\":0.5}"
@@ -120,7 +120,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeString() {
-        let object: [String: JSONValue] = ["key": .string("this is a string")]
+        let object: [String: JSON] = ["key": .string("this is a string")]
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{\"key\":\"this is a string\"}"
@@ -128,7 +128,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeArray() {
-        let object: [String: JSONValue] = ["key": .array([.null, .boolean(true), .int(1), .double(0.5), .string("this is a string")])]
+        let object: [String: JSON] = ["key": .array([.null, .boolean(true), .int(1), .double(0.5), .string("this is a string")])]
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{\"key\":[null,true,1,0.5,\"this is a string\"]}"
@@ -136,7 +136,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeTopLevelArray() {
-        let array: [JSONValue] = [.null, .boolean(true), .int(1), .double(0.5), .string("this is a string")]
+        let array: [JSON] = [.null, .boolean(true), .int(1), .double(0.5), .string("this is a string")]
         let data = try! JSONEncoder().encode(array)
         let json = String(data: data, encoding: .utf8)!
         let expected = "[null,true,1,0.5,\"this is a string\"]"
@@ -144,7 +144,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeNestedArrays() {
-        let array: [JSONValue] = [.array([.int(1), .int(2), .int(3)]), .array([.int(4), .int(5), .int(6)])]
+        let array: [JSON] = [.array([.int(1), .int(2), .int(3)]), .array([.int(4), .int(5), .int(6)])]
         let data = try! JSONEncoder().encode(array)
         let json = String(data: data, encoding: .utf8)!
         let expected = "[[1,2,3],[4,5,6]]"
@@ -152,7 +152,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeArrayOfObjects() {
-        let array: [JSONValue] = [.object(["x": .int(1)]), .object(["y": .int(2)]), .object(["z": .int(3)])]
+        let array: [JSON] = [.object(["x": .int(1)]), .object(["y": .int(2)]), .object(["z": .int(3)])]
         let data = try! JSONEncoder().encode(array)
         let json = String(data: data, encoding: .utf8)!
         let expected = "[{\"x\":1},{\"y\":2},{\"z\":3}]"
@@ -160,7 +160,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeObject() {
-        let object: [String: JSONValue] = ["key": .object(["null": .null, "bool": .boolean(true), "int": .int(1), "double": .double(0.5), "string": .string("this is a string")])]
+        let object: [String: JSON] = ["key": .object(["null": .null, "bool": .boolean(true), "int": .int(1), "double": .double(0.5), "string": .string("this is a string")])]
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{\"key\":{\"bool\":true,\"double\":0.5,\"string\":\"this is a string\",\"int\":1,\"null\":null}}"
@@ -168,7 +168,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeEmptyObject() {
-        let object = [String: JSONValue]()
+        let object = [String: JSON]()
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{}"
@@ -176,7 +176,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeNested() {
-        let object: [String: JSONValue] = ["key": .object(["array": .array([.int(1), .int(2), .int(3)]), "object": .object(["x": .int(1), "y": .int(2), "z": .int(3)])])]
+        let object: [String: JSON] = ["key": .object(["array": .array([.int(1), .int(2), .int(3)]), "object": .object(["x": .int(1), "y": .int(2), "z": .int(3)])])]
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{\"key\":{\"array\":[1,2,3],\"object\":{\"y\":2,\"x\":1,\"z\":3}}}"
@@ -184,7 +184,7 @@ class JSONValueTests: XCTestCase {
     }
 
     func testEncodeDeeplyNested() {
-        let object: [String: JSONValue] = ["key1": .object(["key2": .object(["key3": .object(["key4": .array([.int(1), .int(2), .int(3)])])])])]
+        let object: [String: JSON] = ["key1": .object(["key2": .object(["key3": .object(["key4": .array([.int(1), .int(2), .int(3)])])])])]
         let data = try! JSONEncoder().encode(object)
         let json = String(data: data, encoding: .utf8)!
         let expected = "{\"key1\":{\"key2\":{\"key3\":{\"key4\":[1,2,3]}}}}"
@@ -194,42 +194,42 @@ class JSONValueTests: XCTestCase {
     func testDecodeNull() {
         let json = "{ \"key\": null }"
         let data = json.data(using: .utf8)!
-        let object = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object = try! JSONDecoder().decode([String: JSON].self, from: data)
         XCTAssertEqual(object["key"], .null)
     }
 
     func testDecodeBool() {
         let json = "{ \"key\": true }"
         let data = json.data(using: .utf8)!
-        let object = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object = try! JSONDecoder().decode([String: JSON].self, from: data)
         XCTAssertEqual(object["key"], .boolean(true))
     }
 
     func testDecodeInt() {
         let json = "{ \"key\": 1 }"
         let data = json.data(using: .utf8)!
-        let object = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object = try! JSONDecoder().decode([String: JSON].self, from: data)
         XCTAssertEqual(object["key"], .int(1))
     }
 
     func testDecodeDouble() {
         let json = "{ \"key\": 0.5 }"
         let data = json.data(using: .utf8)!
-        let object = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object = try! JSONDecoder().decode([String: JSON].self, from: data)
         XCTAssertEqual(object["key"], .double(0.5))
     }
 
     func testDecodeString() {
         let json = "{ \"key\": \"this is a string\" }"
         let data = json.data(using: .utf8)!
-        let object = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object = try! JSONDecoder().decode([String: JSON].self, from: data)
         XCTAssertEqual(object["key"], .string("this is a string"))
     }
 
     func testDecodeArray() {
         let json = "{ \"key\": [null, true, 1, 0.5, \"this is a string\"] }"
         let data = json.data(using: .utf8)!
-        let object = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object = try! JSONDecoder().decode([String: JSON].self, from: data)
         guard case let .array(array) = object["key"]! else { XCTFail(); return }
         XCTAssertEqual(array.count, 5)
         XCTAssertEqual(array[0], .null)
@@ -242,7 +242,7 @@ class JSONValueTests: XCTestCase {
     func testDecodeTopLevelArray() {
         let json = "[ null, true, 1, 0.5, \"this is a string\" ]"
         let data = json.data(using: .utf8)!
-        let array = try! JSONDecoder().decode([JSONValue].self, from: data)
+        let array = try! JSONDecoder().decode([JSON].self, from: data)
         XCTAssertEqual(array.count, 5)
         XCTAssertEqual(array[0], .null)
         XCTAssertEqual(array[1], .boolean(true))
@@ -254,7 +254,7 @@ class JSONValueTests: XCTestCase {
     func testDecodeNestedArrays() {
         let json = "[[1, 2, 3], [4, 5, 6]]"
         let data = json.data(using: .utf8)!
-        let array = try! JSONDecoder().decode([JSONValue].self, from: data)
+        let array = try! JSONDecoder().decode([JSON].self, from: data)
         guard case let .array(subarray1) = array[0] else { XCTFail(); return }
         guard case let .array(subarray2) = array[1] else { XCTFail(); return }
         XCTAssertEqual(subarray1[0], .int(1))
@@ -268,7 +268,7 @@ class JSONValueTests: XCTestCase {
     func testDecodeArrayOfObjects() {
         let json = "[{ \"x\": 1 }, { \"y\": 2}, { \"z\": 3 }]"
         let data = json.data(using: .utf8)!
-        let array = try! JSONDecoder().decode([JSONValue].self, from: data)
+        let array = try! JSONDecoder().decode([JSON].self, from: data)
         guard case let .object(object1) = array[0] else { XCTFail(); return }
         guard case let .object(object2) = array[1] else { XCTFail(); return }
         XCTAssertEqual(object1["x"], .int(1))
@@ -278,7 +278,7 @@ class JSONValueTests: XCTestCase {
     func testDecodeObject() {
         let json = "{ \"key\": { \"null\": null, \"bool\": true, \"int\": 1, \"double\": 0.5, \"string\": \"this is a string\" }}"
         let data = json.data(using: .utf8)!
-        let object = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object = try! JSONDecoder().decode([String: JSON].self, from: data)
         guard case let .object(subobject) = object["key"]! else { XCTFail(); return }
         XCTAssertEqual(subobject["null"], .null)
         XCTAssertEqual(subobject["bool"], .boolean(true))
@@ -290,14 +290,14 @@ class JSONValueTests: XCTestCase {
     func testDecodeEmptyObject() {
         let json = "{ }"
         let data = json.data(using: .utf8)!
-        let object = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object = try! JSONDecoder().decode([String: JSON].self, from: data)
         XCTAssertEqual(object.count, 0)
     }
 
     func testDecodeNested() {
         let json = "{ \"key\": { \"array\": [1, 2, 3], \"object\": { \"x\": 1, \"y\": 2, \"z\": 3 }}}"
         let data = json.data(using: .utf8)!
-        let object = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object = try! JSONDecoder().decode([String: JSON].self, from: data)
         guard case let .object(subobject) = object["key"]! else { XCTFail(); return }
         guard case let .array(array) = subobject["array"]! else { XCTFail(); return }
         guard case let .object(subsubobject) = subobject["object"]! else { XCTFail(); return }
@@ -312,7 +312,7 @@ class JSONValueTests: XCTestCase {
     func testDecodeDeeplyNested() {
         let json = "{ \"key1\": { \"key2\": { \"key3\": { \"key4\": [1,2,3] }}}}"
         let data = json.data(using: .utf8)!
-        let object1 = try! JSONDecoder().decode([String: JSONValue].self, from: data)
+        let object1 = try! JSONDecoder().decode([String: JSON].self, from: data)
         guard case let .object(object2) = object1["key1"]! else { XCTFail(); return }
         guard case let .object(object3) = object2["key2"]! else { XCTFail(); return }
         guard case let .object(object4) = object3["key3"]! else { XCTFail(); return }


### PR DESCRIPTION
- Make the `additionalProperties` dictionary required (not optional)
- Rename `JSONValue` to `JSON` in the RestKit tests
- Add a test to decode an unknown field