### PR TITLE
Handle interim speaker label results

### DIFF
--- a/Source/SpeechToTextV1/Models/SpeechRecognitionEvent.swift
+++ b/Source/SpeechToTextV1/Models/SpeechRecognitionEvent.swift
@@ -21,7 +21,7 @@ internal struct SpeechRecognitionEvent: JSONDecodable {
 
     /// Index indicating change point in the results array.
     /// (See description of `results` array for more information.)
-    internal let resultIndex: Int
+    internal let resultIndex: Int?
 
     /// The results array consists of 0 or more final results, followed by 0 or 1 interim
     /// result. The final results are guaranteed not to change, while the interim result may
@@ -29,15 +29,16 @@ internal struct SpeechRecognitionEvent: JSONDecodable {
     /// periodically sends "updates" to the result list, with the `resultIndex` set to the
     /// lowest index in the array that has changed. `resultIndex` always points to the slot
     /// just after the most recent final result.
-    internal let results: [SpeechRecognitionResult]
+    internal let results: [SpeechRecognitionResult]?
     
-    /// The speakerLabels variable will contain an optional array of SpeakerLabel objects
+    /// An array that identifies which words were spoken by which speakers in a multi-person exchange.
+    /// Returned in the response only if the `speakerLabels` recognition setting is `true`.
     internal let speakerLabels: [SpeakerLabel]?
 
     /// Used internally to initialize a `SpeechRecognitionEvent` model from JSON.
     internal init(json: JSONWrapper) throws {
-        resultIndex = try json.getInt(at: "result_index")
-        results = try json.decodedArray(at: "results", type: SpeechRecognitionResult.self)
+        resultIndex = try? json.getInt(at: "result_index")
+        results = try? json.decodedArray(at: "results", type: SpeechRecognitionResult.self)
         speakerLabels = try? json.decodedArray(at: "speaker_labels", type: SpeakerLabel.self)
     }
 }

--- a/Source/SpeechToTextV1/Models/SpeechRecognitionResults.swift
+++ b/Source/SpeechToTextV1/Models/SpeechRecognitionResults.swift
@@ -37,23 +37,37 @@ public struct SpeechRecognitionResults {
     public var speakerLabels = [SpeakerLabel]()
     
     /// Add the updates specified by a `SpeechRecognitionEvent`.
-    mutating internal func addResults(wrapper: SpeechRecognitionEvent) {
-        var resultsIndex = wrapper.resultIndex
-        var wrapperIndex = 0
-        while resultsIndex < results.count && wrapperIndex < wrapper.results.count {
-            results[resultsIndex] = wrapper.results[wrapperIndex]
+    mutating internal func addResults(event: SpeechRecognitionEvent) {
+        if let index = event.resultIndex, let updates = event.results {
+            addResults(index: index, updates: updates)
+        }
+        if let speakerLabels = event.speakerLabels {
+            addResults(speakerLabels: speakerLabels)
+        }
+    }
+
+    mutating internal func addResults(index: Int, updates: [SpeechRecognitionResult]) {
+        var resultsIndex = index // lowest index in self.results that has changed
+        var updates = updates // changes to merge into self.results
+        var updatesIndex = 0 // the change that is being merged
+
+        // update existing recognition results that have changed
+        while resultsIndex < results.count && updatesIndex < updates.count {
+            results[resultsIndex] = updates[updatesIndex]
             resultsIndex += 1
-            wrapperIndex += 1
+            updatesIndex += 1
         }
-        while wrapperIndex < wrapper.results.count {
-            results.append(wrapper.results[wrapperIndex])
-            wrapperIndex += 1
+
+        // append new recognition results
+        while updatesIndex < updates.count {
+            results.append(updates[updatesIndex])
+            updatesIndex += 1
         }
-        // If we have parsed some speakerLabel objects, then store them here
-        if (wrapper.speakerLabels != nil) {
-            for speakerLabel in wrapper.speakerLabels! {
-                speakerLabels.append(speakerLabel)
-            }
+    }
+
+    mutating internal func addResults(speakerLabels: [SpeakerLabel]) {
+        for speakerLabel in speakerLabels {
+            self.speakerLabels.append(speakerLabel)
         }
     }
 }

--- a/Source/SpeechToTextV1/SpeechToTextSocket.swift
+++ b/Source/SpeechToTextV1/SpeechToTextSocket.swift
@@ -178,9 +178,9 @@ internal class SpeechToTextSocket: WebSocketDelegate {
         }
     }
     
-    private func onResultsMessage(wrapper: SpeechRecognitionEvent) {
+    private func onResultsMessage(event: SpeechRecognitionEvent) {
         state = .Transcribing
-        results.addResults(wrapper: wrapper)
+        results.addResults(event: event)
         onResults?(results)
     }
     
@@ -234,8 +234,8 @@ internal class SpeechToTextSocket: WebSocketDelegate {
         if let state = try? json.decode(type: RecognitionState.self) {
             onStateMessage(state: state)
         }
-        if let results = try? json.decode(type: SpeechRecognitionEvent.self) {
-            onResultsMessage(wrapper: results)
+        if let event = try? json.decode(type: SpeechRecognitionEvent.self) {
+            onResultsMessage(event: event)
         }
         if let error = try? json.getString(at: "error") {
             onErrorMessage(error: error)

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -946,6 +946,7 @@ class SpeechToTextTests: XCTestCase {
     {
         let description = "Transcribe an audio file."
         let expectation = self.expectation(description: description)
+        var expectationFulfilled = false
         
         let bundle = Bundle(for: type(of: self))
         guard let file = bundle.url(forResource: filename, withExtension: withExtension) else {
@@ -963,10 +964,13 @@ class SpeechToTextTests: XCTestCase {
             settings.timestamps = true
             settings.filterProfanity = false
             settings.speakerLabels = true
-            
+
             speechToText.recognize(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true, failure: failWithError) { results in
-                self.validateSTTSpeakerLabels(speakerLabels: results.speakerLabels)
-                expectation.fulfill()
+                if !expectationFulfilled && results.speakerLabels.count > 0 {
+                    self.validateSTTSpeakerLabels(speakerLabels: results.speakerLabels)
+                    expectationFulfilled = true
+                    expectation.fulfill()
+                }
             }
             waitForExpectations()
         } catch {
@@ -1133,6 +1137,7 @@ class SpeechToTextTests: XCTestCase {
     }
     
     func validateSTTSpeakerLabels(speakerLabels: [SpeakerLabel]) {
+        XCTAssertGreaterThan(speakerLabels.count, 0)
         for speakerLabel in speakerLabels {
             validateSTTSpeakerLabel(speakerLabel: speakerLabel)
         }


### PR DESCRIPTION
This pull request fixes a bug with interim speaker labels.

Interim speaker labels were not handled properly because they did not conform to the documented model. That is, the Speech to Text documentation specifies that a `SpeechRecognitionEvent` object will always contain the `resultIndex` and `results` properties, and may optionally contain a `speakerLabels` property. However, when debugging, I received interim speaker labels by themselves, `{ 'speaker_labels': ... }`. The absence of the `resultIndex` and `results` fields caused the JSON parsing to fail, and the speaker labels to be dropped.

This pull request updates the `SpeechRecognitionEvent` and associated code to handle all fields as optional, and process them when they are present.

(I will be reaching out to the Speech to Text team to notify them about the model discrepancy.)