### PR TITLE
Update Natural Language Classifier Tests

### DIFF
--- a/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
+++ b/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
@@ -85,7 +85,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
     }
 
     /** Wait for expectations. */
-    func waitForExpectations(timeout: TimeInterval = 5.0) {
+    func waitForExpectations(timeout: TimeInterval = 20.0) {
         waitForExpectations(timeout: timeout) { error in
             XCTAssertNil(error, "Timeout")
         }
@@ -169,7 +169,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
             XCTAssertEqual(classification.classes.count, 2)
             expectation.fulfill()
         }
-        waitForExpectations(timeout: 20)
+        waitForExpectations()
     }
 
     // MARK: - Negative Tests

--- a/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
+++ b/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
@@ -22,9 +22,19 @@ import NaturalLanguageClassifierV1
 
 class NaturalLanguageClassifierTests: XCTestCase {
 
+    // Several tests depend upon an already-trained classifier. If the classifier does not exist then use the
+    // API Explorer (watson-api-explorer.mybluemix.net) to create a classifier using the `trained_meta.txt`
+    // and `weather_data_train.csv` files. Be sure to update the `trainedClassifierId` property below!
+
     private var naturalLanguageClassifier: NaturalLanguageClassifier!
-    private let newClassifierName = "Swift SDK Test Classifier"
-    private let trainedClassifierId = "0015a0x264-nlc-12512"
+    private let trainedClassifierId = "33c2fbx273-nlc-11743"
+    private let trainedClassifierName = "swift-sdk-test-classifier"
+    private let temporaryClassifierName = "swift-sdk-temporary-classifier"
+
+    private var metadataFile: URL!
+    private var metadataFileEmpty: URL!
+    private var metadataFileMissingName: URL!
+    private var trainingFile: URL!
 
     // MARK: - Test Configuration
 
@@ -32,6 +42,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
         super.setUp()
         continueAfterFailure = false
         instantiateNaturalLanguageClassifier()
+        loadClassifierFiles()
     }
 
     static var allTests: [(String, (NaturalLanguageClassifierTests) -> () throws -> Void)] {
@@ -82,218 +93,80 @@ class NaturalLanguageClassifierTests: XCTestCase {
 
     // MARK: - Helper Functions
 
-    /** Load a file used when creating a classifier. */
-    func loadClassifierFile(withName name: String, withExtension: String) -> URL? {
+    func loadClassifierFiles() {
+        metadataFile = loadClassifierFile(name: "training_meta", withExtension: "txt")
+        metadataFileEmpty = loadClassifierFile(name: "training_meta_empty", withExtension: "txt")
+        metadataFileMissingName = loadClassifierFile(name: "training_meta_missing_name", withExtension: "txt")
+        trainingFile = loadClassifierFile(name: "weather_data_train", withExtension: "csv")
+        guard metadataFile != nil, metadataFileEmpty != nil, metadataFileMissingName != nil, trainingFile != nil else {
+            XCTFail("Failed to load files required to create a classifier.")
+            return
+        }
+    }
 
+    /** Load a file used when creating a classifier. */
+    func loadClassifierFile(name: String, withExtension: String) -> URL? {
         #if os(iOS)
             let bundle = Bundle(for: type(of: self))
-            guard let url = bundle.url(forResource: name, withExtension: withExtension) else {
-                return nil
-            }
+            guard let url = bundle.url(forResource: name, withExtension: withExtension) else { return nil }
         #else
-            let url = URL(fileURLWithPath: "Tests/NaturalLanguageClassifierV1Tests/"+name+"."+withExtension)
+            let url = URL(fileURLWithPath: "Tests/NaturalLanguageClassifierV1Tests/" + name + "." + withExtension)
         #endif
-
         return url
-    }
-
-    /** Create a classifier. */
-    func createClassifier(trainingMetaFileName: String, trainingDataFileName: String) -> NaturalLanguageClassifierV1.ClassifierDetails? {
-        let description = "Create a classifier."
-        let expectation = self.expectation(description: description)
-        var classifierDetails: NaturalLanguageClassifierV1.ClassifierDetails?
-
-        guard let trainingMetadataURL = loadClassifierFile(withName: trainingMetaFileName, withExtension: "txt"),
-            let trainingDataURL = loadClassifierFile(withName: trainingDataFileName, withExtension: "csv") else {
-                XCTFail("Failed to load files needed to create a classifier")
-                return nil
-        }
-
-        naturalLanguageClassifier.createClassifier(fromMetadataFile: trainingMetadataURL,
-                                                   andTrainingFile: trainingDataURL,
-                                                   failure: failWithError) { details in
-            classifierDetails = details
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 30)
-        return classifierDetails
-    }
-
-    /** Delete the classifier created during testing. */
-    func deleteClassifier(withID classifierId: String) {
-        let description = "Delete the classifier created during testing."
-        let expectation = self.expectation(description: description)
-
-        naturalLanguageClassifier.deleteClassifier(withID: classifierId, failure: failWithError) {
-            expectation.fulfill()
-        }
-        waitForExpectations()
-    }
-
-    /** Get all classifiers. */
-    func getAllClassifiers() -> [NaturalLanguageClassifierV1.ClassifierModel]? {
-        let description = "Get all classifiers."
-        let expectation = self.expectation(description: description)
-        var classifiersList: [NaturalLanguageClassifierV1.ClassifierModel]?
-
-        naturalLanguageClassifier.getClassifiers(failure: failWithError) { classifiers in
-            classifiersList = classifiers
-            expectation.fulfill()
-        }
-        waitForExpectations()
-        return classifiersList
-    }
-
-    /** Get information about a classifier. */
-    func getClassifier(withID classifierId: String) -> NaturalLanguageClassifierV1.ClassifierDetails? {
-        let description = "Get information about the classifier."
-        let expectation = self.expectation(description: description)
-        var classifierDetails: NaturalLanguageClassifierV1.ClassifierDetails?
-
-        naturalLanguageClassifier.getClassifier(withID: classifierId, failure: failWithError) { details in
-            classifierDetails = details
-            expectation.fulfill()
-        }
-        waitForExpectations()
-        return classifierDetails
-    }
-
-    /** Attempt to get the trained classifier; if it doesn't exist, created one. */
-    func lookupTrainedClassifier(classifierId: String) {
-        let description = "Ensure the given trained classifier is available."
-        let expectation = self.expectation(description: description)
-
-        func createTrainedClassifier() {
-            guard let trainingMetadataURL = loadClassifierFile(withName: "trained_meta", withExtension: "txt"),
-                let trainingDataURL = loadClassifierFile(withName: "weather_data_train", withExtension: "csv") else {
-                    XCTFail("Failed to load files needed to create a classifier")
-                    return
-            }
-            let failToCreate =  { (error: Error) in
-                XCTFail("Failed to create the trained classifier.")
-            }
-            naturalLanguageClassifier.createClassifier(fromMetadataFile: trainingMetadataURL,
-                                                       andTrainingFile: trainingDataURL,
-                                                       failure: failToCreate) { classifier in
-                XCTAssertNotNil(classifier)
-                XCTAssertNotEqual("", classifier.classifierId, "Expected to get an id")
-                let message = "A trained classifier was not found. It has been created and " +
-                    "is currently being trained. You will need to set the " +
-                    "trainedClassifierID property using the classifier id " +
-                    "printed below. Then wait a few minutes for training to " +
-                "complete before running the tests again.\n"
-                print(message)
-                print("** trainedClassifierID: \(classifier.classifierId)\n")
-                XCTFail("Trained classifier not found. Set trainedClassifierID and try again.")
-            }
-        }
-
-        let failure = { (error: Error) in
-            createTrainedClassifier()
-            expectation.fulfill()
-        }
-
-        naturalLanguageClassifier.getClassifier(withID: classifierId, failure: failure) { classifier in
-            if classifier.name != "Trained Classifier" {
-                let message = "The wrong classifier was provided as a trained " +
-                "classifier. The trained classifier will be recreated."
-                print(message)
-                createTrainedClassifier()
-                return
-            }
-            if classifier.status != NaturalLanguageClassifierV1.ClassifierStatus.available {
-                XCTFail("Please wait. The given classifier is still being trained.")
-                return
-            }
-            expectation.fulfill()
-        }
-
-        waitForExpectations()
     }
 
     // MARK: - Positive Tests
 
-    /** Test successfuly creating a classifier */
     func testCreateAndDelete() {
-
-        guard let classifier = createClassifier(trainingMetaFileName: "training_meta",
-                                                trainingDataFileName: "weather_data_train") else {
-            XCTFail("Failed to create a new classifier.")
-            return
+        let expectation = self.expectation(description: "Create and delete a classifier")
+        naturalLanguageClassifier.createClassifier(fromMetadataFile: metadataFile, andTrainingFile: trainingFile, failure: failWithError) {
+            classifier in
+            XCTAssertEqual(classifier.name, self.temporaryClassifierName)
+            XCTAssertEqual(classifier.language, "en")
+            self.naturalLanguageClassifier.deleteClassifier(withID: classifier.classifierId, failure: self.failWithError) {
+                expectation.fulfill()
+            }
         }
-
-        XCTAssertEqual(classifier.name, newClassifierName, "Expected created classifier to be named \(newClassifierName)")
-        XCTAssertEqual(classifier.language, "en", "Expected created classifier language to be English.")
-
-        deleteClassifier(withID: classifier.classifierId)
+        waitForExpectations()
     }
 
-    /** Test that creating a classifier without providing a name is successful */
     func testCreateAndDeleteClassifierWithoutOptionalName() {
-
-        guard let classifier = createClassifier(trainingMetaFileName: "training_meta_missing_name",
-                                                trainingDataFileName: "weather_data_train") else {
-            XCTFail("Failed to create a new classifier.")
-            return
+        let expectation = self.expectation(description: "Create and delete a classifier with no name.")
+        naturalLanguageClassifier.createClassifier(fromMetadataFile: metadataFileMissingName, andTrainingFile: trainingFile, failure: failWithError) {
+            classifier in
+            XCTAssertEqual(classifier.name, nil)
+            XCTAssertEqual(classifier.language, "en")
+            self.naturalLanguageClassifier.deleteClassifier(withID: classifier.classifierId, failure: self.failWithError) {
+                expectation.fulfill()
+            }
         }
-
-        XCTAssertEqual(classifier.name, nil, "Expected classifier name to be nil.")
-        XCTAssertEqual(classifier.language, "en", "Expected created classifier language to be English.")
-
-        deleteClassifier(withID: classifier.classifierId)
+        waitForExpectations()
     }
 
-    /** List all classifiers associated with this service instance */
     func testGetAllClassifiers() {
-
-        guard let classifier = createClassifier(trainingMetaFileName: "training_meta",
-                                                trainingDataFileName: "weather_data_train") else {
-            XCTFail("Failed to create a new classifier.")
-            return
+        let expectation = self.expectation(description: "Get classifiers.")
+        naturalLanguageClassifier.getClassifiers(failure: failWithError) { classifiers in
+            XCTAssertGreaterThan(classifiers.count, 0)
+            expectation.fulfill()
         }
-
-        guard let classifiers = getAllClassifiers() else {
-            XCTFail("Failed to list all classifiers.")
-            return
-        }
-
-        XCTAssertGreaterThanOrEqual(classifiers.count, 2, "Expected there to be at least 2 classifiers.")
-
-        deleteClassifier(withID: classifier.classifierId)
+        waitForExpectations()
     }
 
-    /** Test getting the classifier that was created for this test. */
     func testGetClassifier() {
-
-        guard let classifier = createClassifier(trainingMetaFileName: "training_meta",
-                                                trainingDataFileName: "weather_data_train") else {
-            XCTFail("Failed to create a new classifier.")
-            return
+        let expectation = self.expectation(description: "Get classifier.")
+        naturalLanguageClassifier.getClassifier(withID: trainedClassifierId, failure: failWithError) { classifier in
+            XCTAssertEqual(classifier.name, self.trainedClassifierName)
+            expectation.fulfill()
         }
-
-        guard let classifierDetails = getClassifier(withID: classifier.classifierId) else {
-            XCTFail("Failed to get the newly created classifier.")
-            return
-        }
-
-        XCTAssertEqual(classifierDetails.name, newClassifierName, "Expected the classifier we got to have the correct name.")
-        XCTAssertEqual(classifierDetails.url, classifier.url, "The classifier we got back should have the expected URL.")
-
-        deleteClassifier(withID: classifier.classifierId)
+        waitForExpectations()
     }
 
-    /** Classify the given text using a trained classifier. */
     func testClassify() {
-        lookupTrainedClassifier(classifierId: trainedClassifierId)
-
-        let expectation = self.expectation(description: "Classify text using the test classifier.")
-        naturalLanguageClassifier.classify("How hot will it be today?",
-                                           withClassifierID: trainedClassifierId,
-                                           failure: failWithError) {
+        let expectation = self.expectation(description: "Classify text.")
+        naturalLanguageClassifier.classify("How hot will it be today?", withClassifierID: trainedClassifierId, failure: failWithError) {
             classification in
-            XCTAssertEqual(classification.topClass, "temperature", "Expected the top class returned to be temperature.")
-            XCTAssertEqual(classification.classes.count, 2, "Expected there to be two classes returned.")
+            XCTAssertEqual(classification.topClass, "temperature")
+            XCTAssertEqual(classification.classes.count, 2)
             expectation.fulfill()
         }
         waitForExpectations(timeout: 20)
@@ -301,86 +174,55 @@ class NaturalLanguageClassifierTests: XCTestCase {
 
     // MARK: - Negative Tests
 
-    /** Create a classifier with missing metadata. */
     func testCreateClassifierWithMissingMetadata() {
-        let description = "Create a classifier with a file that is missing metadata."
-        let expectation = self.expectation(description: description)
-
-        let failure = { (error: Error) in
-            expectation.fulfill()
-        }
-
-        guard let trainingMetadataURL = loadClassifierFile(withName: "training_meta_empty", withExtension: "txt"),
-            let trainingDataURL = loadClassifierFile(withName: "weather_data_train", withExtension: "csv") else {
-                XCTFail("Failed to load files needed to create a classifier")
-                return
-        }
-
-        naturalLanguageClassifier.createClassifier(fromMetadataFile: trainingMetadataURL,
-                                                   andTrainingFile: trainingDataURL,
-                                                   failure: failure, success: failWithResult)
-
+        let expectation = self.expectation(description: "Create a classifier with missing metadata")
+        let failure = { (error: Error) in expectation.fulfill() }
+        naturalLanguageClassifier.createClassifier(
+            fromMetadataFile: metadataFileEmpty,
+            andTrainingFile: trainingFile,
+            failure: failure,
+            success: failWithResult)
         waitForExpectations()
     }
 
-    /** Attempt to classify an empty string. */
     func testClassifyEmptyString() {
-        let description = "Attempt to classify an empty string."
-        let expectation = self.expectation(description: description)
-
-        let failure = { (error: Error) in
-            expectation.fulfill()
-        }
-
-        naturalLanguageClassifier.classify("", withClassifierID: trainedClassifierId,
-                                           failure: failure, success: failWithResult)
-
+        let expectation = self.expectation(description: "Classify and empty string.")
+        let failure = { (error: Error) in expectation.fulfill() }
+        naturalLanguageClassifier.classify("", withClassifierID: trainedClassifierId, failure: failure, success: failWithResult)
         waitForExpectations()
     }
 
-    /** Attempt to classify a string by using a classifier that doesn't exist. */
     func testClassifyWithInvalidClassifier() {
-        let description = "Attempt to classify a string by using a classifier that doesn't exist."
-        let expectation = self.expectation(description: description)
-
-        let failure = { (error: Error) in
-            expectation.fulfill()
-        }
-
-        naturalLanguageClassifier.classify("How hot will it be today?",
-                                           withClassifierID: "InvalidClassifierID",
-                                           failure: failure, success: failWithResult)
-
+        let expectation = self.expectation(description: "Classify using an invalid classifier id.")
+        let failure = { (error: Error) in expectation.fulfill() }
+        naturalLanguageClassifier.classify(
+            "How hot will it be today?",
+            withClassifierID: "this-is-an-invalid-classifier-id",
+            failure: failure,
+            success: failWithResult
+        )
         waitForExpectations()
     }
 
-    /** Attempt to delete a classifier that doesn't exist. */
     func testDeleteInvalidClassifier() {
-        let description = "Attempt to delete a classifier that doesn't exist."
-        let expectation = self.expectation(description: description)
-
-        let failure = { (error: Error) in
-            expectation.fulfill()
-        }
-
-        naturalLanguageClassifier.deleteClassifier(withID: "InvalidClassifierID", failure: failure,
-                                                   success: failWithResult)
-
+        let expectation = self.expectation(description: "Delete a classifier using an invalid classifier id.")
+        let failure = { (error: Error) in expectation.fulfill() }
+        naturalLanguageClassifier.deleteClassifier(
+            withID: "this-is-an-invalid-classifier-id",
+            failure: failure,
+            success: failWithResult
+        )
         waitForExpectations()
     }
 
-    /** Try to get information about a classifier that doesn't exist. */
     func testGetInvalidClassifier() {
-        let description = "Attempt to get information about a classifier that doesn't exist."
-        let expectation = self.expectation(description: description)
-
-        let failure = { (error: Error) in
-            expectation.fulfill()
-        }
-
-        naturalLanguageClassifier.getClassifier(withID: "InvalidClassifierID", failure: failure,
-                                                success: failWithResult)
-
+        let expectation = self.expectation(description: "Get classifier using an invalid classifier id.")
+        let failure = { (error: Error) in expectation.fulfill() }
+        naturalLanguageClassifier.getClassifier(
+            withID: "this-is-an-invalid-classifier-id",
+            failure: failure,
+            success: failWithResult
+        )
         waitForExpectations()
     }
 }

--- a/Tests/NaturalLanguageClassifierV1Tests/trained_meta.txt
+++ b/Tests/NaturalLanguageClassifierV1Tests/trained_meta.txt
@@ -1,1 +1,4 @@
-{"language":"en","name":"Trained Classifier"}
+{
+    "language": "en",
+    "name": "swift-sdk-test-classifier"
+}

--- a/Tests/NaturalLanguageClassifierV1Tests/training_meta.txt
+++ b/Tests/NaturalLanguageClassifierV1Tests/training_meta.txt
@@ -1,1 +1,4 @@
-{"language":"en","name":"Swift SDK Test Classifier"}
+{
+    "language": "en",
+    "name": "swift-sdk-temporary-classifier"
+}


### PR DESCRIPTION
This pull request updates the Natural Language Classifier tests to make them easier to read and easier to maintain.

In particular, they no longer try to create and train a classifier when the trained classifier cannot be found. This was causing each test to try creating a classifier. After a couple of executions, the NLC environment would be full and prevent any new classifiers from being created.

The tests are also simpler to read with the removal of obfuscating helper functions. Instead of calling helper functions, the tests now call SDK methods directly.