### PR TITLE
Generate Tone Analyzer

### DIFF
--- a/Source/ToneAnalyzerV3/Models/DocumentAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/DocumentAnalysis.swift
@@ -1,0 +1,70 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/** DocumentAnalysis. */
+public struct DocumentAnalysis {
+
+    /// **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the document. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
+    public var tones: [ToneScore]?
+
+    /// **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the full document of the input content. The service returns results only for the tones specified with the `tones` parameter of the request.
+    public var toneCategories: [ToneCategory]?
+
+    /// **`2017-09-21`:** A warning message if the overall content exceeds 128 KB or contains more than 1000 sentences. The service analyzes only the first 1000 sentences for document-level analysis and the first 100 sentences for sentence-level analysis. **`2016-05-19`:** Not returned.
+    public var warning: String?
+
+    /**
+     Initialize a `DocumentAnalysis` with member variables.
+
+     - parameter tones: **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the document. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
+     - parameter toneCategories: **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the full document of the input content. The service returns results only for the tones specified with the `tones` parameter of the request.
+     - parameter warning: **`2017-09-21`:** A warning message if the overall content exceeds 128 KB or contains more than 1000 sentences. The service analyzes only the first 1000 sentences for document-level analysis and the first 100 sentences for sentence-level analysis. **`2016-05-19`:** Not returned.
+
+     - returns: An initialized `DocumentAnalysis`.
+    */
+    public init(tones: [ToneScore]? = nil, toneCategories: [ToneCategory]? = nil, warning: String? = nil) {
+        self.tones = tones
+        self.toneCategories = toneCategories
+        self.warning = warning
+    }
+}
+
+extension DocumentAnalysis: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case tones = "tones"
+        case toneCategories = "tone_categories"
+        case warning = "warning"
+        static let allValues = [tones, toneCategories, warning]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        tones = try container.decodeIfPresent([ToneScore].self, forKey: .tones)
+        toneCategories = try container.decodeIfPresent([ToneCategory].self, forKey: .toneCategories)
+        warning = try container.decodeIfPresent(String.self, forKey: .warning)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(tones, forKey: .tones)
+        try container.encodeIfPresent(toneCategories, forKey: .toneCategories)
+        try container.encodeIfPresent(warning, forKey: .warning)
+    }
+
+}

--- a/Source/ToneAnalyzerV3/Models/SentenceAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/SentenceAnalysis.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,32 +16,79 @@
 
 import Foundation
 
-/** The result of analyzing a sentence within a document. */
-public struct SentenceAnalysis: JSONDecodable {
+/** SentenceAnalysis. */
+public struct SentenceAnalysis {
 
-    /// A unique number identifying this sentence within the document.
-    public let sentenceID: Int
+    /// The unique identifier of a sentence of the input content. The first sentence has ID 0, and the ID of each subsequent sentence is incremented by one.
+    public var sentenceID: Int
 
-    /// The index of the character in the document where this sentence starts.
-    public let inputFrom: Int
+    /// The text of the input sentence.
+    public var text: String
 
-    /// The index of the character in the document after the end of this sentence
-    /// (i.e. `inputTo - inputFrom` is the length of the sentence in characters).
-    public let inputTo: Int
+    /// **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the sentence. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
+    public var tones: [ToneScore]?
 
-    /// The text of this sentence.
-    public let text: String
+    /// **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the sentence. The service returns results only for the tones specified with the `tones` parameter of the request.
+    public var toneCategories: [ToneCategory]?
 
-    /// The tone analysis results for this sentence, divided into
-    /// three categories: social tone, emotion tone, and writing tone.
-    public let toneCategories: [ToneCategory]
+    /// **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the first character of the sentence in the overall input content.
+    public var inputFrom: Int?
 
-    /// Used internally to initialize a `SentenceAnalysis` model from JSON.
-    public init(json: JSONWrapper) throws {
-        sentenceID = try json.getInt(at: "sentence_id")
-        inputFrom = try json.getInt(at: "input_from")
-        inputTo = try json.getInt(at: "input_to")
-        text = try json.getString(at: "text")
-        toneCategories = try json.decodedArray(at: "tone_categories", type: ToneCategory.self)
+    /// **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the last character of the sentence in the overall input content.
+    public var inputTo: Int?
+
+    /**
+     Initialize a `SentenceAnalysis` with member variables.
+
+     - parameter sentenceID: The unique identifier of a sentence of the input content. The first sentence has ID 0, and the ID of each subsequent sentence is incremented by one.
+     - parameter text: The text of the input sentence.
+     - parameter tones: **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the sentence. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
+     - parameter toneCategories: **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the sentence. The service returns results only for the tones specified with the `tones` parameter of the request.
+     - parameter inputFrom: **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the first character of the sentence in the overall input content.
+     - parameter inputTo: **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the last character of the sentence in the overall input content.
+
+     - returns: An initialized `SentenceAnalysis`.
+    */
+    public init(sentenceID: Int, text: String, tones: [ToneScore]? = nil, toneCategories: [ToneCategory]? = nil, inputFrom: Int? = nil, inputTo: Int? = nil) {
+        self.sentenceID = sentenceID
+        self.text = text
+        self.tones = tones
+        self.toneCategories = toneCategories
+        self.inputFrom = inputFrom
+        self.inputTo = inputTo
     }
+}
+
+extension SentenceAnalysis: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case sentenceID = "sentence_id"
+        case text = "text"
+        case tones = "tones"
+        case toneCategories = "tone_categories"
+        case inputFrom = "input_from"
+        case inputTo = "input_to"
+        static let allValues = [sentenceID, text, tones, toneCategories, inputFrom, inputTo]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sentenceID = try container.decode(Int.self, forKey: .sentenceID)
+        text = try container.decode(String.self, forKey: .text)
+        tones = try container.decodeIfPresent([ToneScore].self, forKey: .tones)
+        toneCategories = try container.decodeIfPresent([ToneCategory].self, forKey: .toneCategories)
+        inputFrom = try container.decodeIfPresent(Int.self, forKey: .inputFrom)
+        inputTo = try container.decodeIfPresent(Int.self, forKey: .inputTo)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sentenceID, forKey: .sentenceID)
+        try container.encode(text, forKey: .text)
+        try container.encodeIfPresent(tones, forKey: .tones)
+        try container.encodeIfPresent(toneCategories, forKey: .toneCategories)
+        try container.encodeIfPresent(inputFrom, forKey: .inputFrom)
+        try container.encodeIfPresent(inputTo, forKey: .inputTo)
+    }
+
 }

--- a/Source/ToneAnalyzerV3/Models/ToneAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneAnalysis.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,47 @@
 
 import Foundation
 
-/** The results of performing tone analysis on a document. */
-public struct ToneAnalysis: JSONDecodable {
+/** ToneAnalysis. */
+public struct ToneAnalysis {
 
-    /// Tone analysis results of the entire document's text. This includes three
-    /// tone categories: social tone, emotional tone, and language tone.
-    public let documentTone: [ToneCategory]
+    /// An object of type `DocumentAnalysis` that provides the results of the analysis for the full input document.
+    public var documentTone: DocumentAnalysis
 
-    /// Tone analysis results for each sentence contained in the document.
-    public let sentencesTones: [SentenceAnalysis]?
+    /// An array of `SentenceAnalysis` objects that provides the results of the analysis for the individual sentences of the input content. The service returns results only for the first 100 sentences of the input. The field is omitted if the `sentences` parameter of the request is set to `false`.
+    public var sentencesTone: [SentenceAnalysis]?
 
-    /// Used internally to initialize a `ToneAnalysis` model from JSON.
-    public init(json: JSONWrapper) throws {
-        documentTone = try json.decodedArray(at: "document_tone", "tone_categories", type: ToneCategory.self)
-        sentencesTones = try? json.decodedArray(at: "sentences_tone", type: SentenceAnalysis.self)
+    /**
+     Initialize a `ToneAnalysis` with member variables.
 
+     - parameter documentTone: An object of type `DocumentAnalysis` that provides the results of the analysis for the full input document.
+     - parameter sentencesTone: An array of `SentenceAnalysis` objects that provides the results of the analysis for the individual sentences of the input content. The service returns results only for the first 100 sentences of the input. The field is omitted if the `sentences` parameter of the request is set to `false`.
+
+     - returns: An initialized `ToneAnalysis`.
+    */
+    public init(documentTone: DocumentAnalysis, sentencesTone: [SentenceAnalysis]? = nil) {
+        self.documentTone = documentTone
+        self.sentencesTone = sentencesTone
     }
+}
+
+extension ToneAnalysis: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case documentTone = "document_tone"
+        case sentencesTone = "sentences_tone"
+        static let allValues = [documentTone, sentencesTone]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        documentTone = try container.decode(DocumentAnalysis.self, forKey: .documentTone)
+        sentencesTone = try container.decodeIfPresent([SentenceAnalysis].self, forKey: .sentencesTone)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(documentTone, forKey: .documentTone)
+        try container.encodeIfPresent(sentencesTone, forKey: .sentencesTone)
+    }
+
 }

--- a/Source/ToneAnalyzerV3/Models/ToneCategory.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneCategory.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,55 @@
 
 import Foundation
 
-/** The tone analysis for a particular tone category (e.g. social, emotion, or writing). */
-public struct ToneCategory: JSONDecodable {
+/** ToneCategory. */
+public struct ToneCategory {
 
-    /// The name of this tone category (e.g. emotion, social, or language).
-    public let name: String
+    /// An array of `ToneScore` objects that provides the results for the tones of the category.
+    public var tones: [ToneScore]
 
-    /// A unique number identifying this tone category, irrespective of language or localization.
-    public let categoryID: String
+    /// The unique, non-localized identifier of the category for the results. The service can return results for the following category IDs: `emotion_tone`, `language_tone`, and `social_tone`.
+    public var categoryID: String
 
-    /// The individual tone results within this category.
-    public let tones: [ToneScore]
+    /// The user-visible, localized name of the category.
+    public var categoryName: String
 
-    /// Used internally to initialize a `ToneCategory` model from JSON.
-    public init(json: JSONWrapper) throws {
-        name = try json.getString(at: "category_name")
-        categoryID = try json.getString(at: "category_id")
-        tones = try json.decodedArray(at: "tones", type: ToneScore.self)
+    /**
+     Initialize a `ToneCategory` with member variables.
+
+     - parameter tones: An array of `ToneScore` objects that provides the results for the tones of the category.
+     - parameter categoryID: The unique, non-localized identifier of the category for the results. The service can return results for the following category IDs: `emotion_tone`, `language_tone`, and `social_tone`.
+     - parameter categoryName: The user-visible, localized name of the category.
+
+     - returns: An initialized `ToneCategory`.
+    */
+    public init(tones: [ToneScore], categoryID: String, categoryName: String) {
+        self.tones = tones
+        self.categoryID = categoryID
+        self.categoryName = categoryName
     }
+}
+
+extension ToneCategory: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case tones = "tones"
+        case categoryID = "category_id"
+        case categoryName = "category_name"
+        static let allValues = [tones, categoryID, categoryName]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        tones = try container.decode([ToneScore].self, forKey: .tones)
+        categoryID = try container.decode(String.self, forKey: .categoryID)
+        categoryName = try container.decode(String.self, forKey: .categoryName)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(tones, forKey: .tones)
+        try container.encode(categoryID, forKey: .categoryID)
+        try container.encode(categoryName, forKey: .categoryName)
+    }
+
 }

--- a/Source/ToneAnalyzerV3/Models/ToneChatInput.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneChatInput.swift
@@ -1,0 +1,54 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/** ToneChatInput. */
+public struct ToneChatInput {
+
+    /// An array of `Utterance` objects that provides the input content that the service is to analyze.
+    public var utterances: [Utterance]
+
+    /**
+     Initialize a `ToneChatInput` with member variables.
+
+     - parameter utterances: An array of `Utterance` objects that provides the input content that the service is to analyze.
+
+     - returns: An initialized `ToneChatInput`.
+    */
+    public init(utterances: [Utterance]) {
+        self.utterances = utterances
+    }
+}
+
+extension ToneChatInput: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case utterances = "utterances"
+        static let allValues = [utterances]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        utterances = try container.decode([Utterance].self, forKey: .utterances)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(utterances, forKey: .utterances)
+    }
+
+}

--- a/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
@@ -1,0 +1,70 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/** ToneChatScore. */
+public struct ToneChatScore {
+
+    /// The score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the utterance.
+    public var score: Double
+
+    /// The unique, non-localized identifier of the tone for the results. The service can return results for the following tone IDs: `sad`, `frustrated`, `satisfied`, `excited`, `polite`, `impolite`, and `sympathetic`. The service returns results only for tones whose scores meet a minimum threshold of 0.5.
+    public var toneID: String
+
+    /// The user-visible, localized name of the tone.
+    public var toneName: String
+
+    /**
+     Initialize a `ToneChatScore` with member variables.
+
+     - parameter score: The score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the utterance.
+     - parameter toneID: The unique, non-localized identifier of the tone for the results. The service can return results for the following tone IDs: `sad`, `frustrated`, `satisfied`, `excited`, `polite`, `impolite`, and `sympathetic`. The service returns results only for tones whose scores meet a minimum threshold of 0.5.
+     - parameter toneName: The user-visible, localized name of the tone.
+
+     - returns: An initialized `ToneChatScore`.
+    */
+    public init(score: Double, toneID: String, toneName: String) {
+        self.score = score
+        self.toneID = toneID
+        self.toneName = toneName
+    }
+}
+
+extension ToneChatScore: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case score = "score"
+        case toneID = "tone_id"
+        case toneName = "tone_name"
+        static let allValues = [score, toneID, toneName]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        score = try container.decode(Double.self, forKey: .score)
+        toneID = try container.decode(String.self, forKey: .toneID)
+        toneName = try container.decode(String.self, forKey: .toneName)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(score, forKey: .score)
+        try container.encode(toneID, forKey: .toneID)
+        try container.encode(toneName, forKey: .toneName)
+    }
+
+}

--- a/Source/ToneAnalyzerV3/Models/ToneInput.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneInput.swift
@@ -1,0 +1,54 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/** ToneInput. */
+public struct ToneInput {
+
+    /// The input content that the service is to analyze.
+    public var text: String
+
+    /**
+     Initialize a `ToneInput` with member variables.
+
+     - parameter text: The input content that the service is to analyze.
+
+     - returns: An initialized `ToneInput`.
+    */
+    public init(text: String) {
+        self.text = text
+    }
+}
+
+extension ToneInput: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case text = "text"
+        static let allValues = [text]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        text = try container.decode(String.self, forKey: .text)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(text, forKey: .text)
+    }
+
+}

--- a/Source/ToneAnalyzerV3/Models/ToneScore.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneScore.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,55 @@
 
 import Foundation
 
-/** The score of a particular tone. */
-public struct ToneScore: JSONDecodable {
+/** ToneScore. */
+public struct ToneScore {
 
-    /// A unique number identifying this particular tone.
-    public let id: String
+    /// The score for the tone. * **`2017-09-21`:** The score that is returned lies in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the content. * **`2016-05-19`:** The score that is returned lies in the range of 0 to 1. A score less than 0.5 indicates that the tone is unlikely to be perceived in the content; a score greater than 0.75 indicates a high likelihood that the tone is perceived.
+    public var score: Double
 
-    /// The name of this particular tone.
-    public let name: String
+    /// The unique, non-localized identifier of the tone. * **`2017-09-21`:** The service can return results for the following tone IDs: `anger`, `fear`, `joy`, and `sadness` (emotional tones); `analytical`, `confident`, and `tentative` (language tones). The service returns results only for tones whose scores meet a minimum threshold of 0.5. * **`2016-05-19`:** The service can return results for the following tone IDs of the different categories: for the `emotion` category: `anger`, `disgust`, `fear`, `joy`, and `sadness`; for the `language` category: `analytical`, `confident`, and `tentative`; for the `social` category: `openness_big5`, `conscientiousness_big5`, `extraversion_big5`, `agreeableness_big5`, and `emotional_range_big5`. The service returns scores for all tones of a category, regardless of their values.
+    public var toneID: String
 
-    /// The raw score of the tone, computed by the algorithms. This can be
-    /// compared to other raw scores and used to build your own normalizations.
-    public let score: Double
+    /// The user-visible, localized name of the tone.
+    public var toneName: String
 
-    /// Used internally to initialize a `ToneScore` model from JSON.
-    public init(json: JSONWrapper) throws {
-        id = try json.getString(at: "tone_id")
-        name = try json.getString(at: "tone_name")
-        score = try json.getDouble(at: "score")
+    /**
+     Initialize a `ToneScore` with member variables.
+
+     - parameter score: The score for the tone. * **`2017-09-21`:** The score that is returned lies in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the content. * **`2016-05-19`:** The score that is returned lies in the range of 0 to 1. A score less than 0.5 indicates that the tone is unlikely to be perceived in the content; a score greater than 0.75 indicates a high likelihood that the tone is perceived.
+     - parameter toneID: The unique, non-localized identifier of the tone. * **`2017-09-21`:** The service can return results for the following tone IDs: `anger`, `fear`, `joy`, and `sadness` (emotional tones); `analytical`, `confident`, and `tentative` (language tones). The service returns results only for tones whose scores meet a minimum threshold of 0.5. * **`2016-05-19`:** The service can return results for the following tone IDs of the different categories: for the `emotion` category: `anger`, `disgust`, `fear`, `joy`, and `sadness`; for the `language` category: `analytical`, `confident`, and `tentative`; for the `social` category: `openness_big5`, `conscientiousness_big5`, `extraversion_big5`, `agreeableness_big5`, and `emotional_range_big5`. The service returns scores for all tones of a category, regardless of their values.
+     - parameter toneName: The user-visible, localized name of the tone.
+
+     - returns: An initialized `ToneScore`.
+    */
+    public init(score: Double, toneID: String, toneName: String) {
+        self.score = score
+        self.toneID = toneID
+        self.toneName = toneName
     }
+}
+
+extension ToneScore: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case score = "score"
+        case toneID = "tone_id"
+        case toneName = "tone_name"
+        static let allValues = [score, toneID, toneName]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        score = try container.decode(Double.self, forKey: .score)
+        toneID = try container.decode(String.self, forKey: .toneID)
+        toneName = try container.decode(String.self, forKey: .toneName)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(score, forKey: .score)
+        try container.encode(toneID, forKey: .toneID)
+        try container.encode(toneName, forKey: .toneName)
+    }
+
 }

--- a/Source/ToneAnalyzerV3/Models/Utterance.swift
+++ b/Source/ToneAnalyzerV3/Models/Utterance.swift
@@ -1,0 +1,62 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/** Utterance. */
+public struct Utterance {
+
+    /// An utterance contributed by a user in the conversation that is to be analyzed. The utterance can contain multiple sentences.
+    public var text: String
+
+    /// A string that identifies the user who contributed the utterance specified by the `text` parameter.
+    public var user: String?
+
+    /**
+     Initialize a `Utterance` with member variables.
+
+     - parameter text: An utterance contributed by a user in the conversation that is to be analyzed. The utterance can contain multiple sentences.
+     - parameter user: A string that identifies the user who contributed the utterance specified by the `text` parameter.
+
+     - returns: An initialized `Utterance`.
+    */
+    public init(text: String, user: String? = nil) {
+        self.text = text
+        self.user = user
+    }
+}
+
+extension Utterance: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case text = "text"
+        case user = "user"
+        static let allValues = [text, user]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        text = try container.decode(String.self, forKey: .text)
+        user = try container.decodeIfPresent(String.self, forKey: .user)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(text, forKey: .text)
+        try container.encodeIfPresent(user, forKey: .user)
+    }
+
+}

--- a/Source/ToneAnalyzerV3/Models/UtteranceAnalyses.swift
+++ b/Source/ToneAnalyzerV3/Models/UtteranceAnalyses.swift
@@ -1,0 +1,62 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/** UtteranceAnalyses. */
+public struct UtteranceAnalyses {
+
+    /// An array of `UtteranceAnalysis` objects that provides the results for each utterance of the input.
+    public var utterancesTone: [UtteranceAnalysis]
+
+    /// **`2017-09-21`:** A warning message if the content contains more than 50 utterances. The service analyzes only the first 50 utterances. **`2016-05-19`:** Not returned.
+    public var warning: String?
+
+    /**
+     Initialize a `UtteranceAnalyses` with member variables.
+
+     - parameter utterancesTone: An array of `UtteranceAnalysis` objects that provides the results for each utterance of the input.
+     - parameter warning: **`2017-09-21`:** A warning message if the content contains more than 50 utterances. The service analyzes only the first 50 utterances. **`2016-05-19`:** Not returned.
+
+     - returns: An initialized `UtteranceAnalyses`.
+    */
+    public init(utterancesTone: [UtteranceAnalysis], warning: String? = nil) {
+        self.utterancesTone = utterancesTone
+        self.warning = warning
+    }
+}
+
+extension UtteranceAnalyses: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case utterancesTone = "utterances_tone"
+        case warning = "warning"
+        static let allValues = [utterancesTone, warning]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        utterancesTone = try container.decode([UtteranceAnalysis].self, forKey: .utterancesTone)
+        warning = try container.decodeIfPresent(String.self, forKey: .warning)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(utterancesTone, forKey: .utterancesTone)
+        try container.encodeIfPresent(warning, forKey: .warning)
+    }
+
+}

--- a/Source/ToneAnalyzerV3/Models/UtteranceAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/UtteranceAnalysis.swift
@@ -20,7 +20,7 @@ import Foundation
 public struct UtteranceAnalysis {
 
     /// The unique identifier of the utterance. The first utterance has ID 0, and the ID of each subsequent utterance is incremented by one.
-    public var utteranceID: String
+    public var utteranceID: Int
 
     /// The text of the utterance.
     public var utteranceText: String
@@ -41,7 +41,7 @@ public struct UtteranceAnalysis {
 
      - returns: An initialized `UtteranceAnalysis`.
     */
-    public init(utteranceID: String, utteranceText: String, tones: [ToneChatScore], error: String? = nil) {
+    public init(utteranceID: Int, utteranceText: String, tones: [ToneChatScore], error: String? = nil) {
         self.utteranceID = utteranceID
         self.utteranceText = utteranceText
         self.tones = tones
@@ -61,7 +61,7 @@ extension UtteranceAnalysis: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        utteranceID = try container.decode(String.self, forKey: .utteranceID)
+        utteranceID = try container.decode(Int.self, forKey: .utteranceID)
         utteranceText = try container.decode(String.self, forKey: .utteranceText)
         tones = try container.decode([ToneChatScore].self, forKey: .tones)
         error = try container.decodeIfPresent(String.self, forKey: .error)

--- a/Source/ToneAnalyzerV3/Models/UtteranceAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/UtteranceAnalysis.swift
@@ -1,0 +1,78 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/** UtteranceAnalysis. */
+public struct UtteranceAnalysis {
+
+    /// The unique identifier of the utterance. The first utterance has ID 0, and the ID of each subsequent utterance is incremented by one.
+    public var utteranceID: String
+
+    /// The text of the utterance.
+    public var utteranceText: String
+
+    /// An array of `ToneChatScore` objects that provides results for the most prevalent tones of the utterance. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold.
+    public var tones: [ToneChatScore]
+
+    /// **`2017-09-21`:** An error message if the utterance contains more than 500 characters. The service does not analyze the utterance. **`2016-05-19`:** Not returned.
+    public var error: String?
+
+    /**
+     Initialize a `UtteranceAnalysis` with member variables.
+
+     - parameter utteranceID: The unique identifier of the utterance. The first utterance has ID 0, and the ID of each subsequent utterance is incremented by one.
+     - parameter utteranceText: The text of the utterance.
+     - parameter tones: An array of `ToneChatScore` objects that provides results for the most prevalent tones of the utterance. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold.
+     - parameter error: **`2017-09-21`:** An error message if the utterance contains more than 500 characters. The service does not analyze the utterance. **`2016-05-19`:** Not returned.
+
+     - returns: An initialized `UtteranceAnalysis`.
+    */
+    public init(utteranceID: String, utteranceText: String, tones: [ToneChatScore], error: String? = nil) {
+        self.utteranceID = utteranceID
+        self.utteranceText = utteranceText
+        self.tones = tones
+        self.error = error
+    }
+}
+
+extension UtteranceAnalysis: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case utteranceID = "utterance_id"
+        case utteranceText = "utterance_text"
+        case tones = "tones"
+        case error = "error"
+        static let allValues = [utteranceID, utteranceText, tones, error]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        utteranceID = try container.decode(String.self, forKey: .utteranceID)
+        utteranceText = try container.decode(String.self, forKey: .utteranceText)
+        tones = try container.decode([ToneChatScore].self, forKey: .tones)
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(utteranceID, forKey: .utteranceID)
+        try container.encode(utteranceText, forKey: .utteranceText)
+        try container.encode(tones, forKey: .tones)
+        try container.encodeIfPresent(error, forKey: .error)
+    }
+
+}

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -105,12 +105,7 @@ public class ToneAnalyzer {
             let json = try JSONWrapper(data: data)
             let code = response?.statusCode ?? 400
             let message = try json.getString(at: "error")
-            var userInfo = [NSLocalizedDescriptionKey: message]
-            let help = try? json.getString(at: "help")
-            let description = try? json.getString(at: "description")
-            if let recoverySuggestion = help ?? description {
-                userInfo[NSLocalizedRecoverySuggestionErrorKey] = recoverySuggestion
-            }
+            let userInfo = [NSLocalizedDescriptionKey: message]
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return nil

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -17,40 +17,34 @@
 import Foundation
 
 /**
-   ### Service Overview
-  The IBM Watson Tone Analyzer service uses linguistic analysis to detect emotional and language
-  tones in written text. The service can analyze tone at both the document and sentence levels. You
-  can use the service to understand how your written communications are perceived and then to
-  improve the tone of your communications. Businesses can use the service to learn the tone of their
-  customers' communications and to respond to each customer appropriately, or to understand and
-  improve their customer conversations.
-  ### API Usage
-  The following information provides details about using the service to analyze tone:
-  * **The tone method:** The service offers `GET` and `POST /v3/tone` methods that use the general
-  purpose endpoint to analyze the tone of input content. The methods accept content in JSON, plain
-  text, or HTML format.
-  * **The tone_chat method:** The service offers a `POST /v3/tone_chat` method that uses the
-  customer engagement endpoint to analyze the tone of customer service and customer support
-  conversations. The method accepts content in JSON format.
-  * **Authentication:** You authenticate to the service by using your service credentials. You can
-  use your credentials to authenticate via a proxy server that resides in IBM Cloud, or you can use
-  your credentials to obtain a token and contact the service directly. See [Service credentials for
-  Watson
-  services](https://console.bluemix.net/docs/services/watson/getting-started-credentials.html) and
-  [Tokens for
-  authentication](https://console.bluemix.net/docs/services/watson/getting-started-tokens.html).
-  * **Request Logging:** By default, all Watson services log requests and their results. Data is
-  collected only to improve the Watson services. If you do not want to share your data, set the
-  header parameter `X-Watson-Learning-Opt-Out` to `true` for each request. Data is collected for any
-  request that omits this header. See [Controlling request logging for Watson
-  services](https://console.bluemix.net/docs/services/watson/getting-started-logging.html).
+  ### Service Overview
+ The IBM Watson Tone Analyzer service uses linguistic analysis to detect emotional and language tones in written text.
+ The service can analyze tone at both the document and sentence levels. You can use the service to understand how your
+ written communications are perceived and then to improve the tone of your communications. Businesses can use the
+ service to learn the tone of their customers' communications and to respond to each customer appropriately, or to
+ understand and improve their customer conversations.
+ ### API Usage
+ The following information provides details about using the service to analyze tone:
+ * **The tone method:** The service offers `GET` and `POST /v3/tone` methods that use the general purpose endpoint to
+ analyze the tone of input content. The methods accept content in JSON, plain text, or HTML format.
+ * **The tone_chat method:** The service offers a `POST /v3/tone_chat` method that uses the customer engagement endpoint
+ to analyze the tone of customer service and customer support conversations. The method accepts content in JSON format.
+ * **Authentication:** You authenticate to the service by using your service credentials. You can use your credentials
+ to authenticate via a proxy server that resides in IBM Cloud, or you can use your credentials to obtain a token and
+ contact the service directly. See [Service credentials for Watson
+ services](https://console.bluemix.net/docs/services/watson/getting-started-credentials.html) and [Tokens for
+ authentication](https://console.bluemix.net/docs/services/watson/getting-started-tokens.html).
+ * **Request Logging:** By default, all Watson services log requests and their results. Data is collected only to
+ improve the Watson services. If you do not want to share your data, set the header parameter
+ `X-Watson-Learning-Opt-Out` to `true` for each request. Data is collected for any request that omits this header. See
+ [Controlling request logging for Watson
+ services](https://console.bluemix.net/docs/services/watson/getting-started-logging.html).
 
-  For more information about the service, see [About Tone
-  Analyzer](https://console.bluemix.net/docs/services/tone-analyzer/index.html).
+ For more information about the service, see [About Tone
+ Analyzer](https://console.bluemix.net/docs/services/tone-analyzer/index.html).
 
-  **Note:** Method descriptions apply to the latest version of the interface, `2017-09-21`. Where
-  necessary, parameters and models describe differences between versions `2017-09-21` and
-  `2016-05-19`.
+ **Note:** Method descriptions apply to the latest version of the interface, `2017-09-21`. Where necessary, parameters
+ and models describe differences between versions `2017-09-21` and `2016-05-19`.
  */
 public class ToneAnalyzer {
 
@@ -115,7 +109,18 @@ public class ToneAnalyzer {
     /**
      Analyze general purpose tone.
 
-     Uses the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for emotional and language tones. The method always analyzes the tone of the full document; by default, it also analyzes the tone of each individual sentence of the content.   You can submit no more than 128 KB of total input content and no more than 1000 individual sentences in JSON, plain text, or HTML format. The service analyzes the first 1000 sentences for document-level analysis and only the first 100 sentences for sentence-level analysis.   Use the `POST` request method to analyze larger amounts of content in any of the available formats. Use the `GET` request method to analyze smaller quantities of plain text content.   Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the service removes HTML tags and analyzes only the textual content.
+          Uses the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for
+     emotional and language tones. The method always analyzes the tone of the full document; by default, it also
+     analyzes the tone of each individual sentence of the content.   You can submit no more than 128 KB of total input
+     content and no more than 1000 individual sentences in JSON, plain text, or HTML format. The service analyzes the
+     first 1000 sentences for document-level analysis and only the first 100 sentences for sentence-level analysis.
+     Use the `POST` request method to analyze larger amounts of content in any of the available formats. Use the `GET`
+     request method to analyze smaller quantities of plain text content.   Per the JSON specification, the default
+     character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default encoding
+     for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content type of
+     plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text; for
+     example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the service removes HTML tags and analyzes only
+     the textual content.
 
      - parameter toneInput: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type `ToneInput`.
      - parameter contentType: The type of the input: application/json, text/plain, or text/html. A character encoding can be specified by including a `charset` parameter. For example, 'text/plain;charset=utf-8'.
@@ -179,7 +184,13 @@ public class ToneAnalyzer {
     /**
      Analyze customer engagement tone.
 
-     Use the customer engagement endpoint to analyze the tone of customer service and customer support conversations. For each utterance of a conversation, the method reports the most prevalent subset of the following seven tones: sad, frustrated, satisfied, excited, polite, impolite, and sympathetic.   If you submit more than 50 utterances, the service returns a warning for the overall content and analyzes only the first 50 utterances. If you submit a single utterance that contains more than 500 characters, the service returns an error for that utterance and does not analyze the utterance. The request fails if all utterances have more than 500 characters.   Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8.
+          Use the customer engagement endpoint to analyze the tone of customer service and customer support conversations.
+     For each utterance of a conversation, the method reports the most prevalent subset of the following seven tones:
+     sad, frustrated, satisfied, excited, polite, impolite, and sympathetic.   If you submit more than 50 utterances,
+     the service returns a warning for the overall content and analyzes only the first 50 utterances. If you submit a
+     single utterance that contains more than 500 characters, the service returns an error for that utterance and does
+     not analyze the utterance. The request fails if all utterances have more than 500 characters.   Per the JSON
+     specification, the default character encoding for JSON content is effectively always UTF-8.
 
      - parameter utterances: An array of `Utterance` objects that provides the input content that the service is to analyze.
      - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`.

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,41 @@
 import Foundation
 
 /**
- The IBM Watson Tone Analyzer service uses linguistic analysis to detect emotional tones,
- social propensities, and writing styles in written communication. Then it offers suggestions
- to help the writer improve their intended language tones.
-**/
+   ### Service Overview
+  The IBM Watson Tone Analyzer service uses linguistic analysis to detect emotional and language
+  tones in written text. The service can analyze tone at both the document and sentence levels. You
+  can use the service to understand how your written communications are perceived and then to
+  improve the tone of your communications. Businesses can use the service to learn the tone of their
+  customers' communications and to respond to each customer appropriately, or to understand and
+  improve their customer conversations.
+  ### API Usage
+  The following information provides details about using the service to analyze tone:
+  * **The tone method:** The service offers `GET` and `POST /v3/tone` methods that use the general
+  purpose endpoint to analyze the tone of input content. The methods accept content in JSON, plain
+  text, or HTML format.
+  * **The tone_chat method:** The service offers a `POST /v3/tone_chat` method that uses the
+  customer engagement endpoint to analyze the tone of customer service and customer support
+  conversations. The method accepts content in JSON format.
+  * **Authentication:** You authenticate to the service by using your service credentials. You can
+  use your credentials to authenticate via a proxy server that resides in IBM Cloud, or you can use
+  your credentials to obtain a token and contact the service directly. See [Service credentials for
+  Watson
+  services](https://console.bluemix.net/docs/services/watson/getting-started-credentials.html) and
+  [Tokens for
+  authentication](https://console.bluemix.net/docs/services/watson/getting-started-tokens.html).
+  * **Request Logging:** By default, all Watson services log requests and their results. Data is
+  collected only to improve the Watson services. If you do not want to share your data, set the
+  header parameter `X-Watson-Learning-Opt-Out` to `true` for each request. Data is collected for any
+  request that omits this header. See [Controlling request logging for Watson
+  services](https://console.bluemix.net/docs/services/watson/getting-started-logging.html).
+
+  For more information about the service, see [About Tone
+  Analyzer](https://console.bluemix.net/docs/services/tone-analyzer/index.html).
+
+  **Note:** Method descriptions apply to the latest version of the interface, `2017-09-21`. Where
+  necessary, parameters and models describe differences between versions `2017-09-21` and
+  `2016-05-19`.
+ */
 public class ToneAnalyzer {
 
     /// The base URL to use when contacting the service.
@@ -30,8 +61,8 @@ public class ToneAnalyzer {
     public var defaultHeaders = [String: String]()
 
     private let credentials: Credentials
-    private let version: String
     private let domain = "com.ibm.watson.developer-cloud.ToneAnalyzerV3"
+    private let version: String
 
     /**
      Create a `ToneAnalyzer` object.
@@ -39,10 +70,10 @@ public class ToneAnalyzer {
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date
-            in "YYYY-MM-DD" format.
+       in "YYYY-MM-DD" format.
      */
     public init(username: String, password: String, version: String) {
-        self.credentials = Credentials.basicAuthentication(username: username, password: password)
+        self.credentials = .basicAuthentication(username: username, password: password)
         self.version = version
     }
 
@@ -87,43 +118,45 @@ public class ToneAnalyzer {
     }
 
     /**
-     Analyze the tone of the given text.
+     Analyze general purpose tone.
 
-     The message is analyzed for several tones—social, emotional, and writing. For each tone,
-     various traits are derived (e.g. conscientiousness, agreeableness, and openness).
+     Uses the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for emotional and language tones. The method always analyzes the tone of the full document; by default, it also analyzes the tone of each individual sentence of the content.   You can submit no more than 128 KB of total input content and no more than 1000 individual sentences in JSON, plain text, or HTML format. The service analyzes the first 1000 sentences for document-level analysis and only the first 100 sentences for sentence-level analysis.   Use the `POST` request method to analyze larger amounts of content in any of the available formats. Use the `GET` request method to analyze smaller quantities of plain text content.   Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the service removes HTML tags and analyzes only the textual content.
 
-     - parameter ofText: The text to analyze.
-     - parameter tones: Filter the results by a specific tone. Valid values for `tones` are
-            `emotion`, `writing`, or `social`.
-     - parameter sentences: Should sentence-level tone analysis by performed?
-     - parameter failure: A function invoked if an error occurs.
-     - parameter success: A function invoked with the tone analysis.
-     */
-    public func getTone(
-        ofText text: String,
-        tones: [String]? = nil,
+     - parameter toneInput: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type `ToneInput`.
+     - parameter contentType: The type of the input: application/json, text/plain, or text/html. A character encoding can be specified by including a `charset` parameter. For example, 'text/plain;charset=utf-8'.
+     - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of the full document. If `true` (the default), the service returns results for each sentence.
+     - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the parameter no longer affects the response.   **`2016-05-19`:** A comma-separated list of tones for which the service is to return its analysis of the input; the indicated tones apply both to the full document and to individual sentences of the document. You can specify one or more of the valid values. Omit the parameter to request results for all three tones.
+     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not submit content that contains both languages. You can specify any combination of languages for `contentLanguage` and `Accept-Language`. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for `Content-Language` and `acceptLanguage`.
+     - parameter failure: A function executed if an error occurs.
+     - parameter success: A function executed with the successful result.
+    */
+    public func tone(
+        toneInput: ToneInput,
+        contentType: String,
         sentences: Bool? = nil,
+        tones: [String]? = nil,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ToneAnalysis) -> Void)
     {
         // construct body
-        guard let body = try? JSONWrapper(dictionary: ["text": text]).serialize() else {
-            let failureReason = "Classification text could not be serialized to JSON."
-            let userInfo = [NSLocalizedDescriptionKey: failureReason]
-            let error = NSError(domain: domain, code: 0, userInfo: userInfo)
-            failure?(error)
+        guard let body = try? JSONEncoder().encode(toneInput) else {
+            failure?(RestError.serializationError)
             return
         }
 
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
-        if let tones = tones {
-            let tonesList = tones.joined(separator: ",")
-            queryParameters.append(URLQueryItem(name: "tones", value: tonesList))
-        }
         if let sentences = sentences {
-            queryParameters.append(URLQueryItem(name: "sentences", value: "\(sentences)"))
+            let queryParameter = URLQueryItem(name: "sentences", value: "\(sentences)")
+            queryParameters.append(queryParameter)
+        }
+        if let tones = tones {
+            let queryParameter = URLQueryItem(name: "tones", value: "\(tones)")
+            queryParameters.append(queryParameter)
         }
 
         // construct REST request
@@ -142,9 +175,59 @@ public class ToneAnalyzer {
         request.responseObject(responseToError: responseToError) {
             (response: RestResponse<ToneAnalysis>) in
             switch response.result {
-            case .success(let toneAnalysis): success(toneAnalysis)
+            case .success(let retval): success(retval)
             case .failure(let error): failure?(error)
             }
         }
     }
+
+    /**
+     Analyze customer engagement tone.
+
+     Use the customer engagement endpoint to analyze the tone of customer service and customer support conversations. For each utterance of a conversation, the method reports the most prevalent subset of the following seven tones: sad, frustrated, satisfied, excited, polite, impolite, and sympathetic.   If you submit more than 50 utterances, the service returns a warning for the overall content and analyzes only the first 50 utterances. If you submit a single utterance that contains more than 500 characters, the service returns an error for that utterance and does not analyze the utterance. The request fails if all utterances have more than 500 characters.   Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8.
+
+     - parameter utterances: An array of `Utterance` objects that provides the input content that the service is to analyze.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`.
+     - parameter failure: A function executed if an error occurs.
+     - parameter success: A function executed with the successful result.
+    */
+    public func toneChat(
+        utterances: [Utterance],
+        acceptLanguage: String? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (UtteranceAnalyses) -> Void)
+    {
+        // construct body
+        let toneChatRequest = ToneChatInput(utterances: utterances)
+        guard let body = try? JSONEncoder().encode(toneChatRequest) else {
+            failure?(RestError.serializationError)
+            return
+        }
+
+        // construct query parameters
+        var queryParameters = [URLQueryItem]()
+        queryParameters.append(URLQueryItem(name: "version", value: version))
+
+        // construct REST request
+        let request = RestRequest(
+            method: "POST",
+            url: serviceURL + "/v3/tone_chat",
+            credentials: credentials,
+            headerParameters: defaultHeaders,
+            acceptType: "application/json",
+            contentType: "application/json",
+            queryItems: queryParameters,
+            messageBody: body
+        )
+
+        // execute REST request
+        request.responseObject(responseToError: responseToError) {
+            (response: RestResponse<UtteranceAnalyses>) in
+            switch response.result {
+            case .success(let retval): success(retval)
+            case .failure(let error): failure?(error)
+            }
+        }
+    }
+
 }

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -45,7 +45,7 @@ class ToneAnalyzerTests: XCTestCase {
         Utterance(text: "Thanks for reaching out. Can you give me some more detail about the issue?", user: "agent"),
         Utterance(text: "I put my charger in my phone last night to charge and it isn't working. " +
             "Which is ridiculous, it's a new charger, I bought it yesterday.", user: "customer"),
-        Utterance(text: "I'm sorry you're having issues with charging. What kind of charger do you have?", user: "agent")
+        Utterance(text: "I'm sorry you're having issues with charging. What kind of charger do you have?", user: "agent"),
     ]
 
     // MARK: - Test Configuration

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -26,16 +26,26 @@ class ToneAnalyzerTests: XCTestCase {
 
     static var allTests: [(String, (ToneAnalyzerTests) -> () throws -> Void)] {
         return [
-            ("testGetToneWithDefaultParameters", testGetToneWithDefaultParameters),
-            ("testGetToneWithCustomParameters", testGetToneWithCustomParameters),
+            ("testGetTone", testGetTone),
+            ("testGetToneCustom", testGetToneCustom),
+            ("testToneChat", testToneChat),
             ("testGetToneEmptyString", testGetToneEmptyString),
         ]
     }
 
-    let text = "I know the times are difficult! Our sales have been disappointing for " +
-               "the past three quarters for our data analytics product suite. We have a " +
-               "competitive data analytics product suite in the industry. But we need " +
-               "to do our job selling it! "
+    let text = """
+        I know the times are difficult! Our sales have been disappointing for the past three quarters for
+        our data analytics product suite. We have a competitive data analytics product suite in the industry.
+        But we need to do our job selling it!
+    """
+
+    let utterances = [
+        Utterance(text: "My charger isn't working.", user: "customer"),
+        Utterance(text: "Thanks for reaching out. Can you give me some more detail about the issue?", user: "agent"),
+        Utterance(text: "I put my charger in my phone last night to charge and it isn't working. " +
+            "Which is ridiculous, it's a new charger, I bought it yesterday.", user: "customer"),
+        Utterance(text: "I'm sorry you're having issues with charging. What kind of charger do you have?", user: "agent")
+    ]
 
     // MARK: - Test Configuration
 
@@ -79,10 +89,8 @@ class ToneAnalyzerTests: XCTestCase {
 
     // MARK: - Positive Tests
 
-    /** Analyze the tone of the given text using the default parameters. */
-    func testGetToneWithDefaultParameters() {
-        let description = "Analyze the tone of the given text using the default parameters."
-        let expectation = self.expectation(description: description)
+    func testGetTone() {
+        let expectation = self.expectation(description: "Get tone.")
         toneAnalyzer.tone(toneInput: ToneInput(text: text), contentType: "plain/text", failure: failWithError) {
             toneAnalysis in
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
@@ -101,10 +109,8 @@ class ToneAnalyzerTests: XCTestCase {
         waitForExpectations()
     }
 
-    /** Analyze the tone of the given text with custom parameters. */
-    func testGetToneWithCustomParameters() {
-        let description = "Analyze the tone of the given text using custom parameters."
-        let expectation = self.expectation(description: description)
+    func testGetToneCustom() {
+        let expectation = self.expectation(description: "Get tone with custom parameters.")
         toneAnalyzer.tone(
             toneInput: ToneInput(text: text),
             contentType: "plain/text",
@@ -122,11 +128,19 @@ class ToneAnalyzerTests: XCTestCase {
         waitForExpectations()
     }
 
+    func testToneChat() {
+        let expectation = self.expectation(description: "Tone chat.")
+        toneAnalyzer.toneChat(utterances: utterances, acceptLanguage: "en", failure: failWithError) { analyses in
+            print(analyses)
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+
     // MARK: - Negative Tests
 
     func testGetToneEmptyString() {
-        let description = "Analyze the tone of an empty string."
-        let expectation = self.expectation(description: description)
+        let expectation = self.expectation(description: "Get tone with an empty string.")
         let failure = { (error: Error) in expectation.fulfill() }
         toneAnalyzer.tone(
             toneInput: ToneInput(text: ""),
@@ -134,6 +148,13 @@ class ToneAnalyzerTests: XCTestCase {
             failure: failure,
             success: failWithResult
         )
+        waitForExpectations()
+    }
+
+    func testToneChatEmptyArray() {
+        let expectation = self.expectation(description: "Tone chat with an empty array.")
+        let failure = { (error: Error) in expectation.fulfill() }
+        toneAnalyzer.toneChat(utterances: [], acceptLanguage: "en", failure: failure, success: failWithResult)
         waitForExpectations()
     }
 }

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -30,6 +30,7 @@ class ToneAnalyzerTests: XCTestCase {
             ("testGetToneCustom", testGetToneCustom),
             ("testToneChat", testToneChat),
             ("testGetToneEmptyString", testGetToneEmptyString),
+            ("testToneChatEmptyArray", testToneChatEmptyArray),
         ]
     }
 

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -328,6 +328,13 @@
 		68BC29031F8C38700042810E /* RestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A61174F1CB5988B009A4DA1 /* RestRequest.swift */; };
 		68BC29041F8C38700042810E /* RestToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAA9A3D1CEE3059002C9564 /* RestToken.swift */; };
 		68BC29051F8C38700042810E /* RestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAA9A3C1CEE3059002C9564 /* RestUtilities.swift */; };
+		68D09C1F200D61870087ADE5 /* ToneChatInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C18200D61870087ADE5 /* ToneChatInput.swift */; };
+		68D09C20200D61870087ADE5 /* UtteranceAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C19200D61870087ADE5 /* UtteranceAnalysis.swift */; };
+		68D09C21200D61870087ADE5 /* ToneChatScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C1A200D61870087ADE5 /* ToneChatScore.swift */; };
+		68D09C22200D61870087ADE5 /* UtteranceAnalyses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C1B200D61870087ADE5 /* UtteranceAnalyses.swift */; };
+		68D09C23200D61870087ADE5 /* ToneInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C1C200D61870087ADE5 /* ToneInput.swift */; };
+		68D09C24200D61870087ADE5 /* Utterance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C1D200D61870087ADE5 /* Utterance.swift */; };
+		68D09C25200D61870087ADE5 /* DocumentAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C1E200D61870087ADE5 /* DocumentAnalysis.swift */; };
 		68D8A8862009CF5B0090B84B /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68A0EEE72006D22700E58658 /* Starscream.framework */; };
 		68D8A8872009CF680090B84B /* Starscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 68A0EEE72006D22700E58658 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7A1B0F291D82645100783EA3 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B0F281D82645100783EA3 /* Model.swift */; };
@@ -1047,6 +1054,13 @@
 		68B213E81F84296D0052DC00 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		68B213ED1F8429880052DC00 /* CodableExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableExtensionsTests.swift; sourceTree = "<group>"; };
 		68B213EE1F8429890052DC00 /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
+		68D09C18200D61870087ADE5 /* ToneChatInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneChatInput.swift; sourceTree = "<group>"; };
+		68D09C19200D61870087ADE5 /* UtteranceAnalysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtteranceAnalysis.swift; sourceTree = "<group>"; };
+		68D09C1A200D61870087ADE5 /* ToneChatScore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneChatScore.swift; sourceTree = "<group>"; };
+		68D09C1B200D61870087ADE5 /* UtteranceAnalyses.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtteranceAnalyses.swift; sourceTree = "<group>"; };
+		68D09C1C200D61870087ADE5 /* ToneInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneInput.swift; sourceTree = "<group>"; };
+		68D09C1D200D61870087ADE5 /* Utterance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utterance.swift; sourceTree = "<group>"; };
+		68D09C1E200D61870087ADE5 /* DocumentAnalysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentAnalysis.swift; sourceTree = "<group>"; };
 		7A0F95B61C23288E004C01C0 /* WatsonDeveloperCloud.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WatsonDeveloperCloud.h; path = Source/SupportingFiles/WatsonDeveloperCloud.h; sourceTree = "<group>"; };
 		7A0F95B81C23288E004C01C0 /* Info-Release.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-Release.plist"; path = "Source/SupportingFiles/Info-Release.plist"; sourceTree = "<group>"; };
 		7A0F95C41C23288E004C01C0 /* Info-Tests.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-Tests.plist"; path = "Source/SupportingFiles/Info-Tests.plist"; sourceTree = "<group>"; };
@@ -2643,10 +2657,17 @@
 		B1F21DF01CE2461800393146 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				68D09C1E200D61870087ADE5 /* DocumentAnalysis.swift */,
 				B1F21DF21CE2461800393146 /* SentenceAnalysis.swift */,
 				B1F21DF31CE2461800393146 /* ToneAnalysis.swift */,
 				B1F21DF41CE2461800393146 /* ToneCategory.swift */,
+				68D09C18200D61870087ADE5 /* ToneChatInput.swift */,
+				68D09C1A200D61870087ADE5 /* ToneChatScore.swift */,
+				68D09C1C200D61870087ADE5 /* ToneInput.swift */,
 				B1F21DF51CE2461800393146 /* ToneScore.swift */,
+				68D09C1D200D61870087ADE5 /* Utterance.swift */,
+				68D09C1B200D61870087ADE5 /* UtteranceAnalyses.swift */,
+				68D09C19200D61870087ADE5 /* UtteranceAnalysis.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -4836,16 +4857,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				68D09C21200D61870087ADE5 /* ToneChatScore.swift in Sources */,
 				7AAAF4101CEE9D5300B74848 /* SentenceAnalysis.swift in Sources */,
 				68BC28E81F8C35080042810E /* JSON.swift in Sources */,
 				68BC28E71F8C35080042810E /* JSONWrapper.swift in Sources */,
+				68D09C25200D61870087ADE5 /* DocumentAnalysis.swift in Sources */,
 				7AAAF4131CEE9D5300B74848 /* ToneScore.swift in Sources */,
 				68BC28E61F8C35080042810E /* CodableExtensions.swift in Sources */,
 				68BC28EC1F8C35080042810E /* RestToken.swift in Sources */,
+				68D09C22200D61870087ADE5 /* UtteranceAnalyses.swift in Sources */,
 				68BC28EB1F8C35080042810E /* RestRequest.swift in Sources */,
+				68D09C24200D61870087ADE5 /* Utterance.swift in Sources */,
 				7AAAF4121CEE9D5300B74848 /* ToneCategory.swift in Sources */,
 				68BC28EA1F8C35080042810E /* RestError.swift in Sources */,
 				68BC28ED1F8C35080042810E /* RestUtilities.swift in Sources */,
+				68D09C20200D61870087ADE5 /* UtteranceAnalysis.swift in Sources */,
+				68D09C1F200D61870087ADE5 /* ToneChatInput.swift in Sources */,
+				68D09C23200D61870087ADE5 /* ToneInput.swift in Sources */,
 				68BC28E91F8C35080042810E /* MultipartFormData.swift in Sources */,
 				7AAAF4141CEE9D5600B74848 /* ToneAnalyzer.swift in Sources */,
 				7AAAF4111CEE9D5300B74848 /* ToneAnalysis.swift in Sources */,


### PR DESCRIPTION
- [x] Generate latest version of Tone Analyzer
- [x] Update tests for latest version of Tone Analyzer

The generated code includes a number of deprecated fields. I am still working on support for deprecation in `watson-swagger-codegen`. I expect to push a new pull request that removes deprecated fields before the major release.