### PR TITLE
Update publishing-release.md

### DIFF
--- a/docs/publishing-release.md
+++ b/docs/publishing-release.md
@@ -5,31 +5,29 @@ The following tasks should be completed before publishing a release. Track the p
 - [ ] Review and merge any outstanding pull requests.
 - [ ] Review any oustanding issues assigned to this release milestone.
 
-#### Source Changes
+#### Publishing a New Service
+
+- [ ] Add service to `README.md`
+- [ ] Add service to `Package.swift`
+- [ ] Add service to `generate-documentation.md` script
+- [ ] Add service to `run-tests.sh` script
+- [ ] Add service credentials to `Credentials.swift` and `CredentialsExample.swift`
+- [ ] Upload encrypted `Credentials.swift` to Travis (see [encrypt-credentials.md](encrypt-credentials.md))
+
+#### Source Code and Tests
 
 - [ ] Update the `sdkVersion` property in `RestRequest.swift`.
-- [ ] Add any new targets/services to `Package.swift`.
-
-#### Tests and Verification
-
-- [ ] Run all tests to verify correctness. Fix any errors.
-- [ ] Update `.travis.yml` for any new targets/services.
-- [ ] Encrypt `Credentials.swift` to support any new targets/services with Travis.
-- [ ] If changes were made to Speech to Text, then test continuous streaming support on a physical device.
+- [ ] Test all services and fix any errors.
+- [ ] Test continuous streaming with Speech to Text on a physical device.
 
 #### Documentation
 
-- [ ] Update the `generate-documentation.sh` script for any new targets/services.
-- [ ] Execute the `generate-documentation.sh` script to update the API documentation.
-- [ ] Update the `docs/index.html` page to add any new services and/or change the date. Consider opening an issue to automate this. 
-- [ ] Check `undocumented.json` for any missing documentation comments. Make the necessary changes then re-run the `generate-documentation.sh` script.
-- [ ] Update `CHANGELOG.md`.
 - [ ] Update `README.md`.
+- [ ] Update `CHANGELOG.md`.
+- [ ] Execute the `generate-documentation.sh` script to update the API documentation. If `undocumented.json` shows any missing documentation comments, be sure to add them then re-run the script.
 
 #### Publish Release
 
 - [ ] Use Github to create a tag/release.
 - [ ] Execute the `generate-binaries.sh` script to build and archive frameworks into a `WatsonDeveloperCloud.framework.zip` file. Then attach `WatsonDeveloperCloud.framework.zip` to the GitHub release.
 - [ ] Test that Carthage successfully builds each service's framework.
-- [ ] Test that the documentation badge includes the service(s) added, if any.
-- [ ] Celebrate the team's hard work! :)


### PR DESCRIPTION
This pull request updates the `publishing-release.md` document.

- [x] Collect tasks for a new service into a single heading.
- [x] Remove step to update `docs/index.html` since it's generated by `generate-documentation.sh`.
- [x] Rearrange a few tasks to make the list easier to follow.
- [x] Tighten up some of the wording.

(Note: We have an open issue to automate the process of publishing a new release.)