### PR TITLE
Collect coverage info in run_tests and add script to upload coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ branches:
     - master
 env:
   global:
-    - IOS_SDK="iphonesimulator"
-    - IOS_DESTINATION="OS=11.2,name=iPhone 7"
+    - DESTINATION="OS=11.2,name=iPhone 7"
 before_install:
   - openssl aes-256-cbc -K $encrypted_0a18e1be1a16_key -iv $encrypted_0a18e1be1a16_iv -in Source/SupportingFiles/Credentials.swift.enc -out Source/SupportingFiles/Credentials.swift -d
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./Scripts/run-tests.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./Scripts/upload-coverage.sh ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -y ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://swift.org/builds/swift-4.0.2-release/ubuntu1404/swift-4.0.2-RELEASE/swift-4.0.2-RELEASE-ubuntu14.04.tar.gz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xzvf swift-4.0.2-RELEASE-ubuntu14.04.tar.gz ; fi

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -8,7 +8,7 @@
 ####################
 
 # the device to build for
-DESTINATION="OS=11.2,name=iPhone 7"
+DESTINATION=${DESTINATION:-"OS=11.2,name=iPhone 7"}
 
 # the exit code of each build command
 EXIT_CODES=()
@@ -47,6 +47,17 @@ carthage bootstrap --platform iOS
 brew outdated swiftlint || brew upgrade swiftlint
 
 ####################
+# Setup
+####################
+
+# Xcode over-writes the coverage info with each build, so we create a directory
+# where we accumulate all the coverage files
+BUILD_ROOT=$(xcodebuild -showBuildSettings | grep '\<BUILD_ROOT\>' | awk '{print $3}')
+COVERAGE_DIR=$BUILD_ROOT/../Coverage
+rm -rf $COVERAGE_DIR
+mkdir $COVERAGE_DIR
+
+####################
 # Build and Test
 ####################
 
@@ -57,9 +68,24 @@ set -o pipefail
 
 # build each scheme
 for SCHEME in ${SCHEMES[@]}; do
-	xcodebuild -scheme "$SCHEME" -destination "$DESTINATION" test | xcpretty
+	xcodebuild -scheme "$SCHEME" -destination "$DESTINATION" -enableCodeCoverage YES test | xcpretty
 	EXIT_CODES+=($?)
+	PROF_DIR=$(dirname $(find $BUILD_ROOT/.. -name Coverage.profdata))
+	cp $PROF_DIR/*.profraw $COVERAGE_DIR
 done
+
+####################
+# Create a composite coverage report
+####################
+
+xcrun llvm-profdata merge -sparse $(ls $COVERAGE_DIR/*.profraw) -o $COVERAGE_DIR/Coverage.profdata
+
+FRAMEWORKS=$(ls -d $BUILD_ROOT/Debug-iphonesimulator/*.framework)
+BINARIES=$(echo $FRAMEWORKS | sed 's/\(\([A-Za-z0-9]*\).framework\)/\1\/\2/g' | sed 's/ / -object /g')
+
+xcrun llvm-cov show -instr-profile $COVERAGE_DIR/Coverage.profdata $BINARIES > $COVERAGE_DIR/Coverage.txt
+
+# Composite coverage report in $COVERAGE_DIR/Coverage.txt"
 
 ####################
 # Set Exit Code

--- a/Scripts/upload-coverage.sh
+++ b/Scripts/upload-coverage.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script uploads the consolidated code coverage report for the Swift SDK.
+
+# Note: to upload a coverage report, set the CODECOV_TOKEN environment variable
+#    export CODECOV_TOKEN=<codecov token>
+
+if [ -z "$CODECOV_TOKEN" ]; then
+	echo "Set the CODECOV_TOKEN environment variable with the codecov.io access token" 
+	exit 1
+fi
+
+BUILD_ROOT=$(xcodebuild -showBuildSettings | grep '\<BUILD_ROOT\>' | awk '{print $3}')
+
+COVERAGE_DIR=$BUILD_ROOT/../Coverage
+
+if [ ! -e "$COVERAGE_DIR/Coverage.txt" ]; then
+	echo "No coverage report found.  Execute the run_tests.sh script to create a coverage report"
+	exit 1
+fi
+
+bash <(curl -s https://codecov.io/bash) -f $COVERAGE_DIR/Coverage.txt
+


### PR DESCRIPTION
This PR adds logic in the run_tests script to collect the coverage information from each of the services and create a consolidated coverage report for the whole SDK.  A separate script was created to upload this consolidated coverage report to codecov.io.  Finally, the Travis config file was updated to run the upload script after run_tests so that coverage is automatically published for every Travis build.