### PR TITLE
Use NSLocalizedDescriptionKey

### DIFF
--- a/Source/AlchemyDataNewsV1/AlchemyDataNews.swift
+++ b/Source/AlchemyDataNewsV1/AlchemyDataNews.swift
@@ -71,8 +71,8 @@ public class AlchemyDataNews {
             let status = try json.getString(at: "status")
             let statusInfo = try json.getString(at: "statusInfo")
             let userInfo = [
-                NSLocalizedFailureReasonErrorKey: status,
-                NSLocalizedDescriptionKey: statusInfo
+                NSLocalizedDescriptionKey: status,
+                NSLocalizedRecoverySuggestionErrorKey: statusInfo
             ]
             return NSError(domain: errorDomain, code: code, userInfo: userInfo)
         } catch {

--- a/Source/AlchemyLanguageV1/AlchemyLanguage.swift
+++ b/Source/AlchemyLanguageV1/AlchemyLanguage.swift
@@ -81,8 +81,8 @@ public class AlchemyLanguage {
             let status = try json.getString(at: "status")
             let statusInfo = try json.getString(at: "statusInfo")
             let userInfo = [
-                NSLocalizedFailureReasonErrorKey: status,
-                NSLocalizedDescriptionKey: statusInfo
+                NSLocalizedDescriptionKey: status,
+                NSLocalizedRecoverySuggestionErrorKey: statusInfo
             ]
             return NSError(domain: errorDomain, code: code, userInfo: userInfo)
         } catch {
@@ -95,7 +95,7 @@ public class AlchemyLanguage {
         guard let docAsString = try String(contentsOfFile: document.relativePath, encoding:.utf8)
             .addingPercentEncoding(withAllowedCharacters: unreservedCharacters) else {
                 let failureReason = "Profile could not be escaped."
-                let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                let userInfo = [NSLocalizedDescriptionKey: failureReason]
                 let error = NSError(domain: errorDomain, code: 0, userInfo: userInfo)
                 throw error
         }
@@ -108,7 +108,7 @@ public class AlchemyLanguage {
         }
         guard let body = "\(type)=\(docAsString)".data(using: String.Encoding.utf8) else {
             let failureReason = "Profile could not be encoded."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: errorDomain, code: 0, userInfo: userInfo)
             throw error
         }

--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -199,7 +199,7 @@ public class AlchemyVision {
     {
         guard let html = try? String(contentsOf: html) else {
             let failureReason = "Failed to read the HTML file."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -224,7 +224,7 @@ public class AlchemyVision {
         // encode html document
         guard let htmlEncoded = html.addingPercentEncoding(withAllowedCharacters: unreservedCharacters) else {
             let failureReason = "Failed to percent encode HTML document."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -233,7 +233,7 @@ public class AlchemyVision {
         // construct body
         guard let body = "html=\(htmlEncoded)".data(using: String.Encoding.utf8) else {
             let failureReason = "Failed to construct body with HTML document."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/DialogV1/Dialog.swift
+++ b/Source/DialogV1/Dialog.swift
@@ -79,7 +79,7 @@ public class Dialog {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            let userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            let userInfo = [NSLocalizedDescriptionKey: message]
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return nil
@@ -249,7 +249,7 @@ public class Dialog {
         let directories = fileManager.urls(for: .downloadsDirectory, in: .userDomainMask)
         guard let downloads = directories.first else {
             let failureReason = "Cannot locate documents directory."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -282,7 +282,7 @@ public class Dialog {
 
             guard let statusCode = response?.statusCode else {
                 let failureReason = "Did not receive response."
-                let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                let userInfo = [NSLocalizedDescriptionKey: failureReason]
                 let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
                 failure?(error)
                 return
@@ -290,7 +290,7 @@ public class Dialog {
 
             if statusCode != 200 {
                 let failureReason = "Status code was not acceptable: \(statusCode)."
-                let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                let userInfo = [NSLocalizedDescriptionKey: failureReason]
                 let error = NSError(domain: self.domain, code: statusCode, userInfo: userInfo)
                 failure?(error)
                 return
@@ -406,7 +406,7 @@ public class Dialog {
         let json = JSONWrapper(dictionary: ["items": nodes.map { $0.toJSONObject() }])
         guard let body = try? json.serialize() else {
             let failureReason = "Nodes could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -619,7 +619,7 @@ public class Dialog {
         let profile = Profile(clientID: clientID, parameters: parameters)
         guard let body = try? profile.toJSON().serialize() else {
             let failureReason = "Profile could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -1256,7 +1256,7 @@ public class Discovery {
     }
 
     private func failWithError(reason: String) -> NSError {
-        let userInfo = [NSLocalizedFailureReasonErrorKey: reason]
+        let userInfo = [NSLocalizedDescriptionKey: reason]
         let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
         return error
     }

--- a/Source/DocumentConversionV1/DocumentConversion.swift
+++ b/Source/DocumentConversionV1/DocumentConversion.swift
@@ -74,7 +74,7 @@ public class DocumentConversion {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            var userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            var userInfo = [NSLocalizedDescriptionKey: message]
             if let description = try? json.getString(at: "description") {
                 userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
             }
@@ -182,7 +182,7 @@ public class DocumentConversion {
             try data.write(to: fileURL, options: .atomic)
         } catch {
             let message = "Unable to create config file"
-            let userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            let userInfo = [NSLocalizedDescriptionKey: message]
             throw NSError(domain: domain, code: 0, userInfo: userInfo)
         }
 

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -71,13 +71,13 @@ public class LanguageTranslator {
             let code = response?.statusCode ?? 400
             let userInfo: [String: String]
             if let message = try? json.getString(at: "error_message") {
-                userInfo = [NSLocalizedFailureReasonErrorKey: message]
+                userInfo = [NSLocalizedDescriptionKey: message]
                 return NSError(domain: domain, code: code, userInfo: userInfo)
             } else {
                 let message = try json.getString(at: "error")
                 let description = try json.getString(at: "description")
                 userInfo = [
-                    NSLocalizedFailureReasonErrorKey: message,
+                    NSLocalizedDescriptionKey: message,
                     NSLocalizedRecoverySuggestionErrorKey: description,
                 ]
             }
@@ -368,7 +368,7 @@ public class LanguageTranslator {
         // serialize translate request to JSON
         guard let body = try? translateRequest.toJSON().serialize() else {
             let failureReason = "Translation request could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -441,7 +441,7 @@ public class LanguageTranslator {
         // convert text to NSData with UTF-8 encoding
         guard let body = text.data(using: String.Encoding.utf8) else {
             let failureReason = "Text could not be encoded to NSData with NSUTF8StringEncoding."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/PersonalityInsightsV2/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV2/PersonalityInsights.swift
@@ -70,7 +70,7 @@ public class PersonalityInsights {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            var userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            var userInfo = [NSLocalizedDescriptionKey: message]
             let help = try? json.getString(at: "help")
             let description = try? json.getString(at: "description")
             if let recoverySuggestion = help ?? description {
@@ -104,7 +104,7 @@ public class PersonalityInsights {
     {
         guard let content = text.data(using: String.Encoding.utf8) else {
             let failureReason = "Text could not be encoded to NSData with NSUTF8StringEncoding."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -144,7 +144,7 @@ public class PersonalityInsights {
     {
         guard let content = html.data(using: String.Encoding.utf8) else {
             let failureReason = "HTML could not be encoded to NSData with NSUTF8StringEncoding."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -184,7 +184,7 @@ public class PersonalityInsights {
         let json = JSONWrapper(dictionary: ["contentItems": contentItems.map { $0.toJSONObject() }])
         guard let content = try? json.serialize() else {
             let failureReason = "Content items could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -74,7 +74,7 @@ public class PersonalityInsights {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            var userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            var userInfo = [NSLocalizedDescriptionKey: message]
             let help = try? json.getString(at: "help")
             let description = try? json.getString(at: "description")
             if let recoverySuggestion = help ?? description {
@@ -111,7 +111,7 @@ public class PersonalityInsights {
     {
         guard let content = text.data(using: String.Encoding.utf8) else {
             let failureReason = "Text could not be encoded to NSData with NSUTF8StringEncoding."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -155,7 +155,7 @@ public class PersonalityInsights {
     {
         guard let content = html.data(using: String.Encoding.utf8) else {
             let failureReason = "HTML could not be encoded to NSData with NSUTF8StringEncoding."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -199,7 +199,7 @@ public class PersonalityInsights {
         let json = JSONWrapper(dictionary: ["contentItems": contentItems.map { $0.toJSONObject() }])
         guard let content = try? json.serialize() else {
             let failureReason = "Content items could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/RelationshipExtractionV1Beta/RelationshipExtraction.swift
+++ b/Source/RelationshipExtractionV1Beta/RelationshipExtraction.swift
@@ -75,7 +75,7 @@ public class RelationshipExtraction {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            let userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            let userInfo = [NSLocalizedDescriptionKey: message]
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return nil

--- a/Source/RetrieveAndRankV1/RetrieveAndRank.swift
+++ b/Source/RetrieveAndRankV1/RetrieveAndRank.swift
@@ -71,12 +71,12 @@ public class RetrieveAndRank {
             let code = response?.statusCode ?? 400
             let userInfo: [String: String]
             if let message = try? json.getString(at: "msg") {
-                userInfo = [NSLocalizedFailureReasonErrorKey: message]
+                userInfo = [NSLocalizedDescriptionKey: message]
             } else {
                 let message = try json.getString(at: "error")
                 let description = try json.getString(at: "description")
                 userInfo = [
-                    NSLocalizedFailureReasonErrorKey: message,
+                    NSLocalizedDescriptionKey: message,
                     NSLocalizedRecoverySuggestionErrorKey: description,
                 ]
             }
@@ -141,7 +141,7 @@ public class RetrieveAndRank {
 
         guard let body = try? JSONWrapper(dictionary: json).serialize() else {
             let failureReason = "Classification text could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -328,7 +328,7 @@ public class RetrieveAndRank {
         let directories = fileManager.urls(for: .downloadsDirectory, in: .userDomainMask)
         guard let downloads = directories.first else {
             let failureReason = "Cannot locate documents directory."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -360,7 +360,7 @@ public class RetrieveAndRank {
 
             guard let statusCode = response?.statusCode else {
                 let failureReason = "Did not receive response."
-                let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                let userInfo = [NSLocalizedDescriptionKey: failureReason]
                 let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
                 failure?(error)
                 return
@@ -368,7 +368,7 @@ public class RetrieveAndRank {
 
             if statusCode != 200 {
                 let failureReason = "Status code was not acceptable: \(statusCode)."
-                let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                let userInfo = [NSLocalizedDescriptionKey: failureReason]
                 let error = NSError(domain: self.domain, code: statusCode, userInfo: userInfo)
                 failure?(error)
                 return
@@ -775,7 +775,7 @@ public class RetrieveAndRank {
         }
         guard let trainingMetadata = try? JSONWrapper(dictionary: json).serialize() else {
             let failureReason = "Ranker metadata could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -61,7 +61,7 @@ extension SpeechToText {
             )
         } catch {
             let failureReason = "Could not load audio data from \(audio)."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -163,7 +163,7 @@ extension SpeechToText {
             try audioSession.setActive(true)
         } catch {
             let failureReason = "Failed to setup the AVAudioSession sharedInstance properly."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -86,7 +86,7 @@ public class SpeechToText {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            var userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            var userInfo = [NSLocalizedDescriptionKey: message]
             let codeDescription = try? json.getString(at: "code_description")
             let description = try? json.getString(at: "description")
             if let recoverySuggestion = codeDescription ?? description {

--- a/Source/SpeechToTextV1/SpeechToTextSession.swift
+++ b/Source/SpeechToTextV1/SpeechToTextSession.swift
@@ -176,7 +176,7 @@ public class SpeechToTextSession {
             recognize(audio: data)
         } catch {
             let failureReason = "Could not load audio data from \(audio)."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             onError?(error)
             return
@@ -224,7 +224,7 @@ public class SpeechToTextSession {
         recorder.session.requestRecordPermission { granted in
             guard granted else {
                 let failureReason = "Permission was not granted to access the microphone."
-                let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                let userInfo = [NSLocalizedDescriptionKey: failureReason]
                 let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
                 self.onError?(error)
                 return
@@ -262,7 +262,7 @@ public class SpeechToTextSession {
                 try self.recorder.startRecording()
             } catch {
                 let failureReason = "Failed to start recording."
-                let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                let userInfo = [NSLocalizedDescriptionKey: failureReason]
                 let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
                 self.onError?(error)
                 return
@@ -278,7 +278,7 @@ public class SpeechToTextSession {
             try recorder.stopRecording()
         } catch {
             let failureReason = "Failed to stop recording."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
             self.onError?(error)
             return

--- a/Source/SpeechToTextV1/SpeechToTextSocket.swift
+++ b/Source/SpeechToTextV1/SpeechToTextSocket.swift
@@ -72,7 +72,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
         // restrict the number of retries
         guard tokenRefreshes <= maxTokenRefreshes else {
             let failureReason = "Invalid HTTP upgrade. Check credentials?"
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: "WebSocket", code: 400, userInfo: userInfo)
             onError?(error)
             return

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -71,7 +71,7 @@ public class TextToSpeech {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            var userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            var userInfo = [NSLocalizedDescriptionKey: message]
             let codeDescription = try? json.getString(at: "code_description")
             let description = try? json.getString(at: "description")
             if let recoverySuggestion = codeDescription ?? description {
@@ -265,7 +265,7 @@ public class TextToSpeech {
                         var wav = data
                         guard TextToSpeech.isWAVFile(data: wav) else {
                             let failureReason = "Returned audio is in an unexpected format."
-                            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                            let userInfo = [NSLocalizedDescriptionKey: failureReason]
                             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
                             failure?(error)
                             return
@@ -278,7 +278,7 @@ public class TextToSpeech {
                             success(decodedAudio.pcmDataWithHeaders)
                         } catch {
                             let failureReason = "Returned audio is in an unexpected format."
-                            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                            let userInfo = [NSLocalizedDescriptionKey: failureReason]
                             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
                             failure?(error)
                             return
@@ -364,7 +364,7 @@ public class TextToSpeech {
 
         guard let body = try? JSONWrapper(dictionary: dict).serialize() else {
             let failureReason = "Custom voice model metadata could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -482,7 +482,7 @@ public class TextToSpeech {
         let customVoiceUpdate = CustomVoiceUpdate(name: name, description: description, words: words)
         guard let body = try? customVoiceUpdate.toJSON().serialize() else {
             let failureReason = "Translation request could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -563,7 +563,7 @@ public class TextToSpeech {
         let customVoiceUpdate = CustomVoiceUpdate(words: words)
         guard let body = try? customVoiceUpdate.toJSON().serialize() else {
             let failureReason = "Translation request could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -682,7 +682,7 @@ public class TextToSpeech {
         let dict = ["translation": translation]
         guard let body = try? JSONWrapper(dictionary: dict).serialize() else {
             let failureReason = "Translation request could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -74,7 +74,7 @@ public class ToneAnalyzer {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            var userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            var userInfo = [NSLocalizedDescriptionKey: message]
             let help = try? json.getString(at: "help")
             let description = try? json.getString(at: "description")
             if let recoverySuggestion = help ?? description {
@@ -109,7 +109,7 @@ public class ToneAnalyzer {
         // construct body
         guard let body = try? JSONWrapper(dictionary: ["text": text]).serialize() else {
             let failureReason = "Classification text could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/TradeoffAnalyticsV1/TradeoffAnalytics.swift
+++ b/Source/TradeoffAnalyticsV1/TradeoffAnalytics.swift
@@ -71,7 +71,7 @@ public class TradeoffAnalytics {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            var userInfo = [NSLocalizedFailureReasonErrorKey: message]
+            var userInfo = [NSLocalizedDescriptionKey: message]
             if let description = try? json.getString(at: "description") {
                 userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
             }
@@ -104,7 +104,7 @@ public class TradeoffAnalytics {
         // construct body
         guard let body = try? problem.toJSON().serialize() else {
             let failureReason = "Problem could not be serialized to JSON."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -75,8 +75,8 @@ public class VisualRecognition {
             if let status = try? json.getString(at: "status") {
                 let statusInfo = try json.getString(at: "statusInfo")
                 userInfo = [
-                    NSLocalizedFailureReasonErrorKey: status,
-                    NSLocalizedDescriptionKey: statusInfo,
+                    NSLocalizedDescriptionKey: status,
+                    NSLocalizedRecoverySuggestionErrorKey: statusInfo,
                 ]
             } else if let message = try? json.getString(at: "error") {
                 userInfo = [
@@ -88,8 +88,8 @@ public class VisualRecognition {
                 let imagesProcessed = try json.getInt(at: "images_processed")
                 code = 400
                 userInfo = [
-                    NSLocalizedFailureReasonErrorKey: message,
-                    NSLocalizedDescriptionKey: description + " -- Images Processed: \(imagesProcessed)",
+                    NSLocalizedDescriptionKey: message,
+                    NSLocalizedRecoverySuggestionErrorKey: description + " -- Images Processed: \(imagesProcessed)",
                 ]
             }
             return NSError(domain: domain, code: code, userInfo: userInfo)
@@ -414,7 +414,7 @@ public class VisualRecognition {
             let failureReason = "You must supply at least two compressed (.zip) files of images, " +
                                 "either two positive example files or one positive and one " +
                                 "negative example file."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
@@ -569,7 +569,7 @@ public class VisualRecognition {
         guard (positiveExamples != nil) || (negativeExamples != nil) else {
             let failureReason = "To update a classifier, you must provide at least one " +
                                 "compressed file of either positive or negative examples."
-            let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+            let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
             failure?(error)
             return


### PR DESCRIPTION
When constructing an `NSError` object, we have commonly used `NSLocalizedFailureReasonErrorKey`. However, this key is not supported well on Linux—the `error.localizedDescription` property on Linux does not check for the failure reason error key.

This pull request replaces instances of `NSLocalizedFailureReasonErrorKey` with `NSLocalizedDescriptionErrorKey`.