### PR TITLE
Fix undocumented code

### DIFF
--- a/Source/RestKit/JSON.swift
+++ b/Source/RestKit/JSON.swift
@@ -18,13 +18,27 @@ import Foundation
 
 /// A JSON value (one of string, number, object, array, true, false, or null).
 public enum JSON: Equatable, Codable {
-    case null                        /// A null value.
-    case boolean(Bool)               /// A boolean value.
-    case string(String)              /// A string value.
-    case int(Int)                    /// A number value, represented as an integer.
-    case double(Double)              /// A number value, represented as a double.
-    case array([JSON])          /// An array value.
-    case object([String: JSON]) /// An object value.
+
+    /// A null value.
+    case null
+
+    /// A boolean value.
+    case boolean(Bool)
+
+    /// A string value.
+    case string(String)
+
+    /// A number value, represented as an integer.
+    case int(Int)
+
+    /// A number value, represented as a double.
+    case double(Double)
+
+    /// An array value.
+    case array([JSON])
+
+    /// An object value.
+    case object([String: JSON])
 
     /// Decode a JSON value.
     public init(from decoder: Decoder) throws {

--- a/Source/RestKit/RestError.swift
+++ b/Source/RestKit/RestError.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 
+/// An error from processing a network request or response.
 public enum RestError: Error {
 
     /// No data was returned from the server.


### PR DESCRIPTION
This pull request updates comments based on the `undocumented.json` file produced by the `generate-documentation.sh` script.

Note that there are still some missing documentation comments. Most of them are from `enum` cases within a model (e.g. `CreateDialogNode.NodeType` from Conversation), which contain no documentation in the Swagger specification. Other documentation is missing from Swagger (e.g. `ListModelsResults.models` from Natural Language Understanding) and should be caught by our validator in the future.