### PR TITLE
Add RestKit support for API keys

### DIFF
--- a/Source/AlchemyDataNewsV1/AlchemyDataNews.swift
+++ b/Source/AlchemyDataNewsV1/AlchemyDataNews.swift
@@ -29,9 +29,7 @@ public class AlchemyDataNews {
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
-    /// The API key credential to use when authenticating with the service.
-    private let apiKey: String
-
+    private let credentials: Credentials
     private let errorDomain = "com.ibm.watson.developer-cloud.AlchemyDataNews"
 
     /**
@@ -39,7 +37,7 @@ public class AlchemyDataNews {
      - parameter apiKey: The API key credential to use when authenticating with the service.
      */
     public init(apiKey: String) {
-        self.apiKey = apiKey
+        self.credentials = .apiKey(name: "apikey", key: apiKey, in: .query)
     }
 
     /**
@@ -110,7 +108,6 @@ public class AlchemyDataNews {
         var queryItems = [URLQueryItem]()
         queryItems.append(URLQueryItem(name: "start", value: startTime))
         queryItems.append(URLQueryItem(name: "end", value: endTime))
-        queryItems.append(URLQueryItem(name: "apikey", value: apiKey))
         queryItems.append(URLQueryItem(name: "outputMode", value: "json"))
         if let query = query {
             for (key, value) in query {
@@ -122,7 +119,7 @@ public class AlchemyDataNews {
         let request = RestRequest(
             method: "GET",
             url: serviceUrl + "/data/GetNews",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",

--- a/Source/AlchemyLanguageV1/AlchemyLanguage.swift
+++ b/Source/AlchemyLanguageV1/AlchemyLanguage.swift
@@ -29,9 +29,7 @@ public class AlchemyLanguage {
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
-    /// The API key credential to use when authenticating with the service.
-    private let apiKey: String
-
+    private let credentials: Credentials
     private let errorDomain = "com.watsonplatform.alchemyLanguage"
 
     // The characters at the end of the CharacterSet break in Linux
@@ -42,7 +40,7 @@ public class AlchemyLanguage {
      - parameter apiKey: The API key credential to use when authenticating with the service.
      */
     public init(apiKey: String) {
-        self.apiKey = apiKey
+        self.credentials = .apiKey(name: "apikey", key: apiKey, in: .query)
     }
 
     /**
@@ -132,13 +130,12 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetAuthors",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
 
@@ -171,8 +168,6 @@ public class AlchemyLanguage {
         let body = try? buildBody(document: html, html: true)
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -181,7 +176,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetAuthors",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -214,8 +209,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "linkedData", value: "1"))
         queryParams.append(URLQueryItem(name: "url", value: url))
@@ -228,7 +221,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetRankedConcepts",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
@@ -265,8 +258,6 @@ public class AlchemyLanguage {
         let body = try? buildBody(document: html, html: true)
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "linkedData", value: "1"))
         if let myUrl = url {
@@ -280,7 +271,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetRankedConcepts",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -314,8 +305,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "linkedData", value: "1"))
         if let myGraph = knowledgeGraph {
@@ -327,7 +316,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/text/TextGetRankedConcepts",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -371,8 +360,6 @@ public class AlchemyLanguage {
     {
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "url", value: url))
         if let myGraph = knowledgeGraph {
@@ -404,7 +391,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetRankedNamedEntities",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams
@@ -452,8 +439,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -487,7 +472,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetRankedNamedEntities",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -534,8 +519,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myGraph = knowledgeGraph {
             queryParams.append(URLQueryItem(name: "knowledgeGraph",
@@ -566,7 +549,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/text/TextGetRankedNamedEntities",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -602,8 +585,6 @@ public class AlchemyLanguage {
     {
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "url", value: url))
         if let graph = knowledgeGraph {
@@ -626,7 +607,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetRankedKeywords",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams
@@ -666,8 +647,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -692,7 +671,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetRankedKeywords",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -731,8 +710,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let graph = knowledgeGraph {
             queryParams.append(URLQueryItem(name: "knowledgeGraph", value: String(graph.rawValue)))
@@ -754,7 +731,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/text/TextGetRankedKeywords",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -786,13 +763,12 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetLanguage",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
         )
@@ -823,15 +799,13 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
 
         // construct request
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/text/TextGetLanguage",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -863,13 +837,12 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetMicroformatData",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
         )
@@ -903,8 +876,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -914,7 +885,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetMicroformatData",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -946,13 +917,12 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetPubDate",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
         )
@@ -985,8 +955,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -996,7 +964,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetPubDate",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1045,8 +1013,6 @@ public class AlchemyLanguage {
     {
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "url", value: url))
         if let graph = knowledgeGraph {
@@ -1083,7 +1049,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetRelations",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams
@@ -1136,8 +1102,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -1176,7 +1140,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetRelations",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1228,8 +1192,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let graph = knowledgeGraph {
             queryParams.append(URLQueryItem(name: "knowledgeGraph", value: String(graph.rawValue)))
@@ -1265,7 +1227,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/text/TextGetRelations",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1297,13 +1259,12 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetTextSentiment",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
         )
@@ -1336,8 +1297,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -1347,7 +1306,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetTextSentiment",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1380,15 +1339,13 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
 
         // construct request
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/text/TextGetTextSentiment",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1422,13 +1379,12 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetTargetedSentiment",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "target", value: targets),
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
         )
@@ -1463,8 +1419,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "target", value: targets))
         if let myUrl = url {
@@ -1475,7 +1429,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetTargetedSentiment",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1510,8 +1464,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "target", value: targets))
 
@@ -1519,7 +1471,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/text/TextGetTargetedSentiment",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1551,12 +1503,11 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetRankedTaxonomy",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
         )
@@ -1589,8 +1540,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -1600,7 +1549,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetRankedTaxonomy",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1633,15 +1582,13 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
 
         // construct request
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/text/TextGetRankedTaxonomy",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1673,12 +1620,11 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetRawText",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
         )
@@ -1711,8 +1657,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -1722,7 +1666,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetRawText",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1756,8 +1700,6 @@ public class AlchemyLanguage {
     {
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "url", value: url))
         if let metadata = useMetadata {
@@ -1771,7 +1713,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetText",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams
@@ -1809,8 +1751,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -1826,7 +1766,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetText",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1857,8 +1797,6 @@ public class AlchemyLanguage {
     {
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParams.append(URLQueryItem(name: "url", value: url))
         if let metadata = useMetadata {
@@ -1869,7 +1807,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetTitle",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams
@@ -1904,8 +1842,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -1918,7 +1854,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetTitle",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -1950,12 +1886,11 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetFeedLinks",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
         )
@@ -1989,8 +1924,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -2000,7 +1933,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetFeedLinks",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -2032,12 +1965,11 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/url/URLGetEmotion",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: [
                 URLQueryItem(name: "url", value: url),
-                URLQueryItem(name: "apikey", value: apiKey),
                 URLQueryItem(name: "outputMode", value: "json")
             ]
         )
@@ -2071,8 +2003,6 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
         if let myUrl = url {
             queryParams.append(URLQueryItem(name: "url", value: myUrl))
@@ -2082,7 +2012,7 @@ public class AlchemyLanguage {
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/html/HTMLGetEmotion",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,
@@ -2116,15 +2046,13 @@ public class AlchemyLanguage {
 
         // construct query parameters
         var queryParams = [URLQueryItem]()
-
-        queryParams.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParams.append(URLQueryItem(name: "outputMode", value: "json"))
 
         // construct request
         let request = RestRequest(
             method: "POST",
             url: serviceUrl + "/text/TextGetEmotion",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             contentType: "application/x-www-form-urlencoded",
             queryItems: queryParams,

--- a/Source/AlchemyVisionV1/AlchemyVision.swift
+++ b/Source/AlchemyVisionV1/AlchemyVision.swift
@@ -30,9 +30,7 @@ public class AlchemyVision {
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
-    /// The API key credential to use when authenticating with the service.
-    private let apiKey: String
-
+    private let credentials: Credentials
     private let domain = "com.ibm.watson.developer-cloud.AlchemyVisionV1"
     private let unreservedCharacters = CharacterSet(charactersIn:
         "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "1234567890-._~")
@@ -43,7 +41,7 @@ public class AlchemyVision {
      - parameter apiKey: The API key credential to use when authenticating with the service.
      */
     public init(apiKey: String) {
-        self.apiKey = apiKey
+        self.credentials = .apiKey(name: "apikey", key: apiKey, in: .query)
     }
 
     /**
@@ -100,7 +98,6 @@ public class AlchemyVision {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParameters.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParameters.append(URLQueryItem(name: "imagePostMode", value: "raw"))
         if let knowledgeGraph = knowledgeGraph {
@@ -115,7 +112,7 @@ public class AlchemyVision {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/image/ImageGetRankedImageFaceTags",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
@@ -151,7 +148,6 @@ public class AlchemyVision {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParameters.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParameters.append(URLQueryItem(name: "url", value: url))
         if let knowledgeGraph = knowledgeGraph {
@@ -166,7 +162,7 @@ public class AlchemyVision {
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/url/URLGetRankedImageFaceTags",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
@@ -241,7 +237,6 @@ public class AlchemyVision {
 
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParameters.append(URLQueryItem(name: "outputMode", value: "json"))
         if let url = url {
             queryParameters.append(URLQueryItem(name: "url", value: url))
@@ -251,7 +246,7 @@ public class AlchemyVision {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/html/HTMLGetImage",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
@@ -283,7 +278,6 @@ public class AlchemyVision {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParameters.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParameters.append(URLQueryItem(name: "url", value: url))
 
@@ -291,7 +285,7 @@ public class AlchemyVision {
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/url/URLGetImage",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             queryItems: queryParameters
@@ -324,7 +318,6 @@ public class AlchemyVision {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParameters.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParameters.append(URLQueryItem(name: "imagePostMode", value: "raw"))
         if let forceShowAll = forceShowAll {
@@ -346,7 +339,7 @@ public class AlchemyVision {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/image/ImageGetRankedImageKeywords",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
@@ -381,7 +374,6 @@ public class AlchemyVision {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParameters.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParameters.append(URLQueryItem(name: "url", value: url))
         if let forceShowAll = forceShowAll {
@@ -403,7 +395,7 @@ public class AlchemyVision {
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/url/URLGetRankedImageKeywords",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             queryItems: queryParameters
@@ -432,7 +424,6 @@ public class AlchemyVision {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParameters.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParameters.append(URLQueryItem(name: "imagePostMode", value: "raw"))
 
@@ -440,7 +431,7 @@ public class AlchemyVision {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/url/URLGetRankedImageSceneText",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: "application/x-www-form-urlencoded",
@@ -471,7 +462,6 @@ public class AlchemyVision {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "apikey", value: apiKey))
         queryParameters.append(URLQueryItem(name: "outputMode", value: "json"))
         queryParameters.append(URLQueryItem(name: "url", value: url))
 
@@ -479,7 +469,7 @@ public class AlchemyVision {
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/url/URLGetRankedImageSceneText",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             queryItems: queryParameters

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -82,28 +82,21 @@ internal struct RestRequest {
             urlComponents.queryItems = queryItems
         }
 
-        // Must encode "+" to %2B (URLComponents does not do this)
+        // encode "+" to %2B (URLComponents does not do this)
         urlComponents.percentEncodedQuery = urlComponents.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
 
-        // construct basic mutable request
-        var request = URLRequest(url: urlComponents.url!)
+        // construct mutable request
+        let url = urlComponents.url!
+        var request = URLRequest(url: url)
         request.httpMethod = method
         request.httpBody = messageBody
 
-        // set the request's user agent
+        // set headers
         request.setValue(RestRequest.userAgent, forHTTPHeaderField: "User-Agent")
-
-        // set the request's header parameters
-        for (key, value) in headerParameters {
-            request.setValue(value, forHTTPHeaderField: key)
-        }
-
-        // set the request's accept type
+        headerParameters.forEach { (key, value) in request.setValue(value, forHTTPHeaderField: key) }
         if let acceptType = acceptType {
             request.setValue(acceptType, forHTTPHeaderField: "Accept")
         }
-
-        // set the request's content type
         if let contentType = contentType {
             request.setValue(contentType, forHTTPHeaderField: "Content-Type")
         }

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -29,7 +29,7 @@ public class VisualRecognition {
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
-    private let apiKey: String
+    private let credentials: Credentials
     private let version: String
     private let domain = "com.ibm.watson.developer-cloud.VisualRecognitionV3"
 
@@ -41,7 +41,7 @@ public class VisualRecognition {
         "YYYY-MM-DD" format.
      */
     public init(apiKey: String, version: String) {
-        self.apiKey = apiKey
+        self.credentials = .apiKey(name: "api_key", key: apiKey, in: .query)
         self.version = version
     }
 
@@ -126,7 +126,6 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
         queryParameters.append(URLQueryItem(name: "url", value: url))
         if let owners = owners {
@@ -151,7 +150,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/v3/classify",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: headerParameters,
             acceptType: "application/json",
             queryItems: queryParameters
@@ -193,7 +192,6 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct header parameters
@@ -231,7 +229,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/v3/classify",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: headerParameters,
             acceptType: "application/json",
             contentType: multipartFormData.contentType,
@@ -266,7 +264,6 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
         queryParameters.append(URLQueryItem(name: "url", value: url))
 
@@ -274,7 +271,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/v3/detect_faces",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             queryItems: queryParameters
@@ -306,7 +303,6 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct body
@@ -321,7 +317,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/v3/detect_faces",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: multipartFormData.contentType,
@@ -353,7 +349,6 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
         queryParameters.append(URLQueryItem(name: "verbose", value: "true"))
 
@@ -361,7 +356,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/v3/classifiers",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             queryItems: queryParameters
@@ -422,7 +417,6 @@ public class VisualRecognition {
 
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // encode name as data
@@ -451,7 +445,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/v3/classifiers",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: multipartFormData.contentType,
@@ -483,14 +477,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "DELETE",
             url: serviceURL + "/v3/classifiers/\(classifierID)",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             queryItems: queryParameters
         )
@@ -524,14 +517,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/v3/classifiers/\(classifierID)",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             queryItems: queryParameters
         )
@@ -577,7 +569,6 @@ public class VisualRecognition {
 
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct body
@@ -601,7 +592,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/v3/classifiers/\(classifierID)",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: multipartFormData.contentType,
@@ -637,7 +628,6 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         //construct body
@@ -653,7 +643,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/v3/collections",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: multipartFormData.contentType,
@@ -684,14 +674,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/v3/collections",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             queryItems: queryParameters
@@ -722,14 +711,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/v3/collections/\(collectionID)",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             queryItems: queryParameters
         )
@@ -759,14 +747,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "DELETE",
             url: serviceURL + "/v3/collections/\(collectionID)",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             queryItems: queryParameters
         )
@@ -812,7 +799,6 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         //construct body
@@ -830,7 +816,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/v3/collections/\(collectionID)/images",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: multipartFormData.contentType,
@@ -864,14 +850,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/v3/collections/\(collectionID)/images",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             queryItems: queryParameters
         )
@@ -903,14 +888,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/v3/collections/\(collectionID)/images/\(imageID)",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             queryItems: queryParameters
         )
@@ -942,14 +926,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "DELETE",
             url: serviceURL + "/v3/collections/\(collectionID)/images/\(imageID)",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             queryItems: queryParameters
         )
@@ -985,14 +968,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "DELETE",
             url: serviceURL + "/v3/collections/\(collectionID)/images/\(imageID)/metadata",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             queryItems: queryParameters
         )
@@ -1028,14 +1010,13 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         // construct REST request
         let request = RestRequest(
             method: "GET",
             url: serviceURL + "/v3/collections/\(collectionID)/images/\(imageID)/metadata",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             queryItems: queryParameters
         )
@@ -1070,7 +1051,6 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         //construct body
@@ -1085,7 +1065,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "PUT",
             url: serviceURL + "/v3/collections/\(collectionID)/images/\(imageID)/metadata",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: multipartFormData.contentType,
@@ -1124,7 +1104,6 @@ public class VisualRecognition {
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "api_key", value: apiKey))
         queryParameters.append(URLQueryItem(name: "version", value: version))
 
         //construct body
@@ -1139,7 +1118,7 @@ public class VisualRecognition {
         let request = RestRequest(
             method: "POST",
             url: serviceURL + "/v3/collections/\(collectionID)/find_similar",
-            credentials: .apiKey,
+            credentials: credentials,
             headerParameters: defaultHeaders,
             acceptType: "application/json",
             contentType: multipartFormData.contentType,

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -4364,7 +4364,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint lint --config ${PROJECT_DIR}/.swiftlint.yml --no-cache --path Source/RestKit\n    swiftlint lint --config ${PROJECT_DIR}/.swiftlint.yml --no-cache --path Test/RestKitTests\nelse\n    echo \"SwiftLint is not available. Install SwiftLint to obtain linter results. See https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint lint --config ${PROJECT_DIR}/.swiftlint.yml --no-cache --path Source/RestKit\n    swiftlint lint --config ${PROJECT_DIR}/.swiftlint.yml --no-cache --path Tests/RestKitTests\nelse\n    echo \"SwiftLint is not available. Install SwiftLint to obtain linter results. See https://github.com/realm/SwiftLint\"\nfi";
 		};
 		CAEC7A671FE961C7002EF4FD /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
This pull request allows RestKit to manage API keys.

### Notes

- The API key implementation is inspired by the [Swagger definition for api keys](https://swagger.io/docs/specification/2-0/authentication/api-keys/).
(API keys must specify `in: .header` or `in: .query` and the `name` of the parameter.)
- I updated services using API keys to ensure that the tests pass, although that code will all be removed soon. 🔥
- We should consider the behavior of `RestRequest` to be _undefined_ when there are conflicting parameters with the same name.
  - Example: Passing `Credentials.apiKey(name: "x-api-key", key: "foo", in: .header)` and `headerParameters["x-api-key"] = "bar"` would conflict. So it is _undefined_ whether the x-api-key header parameter will be set to foo or bar.
  - The implementation happens to prefer the credentials when there is a conflict. But we shouldn't leak this through the interface or rely on it in our SDK.
  - It would be preferable if the type system could prevent a conflict. But I don't think that's possible unless we remove the convenience of setting credentials, accept types, and content types with `RestRequest.init`.