### PR TITLE
Use conditional compilation blocks to identify Linux incompatibilities

### DIFF
--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -1,0 +1,221 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#if os(Linux)
+#else
+
+import Foundation
+import AVFoundation
+
+private var microphoneSession: SpeechToTextSession?
+
+extension SpeechToText {
+
+    /**
+     Perform speech recognition for an audio file.
+     
+     - parameter audio: The audio file to transcribe.
+     - parameter settings: The configuration to use for this recognition request.
+     - parameter model: The language and sample rate of the audio. For supported models, visit
+       https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
+     - parameter customizationID: The GUID of a custom language model that is to be used with the
+       request. The base language model of the specified custom language model must match the
+       model specified with the `model` parameter. By default, no custom model is used.
+     - parameter learningOptOut: If `true`, then this request will not be logged for training.
+     - parameter failure: A function executed whenever an error occurs.
+     - parameter success: A function executed with all transcription results whenever
+       a final or interim transcription is received.
+     */
+    public func recognize(
+        audio: URL,
+        settings: RecognitionSettings,
+        model: String? = nil,
+        customizationID: String? = nil,
+        learningOptOut: Bool? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (SpeechRecognitionResults) -> Void)
+    {
+        do {
+            let data = try Data(contentsOf: audio)
+            recognize(
+                audio: data,
+                settings: settings,
+                model: model,
+                customizationID: customizationID,
+                learningOptOut: learningOptOut,
+                failure: failure,
+                success: success
+            )
+        } catch {
+            let failureReason = "Could not load audio data from \(audio)."
+            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let error = NSError(domain: domain, code: 0, userInfo: userInfo)
+            failure?(error)
+            return
+        }
+    }
+    
+    /**
+     Perform speech recognition for audio data.
+     
+     - parameter audio: The audio data to transcribe.
+     - parameter settings: The configuration to use for this recognition request.
+     - parameter model: The language and sample rate of the audio. For supported models, visit
+       https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
+     - parameter customizationID: The GUID of a custom language model that is to be used with the
+       request. The base language model of the specified custom language model must match the
+       model specified with the `model` parameter. By default, no custom model is used.
+     - parameter learningOptOut: If `true`, then this request will not be logged for training.
+     - parameter failure: A function executed whenever an error occurs.
+     - parameter success: A function executed with all transcription results whenever
+       a final or interim transcription is received.
+     */
+    public func recognize(
+        audio: Data,
+        settings: RecognitionSettings,
+        model: String? = nil,
+        customizationID: String? = nil,
+        learningOptOut: Bool? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (SpeechRecognitionResults) -> Void)
+    {
+        // create session
+        let session = SpeechToTextSession(
+            username: username,
+            password: password,
+            model: model,
+            customizationID: customizationID,
+            learningOptOut: learningOptOut
+        )
+        
+        // set urls
+        session.serviceURL = serviceURL
+        session.tokenURL = tokenURL
+        session.websocketsURL = websocketsURL
+        
+        // set headers
+        session.defaultHeaders = defaultHeaders
+        
+        // set callbacks
+        session.onResults = success
+        session.onError = failure
+        
+        // execute recognition request
+        session.connect()
+        session.startRequest(settings: settings)
+        session.recognize(audio: audio)
+        session.stopRequest()
+        session.disconnect()
+    }
+    
+    /**
+     Perform speech recognition for microphone audio. To stop the microphone, invoke
+     `stopRecognizeMicrophone()`.
+     
+     Microphone audio is compressed to OggOpus format unless otherwise specified by the `compress`
+     parameter. With compression enabled, the `settings` should specify a `contentType` of
+     `AudioMediaType.oggOpus`. With compression disabled, the `settings` should specify a
+     `contentType` of `AudioMediaType.l16(rate: 16000, channels: 1)`.
+     
+     This function may cause the system to automatically prompt the user for permission
+     to access the microphone. Use `AVAudioSession.requestRecordPermission(_:)` if you
+     would prefer to ask for the user's permission in advance.
+     
+     - parameter settings: The configuration for this transcription request.
+     - parameter model: The language and sample rate of the audio. For supported models, visit
+       https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
+     - parameter customizationID: The GUID of a custom language model that is to be used with the
+       request. The base language model of the specified custom language model must match the
+       model specified with the `model` parameter. By default, no custom model is used.
+     - parameter learningOptOut: If `true`, then this request will not be logged for training.
+     - parameter compress: Should microphone audio be compressed to OggOpus format?
+       (OggOpus compression reduces latency and bandwidth.)
+     - parameter failure: A function executed whenever an error occurs.
+     - parameter success: A function executed with all transcription results whenever
+       a final or interim transcription is received.
+     */
+    public func recognizeMicrophone(
+        settings: RecognitionSettings,
+        model: String? = nil,
+        customizationID: String? = nil,
+        learningOptOut: Bool? = nil,
+        compress: Bool = true,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (SpeechRecognitionResults) -> Void)
+    {
+        // make sure the AVAudioSession shared instance is properly configured
+        do {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(AVAudioSessionCategoryPlayAndRecord, with: [.defaultToSpeaker, .mixWithOthers])
+            try audioSession.setActive(true)
+        } catch {
+            let failureReason = "Failed to setup the AVAudioSession sharedInstance properly."
+            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+            failure?(error)
+            return
+        }
+        
+        // validate settings
+        var settings = settings
+        settings.contentType = compress ? .oggOpus : .l16(rate: 16000, channels: 1)
+        
+        // create session
+        let session = SpeechToTextSession(
+            username: username,
+            password: password,
+            model: model,
+            customizationID: customizationID,
+            learningOptOut: learningOptOut
+        )
+        
+        // set urls
+        session.serviceURL = serviceURL
+        session.tokenURL = tokenURL
+        session.websocketsURL = websocketsURL
+        
+        // set headers
+        session.defaultHeaders = defaultHeaders
+        
+        // set callbacks
+        session.onResults = success
+        session.onError = failure
+        
+        // start recognition request
+        session.connect()
+        session.startRequest(settings: settings)
+        session.startMicrophone(compress: compress)
+        
+        // store session
+        microphoneSession = session
+    }
+    
+    /**
+     Stop performing speech recognition for microphone audio.
+     
+     When invoked, this function will
+     1. Stop recording audio from the microphone.
+     2. Send a stop message to stop the current recognition request.
+     3. Wait to receive all recognition results then disconnect from the service.
+     */
+    public func stopRecognizeMicrophone() {
+        microphoneSession?.stopMicrophone()
+        microphoneSession?.stopRequest()
+        microphoneSession?.disconnect()
+    }
+}
+
+#endif

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016-2017
+ * Copyright IBM Corporation 2016, 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  **/
 
 import Foundation
-import AVFoundation
 
 /**
  The IBM Watson Speech to Text service enables you to add speech transcription capabilities to
@@ -42,12 +41,10 @@ public class SpeechToText {
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
-    private let username: String
-    private let password: String
-    private let credentials: Credentials
-    private var microphoneSession: SpeechToTextSession?
-    private let audioSession = AVAudioSession.sharedInstance()
-    private let domain = "com.ibm.watson.developer-cloud.SpeechToTextV1"
+    internal let username: String
+    internal let password: String
+    internal let credentials: Credentials
+    internal let domain = "com.ibm.watson.developer-cloud.SpeechToTextV1"
 
     /**
      Create a `SpeechToText` object.
@@ -156,198 +153,6 @@ public class SpeechToText {
                 case .failure(let error): failure?(error)
                 }
             }
-    }
-
-    /**
-     Perform speech recognition for an audio file.
-
-     - parameter audio: The audio file to transcribe.
-     - parameter settings: The configuration to use for this recognition request.
-     - parameter model: The language and sample rate of the audio. For supported models, visit
-        https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
-     - parameter customizationID: The GUID of a custom language model that is to be used with the
-        request. The base language model of the specified custom language model must match the
-        model specified with the `model` parameter. By default, no custom model is used.
-     - parameter learningOptOut: If `true`, then this request will not be logged for training.
-     - parameter failure: A function executed whenever an error occurs.
-     - parameter success: A function executed with all transcription results whenever
-        a final or interim transcription is received.
-     */
-    public func recognize(
-        audio: URL,
-        settings: RecognitionSettings,
-        model: String? = nil,
-        customizationID: String? = nil,
-        learningOptOut: Bool? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (SpeechRecognitionResults) -> Void)
-    {
-        do {
-            let data = try Data(contentsOf: audio)
-            recognize(
-                audio: data,
-                settings: settings,
-                model: model,
-                customizationID: customizationID,
-                learningOptOut: learningOptOut,
-                failure: failure,
-                success: success
-            )
-        } catch {
-            let failureReason = "Could not load audio data from \(audio)."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
-            let error = NSError(domain: domain, code: 0, userInfo: userInfo)
-            failure?(error)
-            return
-        }
-    }
-
-    /**
-     Perform speech recognition for audio data.
-
-     - parameter audio: The audio data to transcribe.
-     - parameter settings: The configuration to use for this recognition request.
-     - parameter model: The language and sample rate of the audio. For supported models, visit
-        https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
-     - parameter customizationID: The GUID of a custom language model that is to be used with the
-        request. The base language model of the specified custom language model must match the
-        model specified with the `model` parameter. By default, no custom model is used.
-     - parameter learningOptOut: If `true`, then this request will not be logged for training.
-     - parameter failure: A function executed whenever an error occurs.
-     - parameter success: A function executed with all transcription results whenever
-        a final or interim transcription is received.
-     */
-    public func recognize(
-        audio: Data,
-        settings: RecognitionSettings,
-        model: String? = nil,
-        customizationID: String? = nil,
-        learningOptOut: Bool? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (SpeechRecognitionResults) -> Void)
-    {
-        // create session
-        let session = SpeechToTextSession(
-            username: username,
-            password: password,
-            model: model,
-            customizationID: customizationID,
-            learningOptOut: learningOptOut
-        )
-
-        // set urls
-        session.serviceURL = serviceURL
-        session.tokenURL = tokenURL
-        session.websocketsURL = websocketsURL
-
-        // set headers
-        session.defaultHeaders = defaultHeaders
-
-        // set callbacks
-        session.onResults = success
-        session.onError = failure
-
-        // execute recognition request
-        session.connect()
-        session.startRequest(settings: settings)
-        session.recognize(audio: audio)
-        session.stopRequest()
-        session.disconnect()
-    }
-
-    /**
-     Perform speech recognition for microphone audio. To stop the microphone, invoke
-     `stopRecognizeMicrophone()`.
-
-     Microphone audio is compressed to OggOpus format unless otherwise specified by the `compress`
-     parameter. With compression enabled, the `settings` should specify a `contentType` of
-     `AudioMediaType.oggOpus`. With compression disabled, the `settings` should specify a
-     `contentType` of `AudioMediaType.l16(rate: 16000, channels: 1)`.
-
-     This function may cause the system to automatically prompt the user for permission
-     to access the microphone. Use `AVAudioSession.requestRecordPermission(_:)` if you
-     would prefer to ask for the user's permission in advance.
-
-     - parameter settings: The configuration for this transcription request.
-     - parameter model: The language and sample rate of the audio. For supported models, visit
-        https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
-     - parameter customizationID: The GUID of a custom language model that is to be used with the
-        request. The base language model of the specified custom language model must match the
-        model specified with the `model` parameter. By default, no custom model is used.
-     - parameter learningOptOut: If `true`, then this request will not be logged for training.
-     - parameter compress: Should microphone audio be compressed to OggOpus format?
-        (OggOpus compression reduces latency and bandwidth.)
-     - parameter failure: A function executed whenever an error occurs.
-     - parameter success: A function executed with all transcription results whenever
-        a final or interim transcription is received.
-     */
-    public func recognizeMicrophone(
-        settings: RecognitionSettings,
-        model: String? = nil,
-        customizationID: String? = nil,
-        learningOptOut: Bool? = nil,
-        compress: Bool = true,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (SpeechRecognitionResults) -> Void)
-    {
-        // make sure the AVAudioSession shared instance is properly configured
-        do {
-            try audioSession.setCategory(AVAudioSessionCategoryPlayAndRecord, with: [.defaultToSpeaker, .mixWithOthers])
-            try audioSession.setActive(true)
-        } catch {
-            let failureReason = "Failed to setup the AVAudioSession sharedInstance properly."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
-            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
-            failure?(error)
-            return
-        }
-
-        // validate settings
-        var settings = settings
-        settings.contentType = compress ? .oggOpus : .l16(rate: 16000, channels: 1)
-
-        // create session
-        let session = SpeechToTextSession(
-            username: username,
-            password: password,
-            model: model,
-            customizationID: customizationID,
-            learningOptOut: learningOptOut
-        )
-
-        // set urls
-        session.serviceURL = serviceURL
-        session.tokenURL = tokenURL
-        session.websocketsURL = websocketsURL
-
-        // set headers
-        session.defaultHeaders = defaultHeaders
-
-        // set callbacks
-        session.onResults = success
-        session.onError = failure
-
-        // start recognition request
-        session.connect()
-        session.startRequest(settings: settings)
-        session.startMicrophone(compress: compress)
-
-        // store session
-        microphoneSession = session
-    }
-
-    /**
-     Stop performing speech recognition for microphone audio.
-
-     When invoked, this function will
-        1. Stop recording audio from the microphone.
-        2. Send a stop message to stop the current recognition request.
-        3. Wait to receive all recognition results then disconnect from the service.
-     */
-    public func stopRecognizeMicrophone() {
-        microphoneSession?.stopMicrophone()
-        microphoneSession?.stopRequest()
-        microphoneSession?.disconnect()
     }
 
     // MARK: - Custom Models

--- a/Source/SpeechToTextV1/SpeechToTextEncoder.swift
+++ b/Source/SpeechToTextV1/SpeechToTextEncoder.swift
@@ -14,6 +14,9 @@
  * limitations under the License.
  **/
 
+#if os(Linux)
+#else
+
 import Foundation
 import AudioToolbox
 
@@ -501,3 +504,5 @@ internal enum OggError: Error {
     case outOfSync
     case internalError
 }
+
+#endif

--- a/Source/SpeechToTextV1/SpeechToTextRecorder.swift
+++ b/Source/SpeechToTextV1/SpeechToTextRecorder.swift
@@ -14,6 +14,9 @@
  * limitations under the License.
  **/
 
+#if os(Linux)
+#else
+
 import Foundation
 import AudioToolbox
 import AVFoundation
@@ -174,3 +177,5 @@ internal class SpeechToTextRecorder {
         onPowerData?(meters[0].mAveragePower)
     }
 }
+
+#endif

--- a/Source/SpeechToTextV1/SpeechToTextSession.swift
+++ b/Source/SpeechToTextV1/SpeechToTextSession.swift
@@ -14,6 +14,9 @@
  * limitations under the License.
  **/
 
+#if os(Linux)
+#else
+
 import Foundation
 import AVFoundation
 
@@ -304,3 +307,5 @@ public class SpeechToTextSession {
         socket.disconnect()
     }
 }
+
+#endif

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		68AC59381F8DCA0C00012CCB /* TargetedEmotionResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC59111F8DCA0200012CCB /* TargetedEmotionResults.swift */; };
 		68AC59391F8DCA0C00012CCB /* TargetedSentimentResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC59001F8DC9FB00012CCB /* TargetedSentimentResults.swift */; };
 		68AC593A1F8DCA0C00012CCB /* Usage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC58FD1F8DC9FB00012CCB /* Usage.swift */; };
+		68AF76782008167900D35B2D /* SpeechToText+Recognize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AF76772008167900D35B2D /* SpeechToText+Recognize.swift */; };
 		68B213EF1F84298B0052DC00 /* CodableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B213ED1F8429880052DC00 /* CodableExtensionsTests.swift */; };
 		68B213F01F84298B0052DC00 /* JSONValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B213EE1F8429890052DC00 /* JSONValueTests.swift */; };
 		68BC28661F8C34FE0042810E /* CodableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B213E71F84296D0052DC00 /* CodableExtensions.swift */; };
@@ -1032,6 +1033,7 @@
 		68AC59101F8DCA0100012CCB /* SemanticRolesEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticRolesEntity.swift; sourceTree = "<group>"; };
 		68AC59111F8DCA0200012CCB /* TargetedEmotionResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetedEmotionResults.swift; sourceTree = "<group>"; };
 		68AC59121F8DCA0200012CCB /* SemanticRolesOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticRolesOptions.swift; sourceTree = "<group>"; };
+		68AF76772008167900D35B2D /* SpeechToText+Recognize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpeechToText+Recognize.swift"; sourceTree = "<group>"; };
 		68B213E71F84296D0052DC00 /* CodableExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableExtensions.swift; sourceTree = "<group>"; };
 		68B213E81F84296D0052DC00 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		68B213ED1F8429880052DC00 /* CodableExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableExtensionsTests.swift; sourceTree = "<group>"; };
@@ -2270,6 +2272,7 @@
 			children = (
 				7AAA9A111CEE3026002C9564 /* Models */,
 				7AAA9A1D1CEE3026002C9564 /* SpeechToText.swift */,
+				68AF76772008167900D35B2D /* SpeechToText+Recognize.swift */,
 				7A9EC8071D79B75100507725 /* SpeechToTextEncoder.swift */,
 				7A9EC8081D79B75100507725 /* SpeechToTextRecorder.swift */,
 				7A9EC8091D79B75100507725 /* SpeechToTextSession.swift */,
@@ -5000,6 +5003,7 @@
 				68BC28681F8C34FE0042810E /* JSON.swift in Sources */,
 				68BC286C1F8C34FE0042810E /* RestToken.swift in Sources */,
 				68BC286B1F8C34FE0042810E /* RestRequest.swift in Sources */,
+				68AF76782008167900D35B2D /* SpeechToText+Recognize.swift in Sources */,
 				B1A8E54F1D19DCDF00678412 /* Feed.swift in Sources */,
 				B1A8E54A1D19DCDF00678412 /* DocumentEnriched.swift in Sources */,
 				B1A8E54D1D19DCDF00678412 /* EnrichedTitle.swift in Sources */,


### PR DESCRIPTION
This pull request uses `#if os(Linux) #else <code> #endif` to identify code that is incompatible with Linux. It also separates the Speech to Text recognition functions into an extension, `SpeechToText+Recognize.swift`.

These changes have two benefits:
1. With conditional compilation, we may be able to support some Speech to Text functionality on Linux. This would be preferable to ignoring the Speech to Text framework altogether.
2. With the recognition functions in a separate extension, the `SpeechToText.swift` file may be easier to generate.

Although this moves us towards support for Speech to Text in the `Package.swift` file, there is more work that needs to be done. In particular, neither Speech to Text nor Text to Speech build with the Swift Package Manager because they depend on `libogg` and `libopus` in the `SupportingFiles/Dependencies` directory.

There will also be more work required to avoid manual changes to `SpeechToText.swift` after generation. For example, the `tokenURL` and `websocketsURL` properties are not being generated. But this is still dramatically simpler than manually managing the methods in `SpeechToText+Recognize.swift`.