### PR TITLE
A SpeechRecognitionEvent must have at least one non-null value

### DIFF
--- a/Source/SpeechToTextV1/Models/SpeechRecognitionEvent.swift
+++ b/Source/SpeechToTextV1/Models/SpeechRecognitionEvent.swift
@@ -40,5 +40,8 @@ internal struct SpeechRecognitionEvent: JSONDecodable {
         resultIndex = try? json.getInt(at: "result_index")
         results = try? json.decodedArray(at: "results", type: SpeechRecognitionResult.self)
         speakerLabels = try? json.decodedArray(at: "speaker_labels", type: SpeakerLabel.self)
+        if (resultIndex == nil && results == nil && speakerLabels == nil) {
+            throw JSONWrapper.Error.valueNotConvertible(value: json, to: SpeechRecognitionEvent.self)
+        }
     }
 }


### PR DESCRIPTION
This pull request fixes a bug with Speech to Text:

When a `{"state": "listening"}` message was received, it was interpreted as a `SpeechRecognitionEvent` with all properties set to `nil`. The event was returned to the user, but contained no data.

This pull request requires a `SpeechRecognitionEvent` to have at least one non-null property.

(This may pose a challenge for future code generation, but the Speech to Text service is handwritten for now.)