### PR TITLE
Update links to developercloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,18 +106,18 @@ To build the project, run `swift build` from the command line.
 
 ## Service Instances
 
-[IBM Watson Developer Cloud](https://www.ibm.com/watson/developercloud/) offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the [services catalog](https://www.ibm.com/watson/developercloud/services-catalog.html). Services are instantiated using the [IBM Bluemix](http://www.ibm.com/cloud-computing/bluemix/) cloud platform.
+[IBM Watson](https://www.ibm.com/watson/developer/) offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the [products and services](https://www.ibm.com/watson/products-services/) page. Services are instantiated using the [IBM Cloud](https://www.ibm.com/cloud/) platform.
 
 Follow these steps to create a service instance and obtain its credentials:
 
-1. Log in to Bluemix at [https://bluemix.net](https://bluemix.net).
+1. Log in to IBM Cloud at [https://bluemix.net](https://bluemix.net).
 2. Create a service instance:
     1. From the Dashboard, select "Use Services or APIs".
     2. Select the service you want to use.
     3. Click "Create".
 3. Copy your service credentials:
     1. Click "Service Credentials" on the left side of the page.
-    2. Copy the service's `username` and `password` (or `api_key` for Alchemy).
+    2. Copy the service's `username` and `password` (or `api_key` for Visual Recognition).
 
 You will need to provide these service credentials in your mobile application. For example:
 
@@ -125,9 +125,9 @@ You will need to provide these service credentials in your mobile application. F
 let textToSpeech = TextToSpeech(username: "your-username-here", password: "your-password-here")
 ```
 
-Note that service credentials are different from your Bluemix username and password.
+Note that service credentials are different from your IBM Cloud username and password.
 
-See [Getting Started](https://console.bluemix.net/docs/services/watson/index.html) for more information on getting started with the Watson Developer Cloud and Bluemix.
+See [Getting started with Watson and IBM Cloud](https://console.bluemix.net/docs/services/watson/index.html) for details.
 
 ## Custom Service URLs
 
@@ -223,8 +223,7 @@ Refine your query by referring to the [Count and TimeSlice Queries](http://docs.
 The following links provide more information about the IBM AlchemyData News service:
 
 * [IBM AlchemyData News - Service Page](https://www.ibm.com/watson/developercloud/alchemy-data-news.html)
-* [IBM AlchemyData News - Documentation](http://docs.alchemyapi.com/)
-* [IBM AlchemyData News - Demo](http://querybuilder.alchemyapi.com/builder)
+* [IBM AlchemyData News - Documentation](https://console.bluemix.net/docs/services/alchemydata-news/index.html)
 
 ## AlchemyLanguage
 
@@ -262,8 +261,7 @@ alchemyLanguage.getTextSentiment(fromContentAtURL: url, failure: failure) { sent
 The following links provide more information about the IBM AlchemyLanguage service:
 
 * [IBM AlchemyLanguage - Service Page](http://www.ibm.com/watson/developercloud/alchemy-language.html)
-* [IBM AlchemyLanguage - Documentation](http://www.ibm.com/watson/developercloud/doc/alchemylanguage/)
-* [IBM AlchemyLanguage - Demo](https://alchemy-language-demo.mybluemix.net/)
+* [IBM AlchemyLanguage - Documentation](https://console.bluemix.net/docs/services/alchemy-language/index.html)
 
 ## Conversation
 
@@ -471,7 +469,7 @@ discovery.queryDocumentsInCollection(
 
 The following links provide more information about the IBM Discovery service:
 
-* [IBM Discovery - Service Page](http://www.ibm.com/watson/developercloud/discovery.html)
+* [IBM Discovery - Service Page](https://www.ibm.com/watson/services/discovery/)
 * [IBM Discovery - Documentation] (https://console.bluemix.net/docs/services/discovery/index.html)
 * [IBM Discovery - API Reference](https://www.ibm.com/watson/developercloud/discovery/api/v1/)
 * [IBM Discovery - API Explorer](https://watson-api-explorer.mybluemix.net/apis/discovery-v1)
@@ -509,7 +507,7 @@ documentConversion.convertDocument(document, withConfigurationFile: config, fail
 
 The following links provide more information about the IBM Document Conversion service:
 
-* [IBM Watson Document Conversion - Service Page](http://www.ibm.com/watson/developercloud/document-conversion.html)
+* [IBM Watson Document Conversion - Service Page](https://www.ibm.com/watson/services/document-conversion/)
 * [IBM Watson Document Conversion - Documentation](https://console.bluemix.net/docs/services/document-conversion/index.html)
 * [IBM Watson Document Conversion - Demo](https://document-conversion-demo.mybluemix.net/)
 
@@ -540,9 +538,9 @@ languageTranslator.translate("Hello", from: "en", to: "es", failure: failure) {
 
 The following links provide more information about the IBM Watson Language Translator service:
 
-* [IBM Watson Language Translator - Service Page](http://www.ibm.com/watson/developercloud/language-translator.html)
+* [IBM Watson Language Translator - Service Page](https://www.ibm.com/watson/services/language-translator/)
 * [IBM Watson Language Translator - Documentation](https://console.bluemix.net/docs/services/language-translator/index.html)
-* [IBM Watson Language Translator - Demo](https://language-translator-demo.mybluemix.net/)
+* [IBM Watson Language Translator - Demo](https://language-translator-demo.ng.bluemix.net/)
 
 ## Natural Language Classifier
 
@@ -568,9 +566,9 @@ naturalLanguageClassifier.classify(text, withClassifierID: classifierID, failure
 
 The following links provide more information about the Natural Language Classifier service:
 
-* [IBM Watson Natural Language Classifier - Service Page](http://www.ibm.com/watson/developercloud/nl-classifier.html)
+* [IBM Watson Natural Language Classifier - Service Page](https://www.ibm.com/watson/services/natural-language-classifier/)
 * [IBM Watson Natural Language Classifier - Documentation](https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html)
-* [IBM Watson Natural Language Classifier - Demo](https://natural-language-classifier-demo.mybluemix.net/)
+* [IBM Watson Natural Language Classifier - Demo](https://natural-language-classifier-demo.ng.bluemix.net/)
 
 ## Natural Language Understanding
 
@@ -616,9 +614,9 @@ Note that **you are required to include at least one feature in your request.** 
 
 The following links provide more information about the Natural Language Understanding service:
 
-* [IBM Watson Natural Language Understanding - Service Page](http://www.ibm.com/watson/developercloud/natural-language-understanding.html)
+* [IBM Watson Natural Language Understanding - Service Page](https://www.ibm.com/watson/services/natural-language-understanding/)
 * [IBM Watson Natural Language Understanding - Documentation](https://console.bluemix.net/docs/services/natural-language-understanding/index.html)
-* [IBM Watson Natural Language Understanding - Demo](http://natural-language-understanding-demo.mybluemix.net)
+* [IBM Watson Natural Language Understanding - Demo](https://natural-language-understanding-demo.ng.bluemix.net/)
 
 ## Personality Insights
 
@@ -643,9 +641,9 @@ personalityInsights.getProfile(fromText: text, failure: failure) { profile in
 
 The following links provide more information about the Personality Insights service:
 
-* [IBM Watson Personality Insights - Service Page](http://www.ibm.com/watson/developercloud/personality-insights.html)
+* [IBM Watson Personality Insights - Service Page](https://www.ibm.com/watson/services/personality-insights/)
 * [IBM Watson Personality Insights - Documentation](https://console.bluemix.net/docs/services/personality-insights/index.html)
-* [IBM Watson Personality Insights - Demo](https://personality-insights-livedemo.mybluemix.net)
+* [IBM Watson Personality Insights - Demo](https://personality-insights-demo.ng.bluemix.net/)
 
 ## Retrieve and Rank
 
@@ -768,9 +766,9 @@ retrieveAndRank.searchAndRank(
 
 The following links provide more information about the Retrieve and Rank service:
 
-* [IBM Watson Retrieve and Rank - Service Page](http://www.ibm.com/watson/developercloud/retrieve-rank.html)
+* [IBM Watson Retrieve and Rank - Service Page](https://www.ibm.com/watson/services/retrieve-and-rank/)
 * [IBM Watson Retrieve and Rank - Documentation](https://console.bluemix.net/docs/services/retrieve-and-rank/index.html)
-* [IBM Watson Retrieve and Rank - Demo](http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/)
+* [IBM Watson Retrieve and Rank - Demo](http://retrieve-and-rank-demo.ng.bluemix.net/)
 
 ## Speech to Text
 
@@ -1047,9 +1045,9 @@ do {
 
 The following links provide more information about the IBM Speech to Text service:
 
-* [IBM Watson Speech to Text - Service Page](http://www.ibm.com/watson/developercloud/speech-to-text.html)
+* [IBM Watson Speech to Text - Service Page](https://www.ibm.com/watson/services/speech-to-text/)
 * [IBM Watson Speech to Text - Documentation](https://console.bluemix.net/docs/services/speech-to-text/index.html)
-* [IBM Watson Speech to Text - Demo](https://speech-to-text-demo.mybluemix.net/)
+* [IBM Watson Speech to Text - Demo](https://speech-to-text-demo.ng.bluemix.net/)
 
 ## Text to Speech
 
@@ -1109,7 +1107,7 @@ textToSpeech.synthesize(text, voice: SynthesisVoice.gb_Kate.rawValue, failure: f
 
 The following links provide more information about the IBM Text To Speech service:
 
-* [IBM Watson Text To Speech - Service Page](http://www.ibm.com/watson/developercloud/text-to-speech.html)
+* [IBM Watson Text To Speech - Service Page](https://www.ibm.com/watson/services/text-to-speech/)
 * [IBM Watson Text To Speech - Documentation](https://console.bluemix.net/docs/services/text-to-speech/index.html)
 * [IBM Watson Text To Speech - Demo](https://text-to-speech-demo.mybluemix.net/)
 
@@ -1138,9 +1136,9 @@ toneAnalyzer.getTone(ofText: text, failure: failure) { tones in
 
 The following links provide more information about the IBM Watson Tone Analyzer service:
 
-* [IBM Watson Tone Analyzer - Service Page](http://www.ibm.com/watson/developercloud/tone-analyzer.html)
+* [IBM Watson Tone Analyzer - Service Page](https://www.ibm.com/watson/services/tone-analyzer/)
 * [IBM Watson Tone Analyzer - Documentation](https://console.bluemix.net/docs/services/tone-analyzer/index.html)
-* [IBM Watson Tone Analyzer - Demo](https://tone-analyzer-demo.mybluemix.net/)
+* [IBM Watson Tone Analyzer - Demo](https://tone-analyzer-demo.ng.bluemix.net/)
 
 ## Tradeoff Analytics
 
@@ -1245,6 +1243,6 @@ visualRecognition.classify(image: url, failure: failure) { classifiedImages in
 
 The following links provide more information about the IBM Watson Visual Recognition service:
 
-* [IBM Watson Visual Recognition - Service Page](http://www.ibm.com/watson/developercloud/visual-recognition.html)
+* [IBM Watson Visual Recognition - Service Page](https://www.ibm.com/watson/services/visual-recognition/)
 * [IBM Watson Visual Recognition - Documentation](https://console.bluemix.net/docs/services/visual-recognition/index.html)
-* [IBM Watson Visual Recognition - Demo](http://visual-recognition-demo.mybluemix.net/)
+* [IBM Watson Visual Recognition - Demo](https://visual-recognition-demo.ng.bluemix.net/)

--- a/docs/swift-api/services/AlchemyDataNewsV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/AlchemyDataNewsV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -129,7 +129,7 @@
         <section>
           <section class="section">
             
-            <h1 id='watson-developer-cloud-swift-sdk' class='heading'>Watson Developer Cloud Swift SDK</h1>
+            <h1 id='watson-developer-cloud-swift-sdk' class='heading'>Watson Swift SDK</h1>
 
 <p><a href="https://travis-ci.org/watson-developer-cloud/swift-sdk"><img src="https://travis-ci.org/watson-developer-cloud/swift-sdk.svg?branch=master" alt="Build Status"></a>
 <img src="https://img.shields.io/badge/platform-iOS,%20Linux-blue.svg?style=flat" alt="">
@@ -138,7 +138,7 @@
 <a href="https://cla-assistant.io/watson-developer-cloud/swift-sdk"><img src="https://cla-assistant.io/readme/badge/watson-developer-cloud/ios-sdk" alt="CLA assistant"></a></p>
 <h2 id='overview' class='heading'>Overview</h2>
 
-<p>The Watson Developer Cloud Swift SDK makes it easy for mobile developers to build Watson-powered applications. With the Swift SDK you can leverage the power of Watson&rsquo;s advanced artificial intelligence, machine learning, and deep learning techniques to understand unstructured data and engage with mobile users in new ways.</p>
+<p>The Watson Swift SDK makes it easy for mobile developers to build Watson-powered applications. With the Swift SDK you can leverage the power of Watson&rsquo;s advanced artificial intelligence, machine learning, and deep learning techniques to understand unstructured data and engage with mobile users in new ways.</p>
 
 <p>There are many resources to help you build your first cognitive application with the Swift SDK:</p>
 
@@ -204,7 +204,7 @@
 <pre class="highlight shell"><code><span class="gp">$ </span>touch Cartfile
 </code></pre>
 
-<p>To use the Watson Developer Cloud Swift SDK in your application, specify it in your <code>Cartfile</code>:</p>
+<p>To use the Watson Swift SDK in your application, specify it in your <code>Cartfile</code>:</p>
 <pre class="highlight plaintext"><code>github "watson-developer-cloud/swift-sdk"
 </code></pre>
 
@@ -227,12 +227,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p><a href="https://www.ibm.com/watson/developer/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">producs and services page</a>. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -252,9 +252,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -293,7 +293,7 @@
 </code></pre>
 <h2 id='objective-c-compatibility' class='heading'>Objective-C Compatibility</h2>
 
-<p>Please see <a href="docs/objective-c.md">this tutorial</a> for more information about consuming the Watson Developer Cloud Swift SDK in an Objective-C application.</p>
+<p>Please see <a href="docs/objective-c.md">this tutorial</a> for more information about consuming the Watson Swift SDK in an Objective-C application.</p>
 <h2 id='linux-compatibility' class='heading'>Linux Compatibility</h2>
 
 <p>The following services offer basic support in Linux: Conversation, Language Translator, Natural Language Classifier, Personality Insights V3, Tone Analyzer, and Tradeoff Analytics. Please note some services are not yet fully supported such as Alchemy Language, Alchemy Data News, Document Conversion, Text to Speech, Speech to Text, and Visual Recognition.</p>
@@ -337,8 +337,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -382,8 +381,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -580,7 +578,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -617,7 +615,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -647,9 +645,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -674,9 +672,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -723,9 +721,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -749,9 +747,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -865,9 +863,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1131,9 +1129,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/)">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1192,7 +1190,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1220,9 +1218,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1325,9 +1323,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/AlchemyDataNewsV1/index.html
+++ b/docs/swift-api/services/AlchemyDataNewsV1/index.html
@@ -227,12 +227,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -252,9 +252,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -337,8 +337,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -382,8 +381,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -580,7 +578,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -617,7 +615,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -647,9 +645,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -674,9 +672,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -723,9 +721,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -749,9 +747,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -865,9 +863,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1131,9 +1129,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1192,7 +1190,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1220,9 +1218,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1325,9 +1323,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/AlchemyLanguageV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/AlchemyLanguageV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -260,12 +260,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -285,9 +285,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -370,8 +370,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -415,8 +414,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -613,7 +611,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -650,7 +648,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -680,9 +678,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -707,9 +705,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -756,9 +754,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -782,9 +780,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -898,9 +896,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1164,9 +1162,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1225,7 +1223,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1253,9 +1251,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1358,9 +1356,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/AlchemyLanguageV1/index.html
+++ b/docs/swift-api/services/AlchemyLanguageV1/index.html
@@ -260,12 +260,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -285,9 +285,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -369,9 +369,8 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM AlchemyData News service:</p>
 
 <ul>
-<li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -414,9 +413,8 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM AlchemyLanguage service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+  <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
+  <li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -613,7 +611,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -650,7 +648,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -680,9 +678,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -707,9 +705,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -756,9 +754,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -782,9 +780,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -898,9 +896,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1164,9 +1162,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1225,7 +1223,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1253,9 +1251,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1358,9 +1356,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/AlchemyVisionV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/AlchemyVisionV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -200,12 +200,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -225,9 +225,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -310,8 +310,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -355,8 +354,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -553,7 +551,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -590,7 +588,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -620,9 +618,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -647,9 +645,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -696,9 +694,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -722,9 +720,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -838,9 +836,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1104,9 +1102,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1165,7 +1163,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1193,9 +1191,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1298,9 +1296,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/AlchemyVisionV1/index.html
+++ b/docs/swift-api/services/AlchemyVisionV1/index.html
@@ -200,12 +200,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -225,9 +225,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -310,8 +310,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -355,8 +354,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -553,7 +551,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -590,7 +588,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -620,9 +618,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -647,9 +645,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -696,9 +694,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -722,9 +720,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -838,9 +836,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1104,9 +1102,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1165,7 +1163,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1193,9 +1191,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1298,9 +1296,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/ConversationV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/ConversationV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -359,12 +359,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -376,7 +376,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -384,9 +384,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -469,8 +469,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -514,8 +513,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -712,7 +710,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -749,7 +747,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -779,9 +777,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -806,9 +804,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -855,9 +853,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -881,9 +879,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -997,9 +995,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1263,9 +1261,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1324,7 +1322,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1352,9 +1350,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1457,9 +1455,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/ConversationV1/index.html
+++ b/docs/swift-api/services/ConversationV1/index.html
@@ -359,12 +359,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -376,7 +376,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -384,9 +384,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -469,8 +469,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -514,8 +513,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -712,7 +710,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -749,7 +747,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -779,9 +777,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -806,9 +804,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -855,9 +853,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -881,9 +879,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -997,9 +995,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1263,9 +1261,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1324,7 +1322,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1352,9 +1350,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1457,9 +1455,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/DialogV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/DialogV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -193,12 +193,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -210,7 +210,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -218,9 +218,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -303,8 +303,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -348,8 +347,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -546,7 +544,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -583,7 +581,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -613,9 +611,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -640,9 +638,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -689,9 +687,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -715,9 +713,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -831,9 +829,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1097,9 +1095,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1158,7 +1156,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1186,9 +1184,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1291,9 +1289,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/DialogV1/index.html
+++ b/docs/swift-api/services/DialogV1/index.html
@@ -193,12 +193,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -210,7 +210,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -218,9 +218,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -303,8 +303,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -348,8 +347,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -546,7 +544,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -583,7 +581,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -613,9 +611,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -640,9 +638,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -689,9 +687,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -715,9 +713,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -831,9 +829,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1097,9 +1095,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1158,7 +1156,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1186,9 +1184,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1291,9 +1289,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/DiscoveryV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/DiscoveryV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -293,12 +293,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -310,7 +310,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -318,9 +318,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -403,8 +403,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -448,8 +447,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -646,7 +644,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -683,7 +681,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -713,9 +711,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -740,9 +738,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -789,9 +787,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -815,9 +813,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -931,9 +929,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1197,9 +1195,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1258,7 +1256,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1286,9 +1284,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1391,9 +1389,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/DiscoveryV1/index.html
+++ b/docs/swift-api/services/DiscoveryV1/index.html
@@ -293,12 +293,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -310,7 +310,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -318,9 +318,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -403,8 +403,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -448,8 +447,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -646,7 +644,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -683,7 +681,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -713,9 +711,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -740,9 +738,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -789,9 +787,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -815,9 +813,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -931,9 +929,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1197,9 +1195,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1258,7 +1256,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1286,9 +1284,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1391,9 +1389,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/DocumentConversionV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/DocumentConversionV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -176,12 +176,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -193,7 +193,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -201,9 +201,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -286,8 +286,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -331,8 +330,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -529,7 +527,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -566,7 +564,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -596,9 +594,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -623,9 +621,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -672,9 +670,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -698,9 +696,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -814,9 +812,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1080,9 +1078,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1141,7 +1139,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1169,9 +1167,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1274,9 +1272,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/DocumentConversionV1/index.html
+++ b/docs/swift-api/services/DocumentConversionV1/index.html
@@ -176,12 +176,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -193,7 +193,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -201,9 +201,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -286,8 +286,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -331,8 +330,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -529,7 +527,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -566,7 +564,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -596,9 +594,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -623,9 +621,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -672,9 +670,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -698,9 +696,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -814,9 +812,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1080,9 +1078,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1141,7 +1139,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1169,9 +1167,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1274,9 +1272,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/LanguageTranslatorV2/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/LanguageTranslatorV2/docsets/.docset/Contents/Resources/Documents/index.html
@@ -179,12 +179,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -196,7 +196,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -204,9 +204,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -289,8 +289,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -334,8 +333,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -532,7 +530,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -569,7 +567,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -599,9 +597,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -626,9 +624,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -675,9 +673,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -701,9 +699,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -817,9 +815,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1083,9 +1081,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1144,7 +1142,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1172,9 +1170,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1277,9 +1275,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/LanguageTranslatorV2/index.html
+++ b/docs/swift-api/services/LanguageTranslatorV2/index.html
@@ -179,12 +179,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -196,7 +196,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -204,9 +204,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -289,8 +289,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -334,8 +333,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -532,7 +530,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -569,7 +567,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -599,9 +597,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -626,9 +624,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -675,9 +673,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -701,9 +699,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -817,9 +815,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1083,9 +1081,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1144,7 +1142,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1172,9 +1170,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1277,9 +1275,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/NaturalLanguageClassifierV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/NaturalLanguageClassifierV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -173,12 +173,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -190,7 +190,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -198,9 +198,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -283,8 +283,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -328,8 +327,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -526,7 +524,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -563,7 +561,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -593,9 +591,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -620,9 +618,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -669,9 +667,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -695,9 +693,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -811,9 +809,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1077,9 +1075,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1138,7 +1136,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1166,9 +1164,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1271,9 +1269,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/NaturalLanguageClassifierV1/index.html
+++ b/docs/swift-api/services/NaturalLanguageClassifierV1/index.html
@@ -173,12 +173,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -190,7 +190,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -198,9 +198,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -283,8 +283,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -328,8 +327,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -526,7 +524,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -563,7 +561,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -593,9 +591,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -620,9 +618,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -669,9 +667,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -695,9 +693,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -811,9 +809,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1077,9 +1075,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1138,7 +1136,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1166,9 +1164,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1271,9 +1269,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/NaturalLanguageUnderstandingV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/NaturalLanguageUnderstandingV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -278,12 +278,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -295,7 +295,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -303,9 +303,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -388,8 +388,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -433,8 +432,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -631,7 +629,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -668,7 +666,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -698,9 +696,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -725,9 +723,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -774,9 +772,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -800,9 +798,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -916,9 +914,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1182,9 +1180,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1243,7 +1241,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1271,9 +1269,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1376,9 +1374,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/NaturalLanguageUnderstandingV1/index.html
+++ b/docs/swift-api/services/NaturalLanguageUnderstandingV1/index.html
@@ -278,12 +278,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -295,7 +295,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -303,9 +303,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -388,8 +388,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -433,8 +432,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -631,7 +629,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -668,7 +666,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -698,9 +696,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -725,9 +723,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -774,9 +772,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -800,9 +798,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -916,9 +914,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1182,9 +1180,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1243,7 +1241,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1271,9 +1269,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1376,9 +1374,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/PersonalityInsightsV2/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/PersonalityInsightsV2/docsets/.docset/Contents/Resources/Documents/index.html
@@ -167,12 +167,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -184,7 +184,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -192,9 +192,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -277,8 +277,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -322,8 +321,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -520,7 +518,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -557,7 +555,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -587,9 +585,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -614,9 +612,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -663,9 +661,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -689,9 +687,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -805,9 +803,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1071,9 +1069,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1132,7 +1130,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1160,9 +1158,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1265,9 +1263,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/PersonalityInsightsV2/index.html
+++ b/docs/swift-api/services/PersonalityInsightsV2/index.html
@@ -167,12 +167,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -184,7 +184,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -192,9 +192,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -277,8 +277,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -322,8 +321,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -520,7 +518,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -557,7 +555,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -587,9 +585,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -614,9 +612,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -663,9 +661,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -689,9 +687,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -805,9 +803,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1071,9 +1069,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1132,7 +1130,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1160,9 +1158,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1265,9 +1263,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/PersonalityInsightsV3/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/PersonalityInsightsV3/docsets/.docset/Contents/Resources/Documents/index.html
@@ -179,12 +179,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -196,7 +196,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -204,9 +204,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -289,8 +289,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -334,8 +333,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -532,7 +530,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -569,7 +567,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -599,9 +597,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -626,9 +624,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -675,9 +673,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -701,9 +699,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -817,9 +815,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1083,9 +1081,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1144,7 +1142,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1172,9 +1170,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1277,9 +1275,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/PersonalityInsightsV3/index.html
+++ b/docs/swift-api/services/PersonalityInsightsV3/index.html
@@ -179,12 +179,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -196,7 +196,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -204,9 +204,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -289,8 +289,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -334,8 +333,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -532,7 +530,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -569,7 +567,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -599,9 +597,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -626,9 +624,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -675,9 +673,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -701,9 +699,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -817,9 +815,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1083,9 +1081,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1144,7 +1142,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1172,9 +1170,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1277,9 +1275,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/RelationshipExtractionV1Beta/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/RelationshipExtractionV1Beta/docsets/.docset/Contents/Resources/Documents/index.html
@@ -212,12 +212,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -229,7 +229,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -237,9 +237,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -322,8 +322,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -367,8 +366,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -565,7 +563,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -602,7 +600,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -632,9 +630,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -659,9 +657,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -708,9 +706,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -734,9 +732,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -850,9 +848,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1116,9 +1114,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1177,7 +1175,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1205,9 +1203,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1310,9 +1308,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/RelationshipExtractionV1Beta/index.html
+++ b/docs/swift-api/services/RelationshipExtractionV1Beta/index.html
@@ -212,12 +212,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -229,7 +229,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -237,9 +237,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -322,8 +322,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -367,8 +366,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -565,7 +563,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -602,7 +600,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -632,9 +630,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -659,9 +657,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -708,9 +706,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -734,9 +732,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -850,9 +848,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1116,9 +1114,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1177,7 +1175,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1205,9 +1203,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1310,9 +1308,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/RetrieveAndRankV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/RetrieveAndRankV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -208,12 +208,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -225,7 +225,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -233,9 +233,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -318,8 +318,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -363,8 +362,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -561,7 +559,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -598,7 +596,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -628,9 +626,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -655,9 +653,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -704,9 +702,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -730,9 +728,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -846,9 +844,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1112,9 +1110,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1173,7 +1171,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1201,9 +1199,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1306,9 +1304,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/RetrieveAndRankV1/index.html
+++ b/docs/swift-api/services/RetrieveAndRankV1/index.html
@@ -208,12 +208,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -225,7 +225,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -233,9 +233,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -318,8 +318,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -363,8 +362,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -561,7 +559,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -598,7 +596,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -628,9 +626,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -655,9 +653,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -704,9 +702,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -730,9 +728,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -846,9 +844,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1112,9 +1110,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1173,7 +1171,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1201,9 +1199,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1306,9 +1304,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/SpeechToTextV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/SpeechToTextV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -236,12 +236,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -253,7 +253,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -261,9 +261,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -346,8 +346,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -391,8 +390,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -589,7 +587,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -626,7 +624,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -656,9 +654,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -683,9 +681,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -732,9 +730,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -758,9 +756,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -874,9 +872,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1140,9 +1138,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1201,7 +1199,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1229,9 +1227,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1334,9 +1332,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/SpeechToTextV1/index.html
+++ b/docs/swift-api/services/SpeechToTextV1/index.html
@@ -236,12 +236,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -253,7 +253,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -261,9 +261,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -346,8 +346,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -391,8 +390,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -589,7 +587,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -626,7 +624,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -656,9 +654,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -683,9 +681,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -732,9 +730,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -758,9 +756,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -874,9 +872,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1140,9 +1138,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1201,7 +1199,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1229,9 +1227,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1334,9 +1332,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/TextToSpeechV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/TextToSpeechV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -191,12 +191,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -208,7 +208,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -216,9 +216,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -301,8 +301,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -346,8 +345,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -544,7 +542,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -581,7 +579,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -611,9 +609,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -638,9 +636,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -687,9 +685,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -713,9 +711,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -829,9 +827,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1095,9 +1093,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1156,7 +1154,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1184,9 +1182,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1289,9 +1287,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/TextToSpeechV1/index.html
+++ b/docs/swift-api/services/TextToSpeechV1/index.html
@@ -191,12 +191,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -208,7 +208,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -216,9 +216,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -301,8 +301,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -346,8 +345,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -544,7 +542,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -581,7 +579,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -611,9 +609,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -638,9 +636,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -687,9 +685,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -713,9 +711,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -829,9 +827,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1095,9 +1093,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1156,7 +1154,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1184,9 +1182,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1289,9 +1287,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/ToneAnalyzerV3/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/ToneAnalyzerV3/docsets/.docset/Contents/Resources/Documents/index.html
@@ -170,12 +170,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -187,7 +187,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -195,9 +195,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -280,8 +280,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -325,8 +324,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -523,7 +521,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -560,7 +558,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -590,9 +588,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -617,9 +615,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -666,9 +664,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -692,9 +690,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -808,9 +806,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1074,9 +1072,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1135,7 +1133,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1163,9 +1161,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1268,9 +1266,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/ToneAnalyzerV3/index.html
+++ b/docs/swift-api/services/ToneAnalyzerV3/index.html
@@ -170,12 +170,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -187,7 +187,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -195,9 +195,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -280,8 +280,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -325,8 +324,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -523,7 +521,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -560,7 +558,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -590,9 +588,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -617,9 +615,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -666,9 +664,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -692,9 +690,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -808,9 +806,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1074,9 +1072,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1135,7 +1133,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1163,9 +1161,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1268,9 +1266,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/TradeoffAnalyticsV1/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/TradeoffAnalyticsV1/docsets/.docset/Contents/Resources/Documents/index.html
@@ -209,12 +209,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -226,7 +226,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -234,9 +234,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -319,8 +319,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -364,8 +363,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -562,7 +560,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -599,7 +597,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -629,9 +627,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -656,9 +654,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -705,9 +703,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -731,9 +729,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -847,9 +845,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1113,9 +1111,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1174,7 +1172,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1202,9 +1200,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1307,9 +1305,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/TradeoffAnalyticsV1/index.html
+++ b/docs/swift-api/services/TradeoffAnalyticsV1/index.html
@@ -209,12 +209,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -226,7 +226,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -234,9 +234,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -319,8 +319,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -364,8 +363,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -562,7 +560,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -599,7 +597,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -629,9 +627,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -656,9 +654,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -705,9 +703,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -731,9 +729,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -847,9 +845,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1113,9 +1111,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1174,7 +1172,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1202,9 +1200,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1307,9 +1305,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/VisualRecognitionV3/docsets/.docset/Contents/Resources/Documents/index.html
+++ b/docs/swift-api/services/VisualRecognitionV3/docsets/.docset/Contents/Resources/Documents/index.html
@@ -218,12 +218,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -235,7 +235,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -243,9 +243,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -328,8 +328,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -373,8 +372,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -571,7 +569,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -608,7 +606,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -638,9 +636,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -665,9 +663,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -714,9 +712,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -740,9 +738,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -856,9 +854,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1122,9 +1120,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1183,7 +1181,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1211,9 +1209,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1316,9 +1314,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>

--- a/docs/swift-api/services/VisualRecognitionV3/index.html
+++ b/docs/swift-api/services/VisualRecognitionV3/index.html
@@ -218,12 +218,12 @@
 <p>To build the project, run <code>swift build</code> from the command line.</p>
 <h2 id='service-instances' class='heading'>Service Instances</h2>
 
-<p><a href="https://www.ibm.com/watson/developercloud/">IBM Watson Developer Cloud</a> offers a variety of services for developing cognitive applications. The complete list of Watson Developer Cloud services is available from the <a href="https://www.ibm.com/watson/developercloud/services-catalog.html">services catalog</a>. Services are instantiated using the <a href="http://www.ibm.com/cloud-computing/bluemix/">IBM Bluemix</a> cloud platform.</p>
+<p>a href="https://www.ibm.com/watson/developercloud/">IBM Watson</a> offers a variety of services for developing cognitive applications. The complete list of Watson services is available from the <a href="https://www.ibm.com/watson/products-services/">products and services</a> page. Services are instantiated using the <a href="https://www.ibm.com/cloud/">IBM Cloud</a> platform.</p>
 
 <p>Follow these steps to create a service instance and obtain its credentials:</p>
 
 <ol>
-<li>Log in to Bluemix at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
+<li>Log in to IBM Cloud at <a href="https://bluemix.net">https://bluemix.net</a>.</li>
 <li>Create a service instance:
 
 <ol>
@@ -235,7 +235,7 @@
 
 <ol>
 <li>Click <q>Service Credentials</q> on the left side of the page.</li>
-<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Alchemy).</li>
+<li>Copy the service&rsquo;s <code>username</code> and <code>password</code> (or <code>api_key</code> for Visual Recognition).</li>
 </ol></li>
 </ol>
 
@@ -243,9 +243,9 @@
 <pre class="highlight swift"><code><span class="k">let</span> <span class="nv">textToSpeech</span> <span class="o">=</span> <span class="kt">TextToSpeech</span><span class="p">(</span><span class="nv">username</span><span class="p">:</span> <span class="s">"your-username-here"</span><span class="p">,</span> <span class="nv">password</span><span class="p">:</span> <span class="s">"your-password-here"</span><span class="p">)</span>
 </code></pre>
 
-<p>Note that service credentials are different from your Bluemix username and password.</p>
+<p>Note that service credentials are different from your IBM Cloud username and password.</p>
 
-<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started</a> for more information on getting started with the Watson Developer Cloud and Bluemix.</p>
+<p>See <a href="https://console.bluemix.net/docs/services/watson/index.html">Getting Started with Watson and IBM Cloud</a> for more details.</p>
 <h2 id='custom-service-urls' class='heading'>Custom Service URLs</h2>
 
 <p>In some instances, users will need to use their own custom URL to access the Watson services. Thus, to make it easier to update, we have exposed the service URL as a public property of each class.</p>
@@ -328,8 +328,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="https://www.ibm.com/watson/developercloud/alchemy-data-news.html">IBM AlchemyData News - Service Page</a></li>
-<li><a href="http://docs.alchemyapi.com/">IBM AlchemyData News - Documentation</a></li>
-<li><a href="http://querybuilder.alchemyapi.com/builder">IBM AlchemyData News - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemydata-news/index.html">IBM AlchemyData News - Documentation</a></li>
 </ul>
 <h2 id='alchemylanguage' class='heading'>AlchemyLanguage</h2>
 
@@ -373,8 +372,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 
 <ul>
 <li><a href="http://www.ibm.com/watson/developercloud/alchemy-language.html">IBM AlchemyLanguage - Service Page</a></li>
-<li><a href="http://www.ibm.com/watson/developercloud/doc/alchemylanguage/">IBM AlchemyLanguage - Documentation</a></li>
-<li><a href="https://alchemy-language-demo.mybluemix.net/">IBM AlchemyLanguage - Demo</a></li>
+<li><a href="https://console.bluemix.net/docs/services/alchemy-language/index.html">IBM AlchemyLanguage - Documentation</a></li>
 </ul>
 <h2 id='conversation' class='heading'>Conversation</h2>
 
@@ -571,7 +569,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Discovery service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/discovery.html">IBM Discovery - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/discovery/">IBM Discovery - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/discovery/index.html">IBM Discovery - Documentation</a></li>
 <li><a href="https://www.ibm.com/watson/developercloud/discovery/api/v1/">IBM Discovery - API Reference</a></li>
 <li><a href="https://watson-api-explorer.mybluemix.net/apis/discovery-v1">IBM Discovery - API Explorer</a></li>
@@ -608,7 +606,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Document Conversion service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/document-conversion.html">IBM Watson Document Conversion - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/document-conversion/">IBM Watson Document Conversion - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/document-conversion/index.html">IBM Watson Document Conversion - Documentation</a></li>
 <li><a href="https://document-conversion-demo.mybluemix.net/">IBM Watson Document Conversion - Demo</a></li>
 </ul>
@@ -638,9 +636,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Language Translator service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/language-translator.html">IBM Watson Language Translator - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/language-translator/">IBM Watson Language Translator - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/language-translator/index.html">IBM Watson Language Translator - Documentation</a></li>
-<li><a href="https://language-translator-demo.mybluemix.net/">IBM Watson Language Translator - Demo</a></li>
+<li><a href="https://language-translator-demo.ng.bluemix.net/">IBM Watson Language Translator - Demo</a></li>
 </ul>
 <h2 id='natural-language-classifier' class='heading'>Natural Language Classifier</h2>
 
@@ -665,9 +663,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Classifier service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/nl-classifier.html">IBM Watson Natural Language Classifier - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-classifier/">IBM Watson Natural Language Classifier - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-classifier/natural-language-classifier-overview.html">IBM Watson Natural Language Classifier - Documentation</a></li>
-<li><a href="https://natural-language-classifier-demo.mybluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
+<li><a href="https://natural-language-classifier-demo.ng.bluemix.net/">IBM Watson Natural Language Classifier - Demo</a></li>
 </ul>
 <h2 id='natural-language-understanding' class='heading'>Natural Language Understanding</h2>
 
@@ -714,9 +712,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Natural Language Understanding service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">IBM Watson Natural Language Understanding - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/natural-language-understanding/">IBM Watson Natural Language Understanding - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/natural-language-understanding/index.html">IBM Watson Natural Language Understanding - Documentation</a></li>
-<li><a href="http://natural-language-understanding-demo.mybluemix.net">IBM Watson Natural Language Understanding - Demo</a></li>
+<li><a href="https://natural-language-understanding-demo.ng.bluemix.net/">IBM Watson Natural Language Understanding - Demo</a></li>
 </ul>
 <h2 id='personality-insights' class='heading'>Personality Insights</h2>
 
@@ -740,9 +738,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Personality Insights service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/personality-insights.html">IBM Watson Personality Insights - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/personality-insights/">IBM Watson Personality Insights - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/personality-insights/index.html">IBM Watson Personality Insights - Documentation</a></li>
-<li><a href="https://personality-insights-livedemo.mybluemix.net">IBM Watson Personality Insights - Demo</a></li>
+<li><a href="https://personality-insights-demo.ng.bluemix.net/">IBM Watson Personality Insights - Demo</a></li>
 </ul>
 <h2 id='retrieve-and-rank' class='heading'>Retrieve and Rank</h2>
 
@@ -856,9 +854,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the Retrieve and Rank service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/retrieve-rank.html">IBM Watson Retrieve and Rank - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/retrieve-and-rank/">IBM Watson Retrieve and Rank - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/retrieve-and-rank/index.html">IBM Watson Retrieve and Rank - Documentation</a></li>
-<li><a href="http://retrieve-and-rank-demo.mybluemix.net/rnr-demo/dist/#/">IBM Watson Retrieve and Rank - Demo</a></li>
+<li><a href="http://retrieve-and-rank-demo.ng.bluemix.net/">IBM Watson Retrieve and Rank - Demo</a></li>
 </ul>
 <h2 id='speech-to-text' class='heading'>Speech to Text</h2>
 
@@ -1122,9 +1120,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Speech to Text service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">IBM Watson Speech to Text - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/speech-to-text/">IBM Watson Speech to Text - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/speech-to-text/index.html">IBM Watson Speech to Text - Documentation</a></li>
-<li><a href="https://speech-to-text-demo.mybluemix.net/">IBM Watson Speech to Text - Demo</a></li>
+<li><a href="https://speech-to-text-demo.ng.bluemix.net/">IBM Watson Speech to Text - Demo</a></li>
 </ul>
 <h2 id='text-to-speech' class='heading'>Text to Speech</h2>
 
@@ -1183,7 +1181,7 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Text To Speech service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">IBM Watson Text To Speech - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/text-to-speech/">IBM Watson Text To Speech - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/text-to-speech/index.html">IBM Watson Text To Speech - Documentation</a></li>
 <li><a href="https://text-to-speech-demo.mybluemix.net/">IBM Watson Text To Speech - Demo</a></li>
 </ul>
@@ -1211,9 +1209,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Tone Analyzer service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">IBM Watson Tone Analyzer - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/tone-analyzer/">IBM Watson Tone Analyzer - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/tone-analyzer/index.html">IBM Watson Tone Analyzer - Documentation</a></li>
-<li><a href="https://tone-analyzer-demo.mybluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
+<li><a href="https://tone-analyzer-demo.ng.bluemix.net/">IBM Watson Tone Analyzer - Demo</a></li>
 </ul>
 <h2 id='tradeoff-analytics' class='heading'>Tradeoff Analytics</h2>
 
@@ -1316,9 +1314,9 @@ available in <a href="https://github.com/watson-developer-cloud/ios-sdk/blob/mas
 <p>The following links provide more information about the IBM Watson Visual Recognition service:</p>
 
 <ul>
-<li><a href="http://www.ibm.com/watson/developercloud/visual-recognition.html">IBM Watson Visual Recognition - Service Page</a></li>
+<li><a href="https://www.ibm.com/watson/services/visual-recognition/">IBM Watson Visual Recognition - Service Page</a></li>
 <li><a href="https://console.bluemix.net/docs/services/visual-recognition/index.html">IBM Watson Visual Recognition - Documentation</a></li>
-<li><a href="http://visual-recognition-demo.mybluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
+<li><a href="https://visual-recognition-demo.ng.bluemix.net/">IBM Watson Visual Recognition - Demo</a></li>
 </ul>
 
           </section>


### PR DESCRIPTION
Updating links that point to WDC documentation to go to the Watson
console.

- Update links that go to WDC to point to IBM Cloud (except for links
for deprecated services that weren't moved).
- Update references of Bluemix to IBM Cloud
- Reduce references to Watson Developer Cloud
- Update service landing pages from WDC to newer marketing pages
- Remove links for demos and docs that don't exist (e.g., alchemy)
- Update links to demos that have moved from mybluemix.net to
bluemix.net
- Update api_key reference from Alchemy to Visual Recognition