### PR TITLE
RestKit improvements to response handling

### DIFF
--- a/Source/AlchemyLanguageV1/AlchemyLanguage.swift
+++ b/Source/AlchemyLanguageV1/AlchemyLanguage.swift
@@ -60,7 +60,7 @@ public class AlchemyLanguage {
         // service, without regards to whether the response itself was a success or a failure.
 
         // First check http status code in response
-        // If statusCode indicates and error, return nil so that RestKit uses its default error
+        // If statusCode indicates an error, return nil so that RestKit uses its default error
         if let response = response {
             if !(200..<300).contains(response.statusCode) {
                 return nil

--- a/Source/AlchemyLanguageV1/AlchemyLanguage.swift
+++ b/Source/AlchemyLanguageV1/AlchemyLanguage.swift
@@ -59,6 +59,14 @@ public class AlchemyLanguage {
         // services return a status code of 200 if you are able to successfully contact the
         // service, without regards to whether the response itself was a success or a failure.
 
+        // First check http status code in response
+        // If statusCode indicates and error, return nil so that RestKit uses its default error
+        if let response = response {
+            if !(200..<300).contains(response.statusCode) {
+                return nil
+            }
+        }
+
         // ensure data is not nil
         guard let data = data else {
             if let code = response?.statusCode {

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -56,7 +56,7 @@ public class Conversation {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/DialogV1/Dialog.swift
+++ b/Source/DialogV1/Dialog.swift
@@ -62,7 +62,7 @@ public class Dialog {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -59,7 +59,7 @@ public class Discovery {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/DocumentConversionV1/DocumentConversion.swift
+++ b/Source/DocumentConversionV1/DocumentConversion.swift
@@ -57,7 +57,7 @@ public class DocumentConversion {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -53,7 +53,7 @@ public class LanguageTranslator {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -56,7 +56,7 @@ public class NaturalLanguageClassifier {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -98,7 +98,7 @@ public class NaturalLanguageUnderstanding {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/PersonalityInsightsV2/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV2/PersonalityInsights.swift
@@ -53,7 +53,7 @@ public class PersonalityInsights {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -57,7 +57,7 @@ public class PersonalityInsights {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/RelationshipExtractionV1Beta/RelationshipExtraction.swift
+++ b/Source/RelationshipExtractionV1Beta/RelationshipExtraction.swift
@@ -58,7 +58,7 @@ public class RelationshipExtraction {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/RestKit/RestError.swift
+++ b/Source/RestKit/RestError.swift
@@ -19,7 +19,7 @@ import Foundation
 /// An error from processing a network request or response.
 public enum RestError: Error {
 
-    /// No response was returned from the server.
+    /// No response was received from the server.
     case noResponse
 
     /// No data was returned from the server.

--- a/Source/RestKit/RestError.swift
+++ b/Source/RestKit/RestError.swift
@@ -19,6 +19,9 @@ import Foundation
 /// An error from processing a network request or response.
 public enum RestError: Error {
 
+    /// No response was returned from the server.
+    case noResponse
+
     /// No data was returned from the server.
     case noData
 

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -103,7 +103,10 @@ internal struct RestRequest {
         self.request = request
     }
 
-    internal func response(completionHandler: @escaping (Data?, HTTPURLResponse?, Error?) -> Void) {
+    internal func response(
+        parseServiceError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
+        completionHandler: @escaping (Data?, HTTPURLResponse?, Error?) -> Void)
+    {
         let task = session.dataTask(with: request) { (data, response, error) in
 
             guard error == nil  else {
@@ -118,7 +121,8 @@ internal struct RestRequest {
             }
 
             guard (200..<300).contains(response.statusCode) else {
-                completionHandler(data, response, self.errorWithCode(code: response.statusCode))
+                let error = parseServiceError?(response, data) ?? self.errorWithCode(code: response.statusCode)
+                completionHandler(data, response, error)
                 return
             }
 
@@ -155,8 +159,8 @@ internal struct RestRequest {
 
     internal func responseData(completionHandler: @escaping (RestResponse<Data>) -> Void) {
         response { data, response, error in
-            if let error = error {
-                let result = RestResult<Data>.failure(error)
+            guard error == nil else {
+                let result = RestResult<Data>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
@@ -178,10 +182,10 @@ internal struct RestRequest {
         path: [JSONPathType]? = nil,
         completionHandler: @escaping (RestResponse<T>) -> Void)
     {
-        response { data, response, error in
+        response(parseServiceError: responseToError) { data, response, error in
 
-            if let error = error ?? responseToError?(response, data) {
-                let result = RestResult<T>.failure(error)
+            guard error == nil else {
+                let result = RestResult<T>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
@@ -228,10 +232,10 @@ internal struct RestRequest {
         responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
         completionHandler: @escaping (RestResponse<T>) -> Void)
     {
-        response { data, response, error in
+        response(parseServiceError: responseToError) { data, response, error in
 
-            if let error = error ?? responseToError?(response, data) {
-                let result = RestResult<T>.failure(error)
+            guard error == nil else {
+                let result = RestResult<T>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
@@ -265,10 +269,10 @@ internal struct RestRequest {
         path: [JSONPathType]? = nil,
         completionHandler: @escaping (RestResponse<[T]>) -> Void)
     {
-        response { data, response, error in
+        response(parseServiceError: responseToError) { data, response, error in
 
-            if let error = error ?? responseToError?(response, data) {
-                let result = RestResult<[T]>.failure(error)
+            guard error == nil else {
+                let result = RestResult<[T]>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
@@ -316,10 +320,10 @@ internal struct RestRequest {
         responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
         completionHandler: @escaping (RestResponse<String>) -> Void)
     {
-        response { data, response, error in
+        response(parseServiceError: responseToError) { data, response, error in
 
-            if let error = error ?? responseToError?(response, data) {
-                let result = RestResult<String>.failure(error)
+            guard error == nil else {
+                let result = RestResult<String>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
@@ -352,10 +356,10 @@ internal struct RestRequest {
         responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
         completionHandler: @escaping (RestResponse<Void>) -> Void)
     {
-        response { data, response, error in
+        response(parseServiceError: responseToError) { data, response, error in
 
-            if let error = error ?? responseToError?(response, data) {
-                let result = RestResult<Void>.failure(error)
+            guard error == nil else {
+                let result = RestResult<Void>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return

--- a/Source/RetrieveAndRankV1/RetrieveAndRank.swift
+++ b/Source/RetrieveAndRankV1/RetrieveAndRank.swift
@@ -53,7 +53,7 @@ public class RetrieveAndRank {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -69,7 +69,7 @@ public class SpeechToText {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -54,7 +54,7 @@ public class TextToSpeech {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -57,7 +57,7 @@ public class ToneAnalyzer {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Source/TradeoffAnalyticsV1/TradeoffAnalytics.swift
+++ b/Source/TradeoffAnalyticsV1/TradeoffAnalytics.swift
@@ -54,7 +54,7 @@ public class TradeoffAnalytics {
 
         // First check http status code in response
         if let response = response {
-            if response.statusCode >= 200 && response.statusCode < 300 {
+            if (200..<300).contains(response.statusCode) {
                 return nil
             }
         }

--- a/Tests/RetrieveAndRankV1Tests/RetrieveAndRankTests.swift
+++ b/Tests/RetrieveAndRankV1Tests/RetrieveAndRankTests.swift
@@ -410,8 +410,8 @@ class RetrieveAndRankTests: XCTestCase {
             forSolrClusterID: trainedClusterID,
             failure: failWithError) { collections in
 
-            XCTAssertEqual(collections.count, 1)
-            XCTAssertEqual(collections.first, self.trainedCollectionName)
+            XCTAssertGreaterThanOrEqual(collections.count, 1)
+            XCTAssertTrue(collections.contains(self.trainedCollectionName))
             expectation.fulfill()
         }
         waitForExpectations()


### PR DESCRIPTION
Refactor processing in RestKit to move call to parseServiceError down into the core response handling method.  This lays the foundation for simplifying response processing once the legacy Alchemy services are retired.

