### PR TITLE
Enable swiftlint rule to flag force unwrapping

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 
 # Exclude deprecated/legacy services
 excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - Carthage
   - Source/AlchemyDataNewsV1
   - Source/AlchemyLanguageV1
   - Source/AlchemyVisionV1
@@ -21,6 +22,9 @@ disabled_rules: # rule identifiers to exclude from running
   - closure_parameter_position
   - opening_brace
   - redundant_string_enum_value
+
+opt_in_rules:
+ - force_unwrapping
 
 file_length:
   warning: 3000

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -44,6 +44,8 @@ brew update
 brew outdated carthage || brew upgrade carthage
 carthage bootstrap --platform iOS
 
+brew outdated swiftlint || brew upgrade swiftlint
+
 ####################
 # Build and Test
 ####################

--- a/Source/DialogV1/Dialog.swift
+++ b/Source/DialogV1/Dialog.swift
@@ -275,6 +275,7 @@ public class Dialog {
         // execute REST request
         request.download(to: destination) { response, error in
             guard error == nil else {
+                // swiftlint:disable:next force_unwrapping
                 failure?(error!)
                 return
             }

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -109,7 +109,7 @@ internal struct RestRequest {
     {
         let task = session.dataTask(with: request) { (data, response, error) in
 
-            guard error == nil  else {
+            guard error == nil else {
                 completionHandler(data, response as? HTTPURLResponse, error)
                 return
             }
@@ -140,6 +140,7 @@ internal struct RestRequest {
     internal func responseData(completionHandler: @escaping (RestResponse<Data>) -> Void) {
         response { data, response, error in
             guard error == nil else {
+                // swiftlint:disable:next force_unwrapping
                 let result = RestResult<Data>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
@@ -165,6 +166,7 @@ internal struct RestRequest {
         response(parseServiceError: responseToError) { data, response, error in
 
             guard error == nil else {
+                // swiftlint:disable:next force_unwrapping
                 let result = RestResult<T>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
@@ -215,6 +217,7 @@ internal struct RestRequest {
         response(parseServiceError: responseToError) { data, response, error in
 
             guard error == nil else {
+                // swiftlint:disable:next force_unwrapping
                 let result = RestResult<T>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
@@ -252,6 +255,7 @@ internal struct RestRequest {
         response(parseServiceError: responseToError) { data, response, error in
 
             guard error == nil else {
+                // swiftlint:disable:next force_unwrapping
                 let result = RestResult<[T]>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
@@ -303,6 +307,7 @@ internal struct RestRequest {
         response(parseServiceError: responseToError) { data, response, error in
 
             guard error == nil else {
+                // swiftlint:disable:next force_unwrapping
                 let result = RestResult<String>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)
@@ -339,6 +344,7 @@ internal struct RestRequest {
         response(parseServiceError: responseToError) { data, response, error in
 
             guard error == nil else {
+                // swiftlint:disable:next force_unwrapping
                 let result = RestResult<Void>.failure(error!)
                 let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
                 completionHandler(dataResponse)

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -26,7 +26,7 @@ extension SpeechToText {
 
     /**
      Perform speech recognition for an audio file.
-     
+
      - parameter audio: The audio file to transcribe.
      - parameter settings: The configuration to use for this recognition request.
      - parameter model: The language and sample rate of the audio. For supported models, visit
@@ -67,10 +67,10 @@ extension SpeechToText {
             return
         }
     }
-    
+
     /**
      Perform speech recognition for audio data.
-     
+
      - parameter audio: The audio data to transcribe.
      - parameter settings: The configuration to use for this recognition request.
      - parameter model: The language and sample rate of the audio. For supported models, visit
@@ -100,19 +100,19 @@ extension SpeechToText {
             customizationID: customizationID,
             learningOptOut: learningOptOut
         )
-        
+
         // set urls
         session.serviceURL = serviceURL
         session.tokenURL = tokenURL
         session.websocketsURL = websocketsURL
-        
+
         // set headers
         session.defaultHeaders = defaultHeaders
-        
+
         // set callbacks
         session.onResults = success
         session.onError = failure
-        
+
         // execute recognition request
         session.connect()
         session.startRequest(settings: settings)
@@ -120,20 +120,20 @@ extension SpeechToText {
         session.stopRequest()
         session.disconnect()
     }
-    
+
     /**
      Perform speech recognition for microphone audio. To stop the microphone, invoke
      `stopRecognizeMicrophone()`.
-     
+
      Microphone audio is compressed to OggOpus format unless otherwise specified by the `compress`
      parameter. With compression enabled, the `settings` should specify a `contentType` of
      `AudioMediaType.oggOpus`. With compression disabled, the `settings` should specify a
      `contentType` of `AudioMediaType.l16(rate: 16000, channels: 1)`.
-     
+
      This function may cause the system to automatically prompt the user for permission
      to access the microphone. Use `AVAudioSession.requestRecordPermission(_:)` if you
      would prefer to ask for the user's permission in advance.
-     
+
      - parameter settings: The configuration for this transcription request.
      - parameter model: The language and sample rate of the audio. For supported models, visit
        https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
@@ -168,11 +168,11 @@ extension SpeechToText {
             failure?(error)
             return
         }
-        
+
         // validate settings
         var settings = settings
         settings.contentType = compress ? .oggOpus : .l16(rate: 16000, channels: 1)
-        
+
         // create session
         let session = SpeechToTextSession(
             username: username,
@@ -181,31 +181,31 @@ extension SpeechToText {
             customizationID: customizationID,
             learningOptOut: learningOptOut
         )
-        
+
         // set urls
         session.serviceURL = serviceURL
         session.tokenURL = tokenURL
         session.websocketsURL = websocketsURL
-        
+
         // set headers
         session.defaultHeaders = defaultHeaders
-        
+
         // set callbacks
         session.onResults = success
         session.onError = failure
-        
+
         // start recognition request
         session.connect()
         session.startRequest(settings: settings)
         session.startMicrophone(compress: compress)
-        
+
         // store session
         microphoneSession = session
     }
-    
+
     /**
      Stop performing speech recognition for microphone audio.
-     
+
      When invoked, this function will
      1. Stop recording audio from the microphone.
      2. Send a stop message to stop the current recognition request.

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/LanguageTranslatorV2Tests/LanguageTranslatorTests.swift
+++ b/Tests/LanguageTranslatorV2Tests/LanguageTranslatorTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
+++ b/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
+++ b/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import PersonalityInsightsV3

--- a/Tests/RestKitTests/CodableExtensionsTests.swift
+++ b/Tests/RestKitTests/CodableExtensionsTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 

--- a/Tests/RestKitTests/JSONValueTests.swift
+++ b/Tests/RestKitTests/JSONValueTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 

--- a/Tests/RetrieveAndRankV1Tests/RetrieveAndRankTests.swift
+++ b/Tests/RetrieveAndRankV1Tests/RetrieveAndRankTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 #if !os(Linux)
 import XCTest

--- a/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/TradeoffAnalyticsV1Tests/TradeoffAnalyticsTests.swift
+++ b/Tests/TradeoffAnalyticsV1Tests/TradeoffAnalyticsTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
 import XCTest
 import Foundation


### PR DESCRIPTION
Enabled force_unwrapping rule that flags force unwraps as (non-severe) lint violations.
Also fixed up some lint errors that crept in since lint support was added and updated the run-tests script so that travis will run swiftlint as part of PR checks.