### PR TITLE
Add minor fixes

### DIFF
--- a/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
@@ -14,14 +14,15 @@
  * limitations under the License.
  **/
 
+#if os(iOS) || os(tvOS) || os(watchOS)
+
 import Foundation
+import UIKit
 
 // This extension adds convenience methods for using `UIImage`. The comments and interface were copied from
 // `VisualRecognition.swift`, then modified to use `UIImage` instead of `URL`. Some parameters were also
 // removed or modified because they are not necessary in this context (e.g. `imagesFileContentType`).
 
-#if os(Linux)
-#else
 extension VisualRecognition {
 
     /**
@@ -146,4 +147,5 @@ extension VisualRecognition {
         return file
     }
 }
+
 #endif

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -132,7 +132,6 @@ class ToneAnalyzerTests: XCTestCase {
     func testToneChat() {
         let expectation = self.expectation(description: "Tone chat.")
         toneAnalyzer.toneChat(utterances: utterances, acceptLanguage: "en", failure: failWithError) { analyses in
-            print(analyses)
             expectation.fulfill()
         }
         waitForExpectations()

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
@@ -16,11 +16,11 @@
 
 // swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
 
-#if os(Linux)
-#else
+#if os(iOS) || os(tvOS) || os(watchOS)
 
 import XCTest
 import Foundation
+import UIKit
 import VisualRecognitionV3
 
 class VisualRecognitionUIImageTests: XCTestCase {


### PR DESCRIPTION
This pull request adds some minor fixes.

- [x] Remove an extraneous print statement from `testToneChat`.
- [x] Update the `UIImage` extension and tests for Visual Recognition to import `UIKit` (which includes `UIImage`) when using a supported platform (iOS, tvOS, or watchOS).

The changes for `UIKit` are required for compatibility with the Swift Package Manager:
- The `UIKit` import was implicit on iOS, but it's good to make it explicit.
- `UIKit` (and `UIImage` by extension) are not actually supported on macOS. So instead of excluding Linux we should include iOS, tvOS, and watchOS platforms.