### PR TITLE
Increase WebSocket timeout to 30 seconds

### DIFF
--- a/Source/SpeechToTextV1/SpeechToTextSocket.swift
+++ b/Source/SpeechToTextV1/SpeechToTextSocket.swift
@@ -41,12 +41,14 @@ internal class SpeechToTextSocket: WebSocketDelegate {
         restToken: RestToken,
         defaultHeaders: [String: String])
     {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 30
+        self.socket = WebSocket(request: request)
         self.url = url
         self.restToken = restToken
         self.maxTokenRefreshes = 1
         self.tokenRefreshes = 0
         self.defaultHeaders = defaultHeaders
-        self.socket = WebSocket(url: url)
         self.queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
         queue.isSuspended = true


### PR DESCRIPTION
This pull request increases the WebSocket timeout from the 5-second default up to 30-seconds. This matches the 30-second [session timeout][1] for the Speech to Text service’s WebSocket interface.

This may help to resolve timeout issues like #693.

[1]: https://console.bluemix.net/docs/services/speech-to-text/websockets.html#WSkeep