### PR TITLE
Deprecate similarity search operations

### DIFF
--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -629,6 +629,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the newly created collection.
     */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func createCollection (
         withName name: String,
         failure: ((Error) -> Void)? = nil,
@@ -676,6 +677,7 @@ public class VisualRecognition {
     - parameter failure: A function executed if an error occurs.
     - parameter success: A function executed with the list of classifiers.
     */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func getCollections(
         failure: ((Error) -> Void)? = nil,
         success: @escaping ([Collection]) -> Void)
@@ -712,6 +714,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the collection retrieved.
      */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func retrieveCollectionDetails(
         withID collectionID: String,
         failure: ((Error) -> Void)? = nil,
@@ -748,6 +751,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed after the collection has been successfully deleted.
     */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func deleteCollection(
         withID collectionID: String,
         failure: ((Error) -> Void)? = nil,
@@ -798,6 +802,7 @@ public class VisualRecognition {
      - parameter success: A function executed with information about the image added to the
         collection.
      */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func addImageToCollection(
         withID collectionID: String,
         imageFile image: URL,
@@ -851,6 +856,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the list of images in the collection.
      */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func getImagesInCollection(
         withID collectionID: String,
         failure: ((Error) -> Void)? = nil,
@@ -888,6 +894,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the image's details.
      */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func listImageDetailsInCollection(
         withID collectionID: String,
         imageID: String,
@@ -926,6 +933,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed when the image is deleted successfully.
     */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func deleteImageFromCollection(
         withID collectionID: String,
         imageID: String,
@@ -968,6 +976,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed when the image metadata is deleted successfully.
     */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func deleteImageMetadata(
         forImageID imageID: String,
         inCollectionID collectionID: String,
@@ -1010,6 +1019,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed when the image metadata is listed successfully.
      */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func listImageMetadata(
         forImageID imageID: String,
         inCollectionID collectionID: String,
@@ -1050,6 +1060,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed when the image metadata is updated successfully.
     */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func updateImageMetadata(
         forImageID imageID: String,
         inCollectionID collectionID: String,
@@ -1103,6 +1114,7 @@ public class VisualRecognition {
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the list of similar images.
     */
+    @available(*, deprecated, message: "The beta period for Similarity Search was closed on September 8, 2017.")
     public func findSimilarImages(
         toImageFile image: URL,
         inCollectionID collectionID: String,

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -274,6 +274,11 @@ class VisualRecognitionTests: XCTestCase {
             XCTFail("The created classifier could not be retrieved from the service.")
         }
         waitForExpectations()
+
+        // allow zip files to propagate through object storage, so that
+        // they will be deleted when the service deletes the classifier
+        // (otherwise they remain and dramatically slow down the tests)
+        sleep(15) // wait 15 seconds
         
         let description3 = "Delete the custom classifier."
         let expectation3 = expectation(description: description3)
@@ -323,7 +328,12 @@ class VisualRecognitionTests: XCTestCase {
             XCTFail("The created classifier could not be retrieved from the service.")
         }
         waitForExpectations()
-        
+
+        // allow zip files to propagate through object storage, so that
+        // they will be deleted when the service deletes the classifier
+        // (otherwise they remain and dramatically slow down the tests)
+        sleep(15) // wait 15 seconds
+
         let description3 = "Delete the custom classifier."
         let expectation3 = expectation(description: description3)
 
@@ -391,9 +401,14 @@ class VisualRecognitionTests: XCTestCase {
             waitForExpectations()
             
             if tries > 5 {
+                // allow zip files to propagate through object storage, so that
+                // they will be deleted when the service deletes the classifier
+                // (otherwise they remain and dramatically slow down the tests)
+                sleep(15) // wait 15 seconds
+
                 let description = "Delete the new classifier."
                 let expectation = self.expectation(description: description)
-                
+
                 visualRecognition.deleteClassifier(withID: newClassifierID, failure: failWithError) {
                     expectation.fulfill()
                 }
@@ -435,9 +450,14 @@ class VisualRecognitionTests: XCTestCase {
             waitForExpectations()
             
             if tries > 5 {
+                // allow zip files to propagate through object storage, so that
+                // they will be deleted when the service deletes the classifier
+                // (otherwise they remain and dramatically slow down the tests)
+                sleep(15) // wait 15 seconds
+
                 let description = "Delete the new classifier."
                 let expectation = self.expectation(description: description)
-                
+
                 visualRecognition.deleteClassifier(withID: newClassifierID, failure: failWithError) {
                     expectation.fulfill()
                 }
@@ -448,10 +468,15 @@ class VisualRecognitionTests: XCTestCase {
             
             sleep(5)
         }
-        
+
+        // allow zip files to propagate through object storage, so that
+        // they will be deleted when the service deletes the classifier
+        // (otherwise they remain and dramatically slow down the tests)
+        sleep(15) // wait 15 seconds
+
         let description4 = "Delete the custom classifier."
         let expectation4 = expectation(description: description4)
-        
+
         visualRecognition.deleteClassifier(withID: newClassifierID, failure: failWithError) {
             expectation4.fulfill()
         }
@@ -502,9 +527,14 @@ class VisualRecognitionTests: XCTestCase {
             waitForExpectations()
             
             if tries > 5 {
+                // allow zip files to propagate through object storage, so that
+                // they will be deleted when the service deletes the classifier
+                // (otherwise they remain and dramatically slow down the tests)
+                sleep(15) // wait 15 seconds
+
                 let description = "Delete the new classifier."
                 let expectation = self.expectation(description: description)
-                
+
                 visualRecognition.deleteClassifier(withID: newClassifierID, failure: failWithError) {
                     expectation.fulfill()
                 }
@@ -545,9 +575,14 @@ class VisualRecognitionTests: XCTestCase {
             waitForExpectations()
             
             if tries > 5 {
+                // allow zip files to propagate through object storage, so that
+                // they will be deleted when the service deletes the classifier
+                // (otherwise they remain and dramatically slow down the tests)
+                sleep(15) // wait 15 seconds
+
                 let description = "Delete the new classifier."
                 let expectation = self.expectation(description: description)
-                
+
                 visualRecognition.deleteClassifier(withID: newClassifierID, failure: failWithError) {
                     expectation.fulfill()
                 }
@@ -558,7 +593,12 @@ class VisualRecognitionTests: XCTestCase {
             
             sleep(5)
         }
-        
+
+        // allow zip files to propagate through object storage, so that
+        // they will be deleted when the service deletes the classifier
+        // (otherwise they remain and dramatically slow down the tests)
+        sleep(15) // wait 15 seconds
+
         let description4 = "Delete the custom classifier."
         let expectation4 = expectation(description: description4)
         

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -1122,14 +1122,14 @@ class VisualRecognitionTests: XCTestCase {
                 for classifier in image.classifiers {
                     var containsCarClass = false
                     var classifierScore: Double?
-                    // verify the image's default classifier
                     if classifier.name == "default" {
+                        // verify the image's default classifier
                         XCTAssertEqual(classifier.classifierID, "default")
                         XCTAssertEqual(classifier.name, "default")
-                        
                         XCTAssertGreaterThan(classifier.classes.count, 0)
                         for c in classifier.classes {
-                            if c.classification == "car" || c.classification == "vehicle" {
+                            let classes = ["car", "vehicle", "sedan", "Parking Garage (Indoor)"]
+                            if classes.contains(c.classification) {
                                 containsCarClass = true
                                 classifierScore = c.score
                             }


### PR DESCRIPTION
The similarity search operations were [deprecated][1] on September 8. This pull request adds a deprecation notice to the similarity search operations and removes their associated tests.

[1]: https://console.bluemix.net/docs/services/visual-recognition/release-notes.html#release-notes