### PR TITLE
Fix created/updated dates in Assistant service

### DIFF
--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -102,6 +102,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -120,9 +125,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -160,6 +163,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (WorkspaceCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -189,8 +196,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + "/v1/workspaces",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -226,6 +232,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -235,9 +246,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + "/v1/workspaces",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -272,6 +281,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (WorkspaceExport) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -294,8 +307,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -335,6 +347,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -353,9 +370,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -385,6 +400,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -399,8 +418,7 @@ public class Assistant {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -442,6 +460,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (IntentCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -480,8 +502,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -523,6 +544,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -537,9 +563,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -576,6 +600,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (IntentExport) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -598,8 +626,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -644,6 +671,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -658,9 +690,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -692,6 +722,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -706,8 +740,7 @@ public class Assistant {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -748,6 +781,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ExampleCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -782,8 +819,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -823,6 +859,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -837,9 +878,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -875,6 +914,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Example) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -893,8 +936,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -936,6 +978,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -950,9 +997,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -986,6 +1031,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1000,8 +1049,7 @@ public class Assistant {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1040,6 +1088,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (CounterexampleCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1074,8 +1126,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1113,6 +1164,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1127,9 +1183,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1163,6 +1217,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Counterexample) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1181,8 +1239,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1222,6 +1279,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1236,9 +1298,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1270,6 +1330,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1284,8 +1348,7 @@ public class Assistant {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1327,6 +1390,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (EntityCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1365,8 +1432,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1403,6 +1469,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1417,9 +1488,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1456,6 +1525,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (EntityExport) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1478,8 +1551,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1519,6 +1591,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1533,9 +1610,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1567,6 +1642,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1581,8 +1660,7 @@ public class Assistant {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1625,6 +1703,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ValueCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1663,8 +1745,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1703,6 +1784,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1717,9 +1803,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1757,6 +1841,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ValueExport) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1779,8 +1867,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1822,6 +1909,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1836,9 +1928,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1872,6 +1962,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1886,8 +1980,7 @@ public class Assistant {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -1930,6 +2023,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (SynonymCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1964,8 +2061,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -2007,6 +2103,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2021,9 +2122,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -2061,6 +2160,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Synonym) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2079,8 +2182,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -2124,6 +2226,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2138,9 +2245,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -2176,6 +2281,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2190,8 +2299,7 @@ public class Assistant {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -2230,6 +2338,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (DialogNodeCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2264,8 +2376,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -2302,6 +2413,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2316,9 +2432,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -2352,6 +2466,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (DialogNode) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2370,8 +2488,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -2410,6 +2527,11 @@ public class Assistant {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2424,9 +2546,7 @@ public class Assistant {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -2458,6 +2578,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2472,8 +2596,7 @@ public class Assistant {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -2511,6 +2634,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (LogCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2541,8 +2668,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 
@@ -2578,6 +2704,10 @@ public class Assistant {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (LogCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2600,8 +2730,7 @@ public class Assistant {
             method: "GET",
             url: serviceURL + "/v1/logs",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters
         )
 

--- a/Source/AssistantV1/Models/Context.swift
+++ b/Source/AssistantV1/Models/Context.swift
@@ -20,10 +20,10 @@ import Foundation
 public struct Context {
 
     /// The unique identifier of the conversation.
-    public var conversationID: String
+    public var conversationID: String?
 
     /// For internal use only.
-    public var system: SystemResponse
+    public var system: SystemResponse?
 
     /// Additional properties associated with this model.
     public var additionalProperties: [String: JSON]
@@ -36,7 +36,7 @@ public struct Context {
 
      - returns: An initialized `Context`.
     */
-    public init(conversationID: String, system: SystemResponse, additionalProperties: [String: JSON] = [:]) {
+    public init(conversationID: String? = nil, system: SystemResponse? = nil, additionalProperties: [String: JSON] = [:]) {
         self.conversationID = conversationID
         self.system = system
         self.additionalProperties = additionalProperties
@@ -53,16 +53,16 @@ extension Context: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        conversationID = try container.decode(String.self, forKey: .conversationID)
-        system = try container.decode(SystemResponse.self, forKey: .system)
+        conversationID = try container.decodeIfPresent(String.self, forKey: .conversationID)
+        system = try container.decodeIfPresent(SystemResponse.self, forKey: .system)
         let dynamicContainer = try decoder.container(keyedBy: DynamicKeys.self)
         additionalProperties = try dynamicContainer.decode([String: JSON].self, excluding: CodingKeys.allValues)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(conversationID, forKey: .conversationID)
-        try container.encode(system, forKey: .system)
+        try container.encodeIfPresent(conversationID, forKey: .conversationID)
+        try container.encodeIfPresent(system, forKey: .system)
         var dynamicContainer = encoder.container(keyedBy: DynamicKeys.self)
         try dynamicContainer.encodeIfPresent(additionalProperties)
     }

--- a/Source/AssistantV1/Models/Counterexample.swift
+++ b/Source/AssistantV1/Models/Counterexample.swift
@@ -23,10 +23,10 @@ public struct Counterexample {
     public var text: String
 
     /// The timestamp for creation of the counterexample.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the counterexample.
-    public var updated: String
+    public var updated: String?
 
     /**
      Initialize a `Counterexample` with member variables.
@@ -37,7 +37,7 @@ public struct Counterexample {
 
      - returns: An initialized `Counterexample`.
     */
-    public init(text: String, created: String, updated: String) {
+    public init(text: String, created: String? = nil, updated: String? = nil) {
         self.text = text
         self.created = created
         self.updated = updated
@@ -56,15 +56,15 @@ extension Counterexample: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         text = try container.decode(String.self, forKey: .text)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(text, forKey: .text)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
     }
 
 }

--- a/Source/AssistantV1/Models/DialogNode.swift
+++ b/Source/AssistantV1/Models/DialogNode.swift
@@ -90,10 +90,10 @@ public struct DialogNode {
     public var nextStep: DialogNodeNextStep?
 
     /// The timestamp for creation of the dialog node.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the most recent update to the dialog node.
-    public var updated: String
+    public var updated: String?
 
     /// The actions for the dialog node.
     public var actions: [DialogNodeAction]?
@@ -123,8 +123,6 @@ public struct DialogNode {
      Initialize a `DialogNode` with member variables.
 
      - parameter dialogNodeID: The dialog node ID.
-     - parameter created: The timestamp for creation of the dialog node.
-     - parameter updated: The timestamp for the most recent update to the dialog node.
      - parameter description: The description of the dialog node.
      - parameter conditions: The condition that triggers the dialog node.
      - parameter parent: The ID of the parent dialog node. This property is not returned if the dialog node has no parent.
@@ -133,6 +131,8 @@ public struct DialogNode {
      - parameter context: The context (if defined) for the dialog node.
      - parameter metadata: Any metadata for the dialog node.
      - parameter nextStep: The next step to execute following this dialog node.
+     - parameter created: The timestamp for creation of the dialog node.
+     - parameter updated: The timestamp for the most recent update to the dialog node.
      - parameter actions: The actions for the dialog node.
      - parameter title: The alias used to identify the dialog node.
      - parameter nodeType: How the dialog node is processed.
@@ -144,10 +144,8 @@ public struct DialogNode {
 
      - returns: An initialized `DialogNode`.
     */
-    public init(dialogNodeID: String, created: String, updated: String, description: String? = nil, conditions: String? = nil, parent: String? = nil, previousSibling: String? = nil, output: [String: JSON]? = nil, context: [String: JSON]? = nil, metadata: [String: JSON]? = nil, nextStep: DialogNodeNextStep? = nil, actions: [DialogNodeAction]? = nil, title: String? = nil, nodeType: String? = nil, eventName: String? = nil, variable: String? = nil, digressIn: String? = nil, digressOut: String? = nil, digressOutSlots: String? = nil) {
+    public init(dialogNodeID: String, description: String? = nil, conditions: String? = nil, parent: String? = nil, previousSibling: String? = nil, output: [String: JSON]? = nil, context: [String: JSON]? = nil, metadata: [String: JSON]? = nil, nextStep: DialogNodeNextStep? = nil, created: String? = nil, updated: String? = nil, actions: [DialogNodeAction]? = nil, title: String? = nil, nodeType: String? = nil, eventName: String? = nil, variable: String? = nil, digressIn: String? = nil, digressOut: String? = nil, digressOutSlots: String? = nil) {
         self.dialogNodeID = dialogNodeID
-        self.created = created
-        self.updated = updated
         self.description = description
         self.conditions = conditions
         self.parent = parent
@@ -156,6 +154,8 @@ public struct DialogNode {
         self.context = context
         self.metadata = metadata
         self.nextStep = nextStep
+        self.created = created
+        self.updated = updated
         self.actions = actions
         self.title = title
         self.nodeType = nodeType
@@ -203,8 +203,8 @@ extension DialogNode: Codable {
         context = try container.decodeIfPresent([String: JSON].self, forKey: .context)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
         nextStep = try container.decodeIfPresent(DialogNodeNextStep.self, forKey: .nextStep)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         actions = try container.decodeIfPresent([DialogNodeAction].self, forKey: .actions)
         title = try container.decodeIfPresent(String.self, forKey: .title)
         nodeType = try container.decodeIfPresent(String.self, forKey: .nodeType)
@@ -226,8 +226,8 @@ extension DialogNode: Codable {
         try container.encodeIfPresent(context, forKey: .context)
         try container.encodeIfPresent(metadata, forKey: .metadata)
         try container.encodeIfPresent(nextStep, forKey: .nextStep)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(actions, forKey: .actions)
         try container.encodeIfPresent(title, forKey: .title)
         try container.encodeIfPresent(nodeType, forKey: .nodeType)

--- a/Source/AssistantV1/Models/Entity.swift
+++ b/Source/AssistantV1/Models/Entity.swift
@@ -23,10 +23,10 @@ public struct Entity {
     public var entityName: String
 
     /// The timestamp for creation of the entity.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the entity.
-    public var updated: String
+    public var updated: String?
 
     /// The description of the entity.
     public var description: String?
@@ -49,7 +49,7 @@ public struct Entity {
 
      - returns: An initialized `Entity`.
     */
-    public init(entityName: String, created: String, updated: String, description: String? = nil, metadata: [String: JSON]? = nil, fuzzyMatch: Bool? = nil) {
+    public init(entityName: String, created: String? = nil, updated: String? = nil, description: String? = nil, metadata: [String: JSON]? = nil, fuzzyMatch: Bool? = nil) {
         self.entityName = entityName
         self.created = created
         self.updated = updated
@@ -74,8 +74,8 @@ extension Entity: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         entityName = try container.decode(String.self, forKey: .entityName)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
         fuzzyMatch = try container.decodeIfPresent(Bool.self, forKey: .fuzzyMatch)
@@ -84,8 +84,8 @@ extension Entity: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(entityName, forKey: .entityName)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(metadata, forKey: .metadata)
         try container.encodeIfPresent(fuzzyMatch, forKey: .fuzzyMatch)

--- a/Source/AssistantV1/Models/EntityExport.swift
+++ b/Source/AssistantV1/Models/EntityExport.swift
@@ -23,10 +23,10 @@ public struct EntityExport {
     public var entityName: String
 
     /// The timestamp for creation of the entity.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the entity.
-    public var updated: String
+    public var updated: String?
 
     /// The description of the entity.
     public var description: String?
@@ -53,7 +53,7 @@ public struct EntityExport {
 
      - returns: An initialized `EntityExport`.
     */
-    public init(entityName: String, created: String, updated: String, description: String? = nil, metadata: [String: JSON]? = nil, fuzzyMatch: Bool? = nil, values: [ValueExport]? = nil) {
+    public init(entityName: String, created: String? = nil, updated: String? = nil, description: String? = nil, metadata: [String: JSON]? = nil, fuzzyMatch: Bool? = nil, values: [ValueExport]? = nil) {
         self.entityName = entityName
         self.created = created
         self.updated = updated
@@ -80,8 +80,8 @@ extension EntityExport: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         entityName = try container.decode(String.self, forKey: .entityName)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
         fuzzyMatch = try container.decodeIfPresent(Bool.self, forKey: .fuzzyMatch)
@@ -91,8 +91,8 @@ extension EntityExport: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(entityName, forKey: .entityName)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(metadata, forKey: .metadata)
         try container.encodeIfPresent(fuzzyMatch, forKey: .fuzzyMatch)

--- a/Source/AssistantV1/Models/Example.swift
+++ b/Source/AssistantV1/Models/Example.swift
@@ -23,10 +23,10 @@ public struct Example {
     public var exampleText: String
 
     /// The timestamp for creation of the example.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the example.
-    public var updated: String
+    public var updated: String?
 
     /**
      Initialize a `Example` with member variables.
@@ -37,7 +37,7 @@ public struct Example {
 
      - returns: An initialized `Example`.
     */
-    public init(exampleText: String, created: String, updated: String) {
+    public init(exampleText: String, created: String? = nil, updated: String? = nil) {
         self.exampleText = exampleText
         self.created = created
         self.updated = updated
@@ -56,15 +56,15 @@ extension Example: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         exampleText = try container.decode(String.self, forKey: .exampleText)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(exampleText, forKey: .exampleText)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
     }
 
 }

--- a/Source/AssistantV1/Models/Intent.swift
+++ b/Source/AssistantV1/Models/Intent.swift
@@ -23,10 +23,10 @@ public struct Intent {
     public var intentName: String
 
     /// The timestamp for creation of the intent.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the intent.
-    public var updated: String
+    public var updated: String?
 
     /// The description of the intent.
     public var description: String?
@@ -41,7 +41,7 @@ public struct Intent {
 
      - returns: An initialized `Intent`.
     */
-    public init(intentName: String, created: String, updated: String, description: String? = nil) {
+    public init(intentName: String, created: String? = nil, updated: String? = nil, description: String? = nil) {
         self.intentName = intentName
         self.created = created
         self.updated = updated
@@ -62,16 +62,16 @@ extension Intent: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         intentName = try container.decode(String.self, forKey: .intentName)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         description = try container.decodeIfPresent(String.self, forKey: .description)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(intentName, forKey: .intentName)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(description, forKey: .description)
     }
 

--- a/Source/AssistantV1/Models/IntentExport.swift
+++ b/Source/AssistantV1/Models/IntentExport.swift
@@ -23,10 +23,10 @@ public struct IntentExport {
     public var intentName: String
 
     /// The timestamp for creation of the intent.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the intent.
-    public var updated: String
+    public var updated: String?
 
     /// The description of the intent.
     public var description: String?
@@ -45,7 +45,7 @@ public struct IntentExport {
 
      - returns: An initialized `IntentExport`.
     */
-    public init(intentName: String, created: String, updated: String, description: String? = nil, examples: [Example]? = nil) {
+    public init(intentName: String, created: String? = nil, updated: String? = nil, description: String? = nil, examples: [Example]? = nil) {
         self.intentName = intentName
         self.created = created
         self.updated = updated
@@ -68,8 +68,8 @@ extension IntentExport: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         intentName = try container.decode(String.self, forKey: .intentName)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         examples = try container.decodeIfPresent([Example].self, forKey: .examples)
     }
@@ -77,8 +77,8 @@ extension IntentExport: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(intentName, forKey: .intentName)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(examples, forKey: .examples)
     }

--- a/Source/AssistantV1/Models/Synonym.swift
+++ b/Source/AssistantV1/Models/Synonym.swift
@@ -23,10 +23,10 @@ public struct Synonym {
     public var synonymText: String
 
     /// The timestamp for creation of the synonym.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the most recent update to the synonym.
-    public var updated: String
+    public var updated: String?
 
     /**
      Initialize a `Synonym` with member variables.
@@ -37,7 +37,7 @@ public struct Synonym {
 
      - returns: An initialized `Synonym`.
     */
-    public init(synonymText: String, created: String, updated: String) {
+    public init(synonymText: String, created: String? = nil, updated: String? = nil) {
         self.synonymText = synonymText
         self.created = created
         self.updated = updated
@@ -56,15 +56,15 @@ extension Synonym: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         synonymText = try container.decode(String.self, forKey: .synonymText)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(synonymText, forKey: .synonymText)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
     }
 
 }

--- a/Source/AssistantV1/Models/Value.swift
+++ b/Source/AssistantV1/Models/Value.swift
@@ -32,10 +32,10 @@ public struct Value {
     public var metadata: [String: JSON]?
 
     /// The timestamp for creation of the entity value.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the entity value.
-    public var updated: String
+    public var updated: String?
 
     /// An array containing any synonyms for the entity value.
     public var synonyms: [String]?
@@ -50,21 +50,21 @@ public struct Value {
      Initialize a `Value` with member variables.
 
      - parameter valueText: The text of the entity value.
-     - parameter created: The timestamp for creation of the entity value.
-     - parameter updated: The timestamp for the last update to the entity value.
      - parameter valueType: Specifies the type of value.
      - parameter metadata: Any metadata related to the entity value.
+     - parameter created: The timestamp for creation of the entity value.
+     - parameter updated: The timestamp for the last update to the entity value.
      - parameter synonyms: An array containing any synonyms for the entity value.
      - parameter patterns: An array containing any patterns for the entity value.
 
      - returns: An initialized `Value`.
     */
-    public init(valueText: String, created: String, updated: String, valueType: String, metadata: [String: JSON]? = nil, synonyms: [String]? = nil, patterns: [String]? = nil) {
+    public init(valueText: String, valueType: String, metadata: [String: JSON]? = nil, created: String? = nil, updated: String? = nil, synonyms: [String]? = nil, patterns: [String]? = nil) {
         self.valueText = valueText
-        self.created = created
-        self.updated = updated
         self.valueType = valueType
         self.metadata = metadata
+        self.created = created
+        self.updated = updated
         self.synonyms = synonyms
         self.patterns = patterns
     }
@@ -87,8 +87,8 @@ extension Value: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         valueText = try container.decode(String.self, forKey: .valueText)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         synonyms = try container.decodeIfPresent([String].self, forKey: .synonyms)
         patterns = try container.decodeIfPresent([String].self, forKey: .patterns)
         valueType = try container.decode(String.self, forKey: .valueType)
@@ -98,8 +98,8 @@ extension Value: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(valueText, forKey: .valueText)
         try container.encodeIfPresent(metadata, forKey: .metadata)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(synonyms, forKey: .synonyms)
         try container.encodeIfPresent(patterns, forKey: .patterns)
         try container.encode(valueType, forKey: .valueType)

--- a/Source/AssistantV1/Models/ValueExport.swift
+++ b/Source/AssistantV1/Models/ValueExport.swift
@@ -32,10 +32,10 @@ public struct ValueExport {
     public var metadata: [String: JSON]?
 
     /// The timestamp for creation of the entity value.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the entity value.
-    public var updated: String
+    public var updated: String?
 
     /// An array containing any synonyms for the entity value.
     public var synonyms: [String]?
@@ -50,21 +50,21 @@ public struct ValueExport {
      Initialize a `ValueExport` with member variables.
 
      - parameter valueText: The text of the entity value.
-     - parameter created: The timestamp for creation of the entity value.
-     - parameter updated: The timestamp for the last update to the entity value.
      - parameter valueType: Specifies the type of value.
      - parameter metadata: Any metadata related to the entity value.
+     - parameter created: The timestamp for creation of the entity value.
+     - parameter updated: The timestamp for the last update to the entity value.
      - parameter synonyms: An array containing any synonyms for the entity value.
      - parameter patterns: An array containing any patterns for the entity value.
 
      - returns: An initialized `ValueExport`.
     */
-    public init(valueText: String, created: String, updated: String, valueType: String, metadata: [String: JSON]? = nil, synonyms: [String]? = nil, patterns: [String]? = nil) {
+    public init(valueText: String, valueType: String, metadata: [String: JSON]? = nil, created: String? = nil, updated: String? = nil, synonyms: [String]? = nil, patterns: [String]? = nil) {
         self.valueText = valueText
-        self.created = created
-        self.updated = updated
         self.valueType = valueType
         self.metadata = metadata
+        self.created = created
+        self.updated = updated
         self.synonyms = synonyms
         self.patterns = patterns
     }
@@ -87,8 +87,8 @@ extension ValueExport: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         valueText = try container.decode(String.self, forKey: .valueText)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         synonyms = try container.decodeIfPresent([String].self, forKey: .synonyms)
         patterns = try container.decodeIfPresent([String].self, forKey: .patterns)
         valueType = try container.decode(String.self, forKey: .valueType)
@@ -98,8 +98,8 @@ extension ValueExport: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(valueText, forKey: .valueText)
         try container.encodeIfPresent(metadata, forKey: .metadata)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(synonyms, forKey: .synonyms)
         try container.encodeIfPresent(patterns, forKey: .patterns)
         try container.encode(valueType, forKey: .valueType)

--- a/Source/AssistantV1/Models/Workspace.swift
+++ b/Source/AssistantV1/Models/Workspace.swift
@@ -26,10 +26,10 @@ public struct Workspace {
     public var language: String
 
     /// The timestamp for creation of the workspace.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the workspace.
-    public var updated: String
+    public var updated: String?
 
     /// The workspace ID.
     public var workspaceID: String
@@ -48,21 +48,21 @@ public struct Workspace {
 
      - parameter name: The name of the workspace.
      - parameter language: The language of the workspace.
+     - parameter workspaceID: The workspace ID.
      - parameter created: The timestamp for creation of the workspace.
      - parameter updated: The timestamp for the last update to the workspace.
-     - parameter workspaceID: The workspace ID.
      - parameter description: The description of the workspace.
      - parameter metadata: Any metadata related to the workspace.
      - parameter learningOptOut: Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
 
      - returns: An initialized `Workspace`.
     */
-    public init(name: String, language: String, created: String, updated: String, workspaceID: String, description: String? = nil, metadata: [String: JSON]? = nil, learningOptOut: Bool? = nil) {
+    public init(name: String, language: String, workspaceID: String, created: String? = nil, updated: String? = nil, description: String? = nil, metadata: [String: JSON]? = nil, learningOptOut: Bool? = nil) {
         self.name = name
         self.language = language
+        self.workspaceID = workspaceID
         self.created = created
         self.updated = updated
-        self.workspaceID = workspaceID
         self.description = description
         self.metadata = metadata
         self.learningOptOut = learningOptOut
@@ -87,8 +87,8 @@ extension Workspace: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
         language = try container.decode(String.self, forKey: .language)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         workspaceID = try container.decode(String.self, forKey: .workspaceID)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
@@ -99,8 +99,8 @@ extension Workspace: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
         try container.encode(language, forKey: .language)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encode(workspaceID, forKey: .workspaceID)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(metadata, forKey: .metadata)

--- a/Source/AssistantV1/Models/WorkspaceExport.swift
+++ b/Source/AssistantV1/Models/WorkspaceExport.swift
@@ -41,10 +41,10 @@ public struct WorkspaceExport {
     public var metadata: [String: JSON]
 
     /// The timestamp for creation of the workspace.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the workspace.
-    public var updated: String
+    public var updated: String?
 
     /// The workspace ID.
     public var workspaceID: String
@@ -74,11 +74,11 @@ public struct WorkspaceExport {
      - parameter description: The description of the workspace.
      - parameter language: The language of the workspace.
      - parameter metadata: Any metadata that is required by the workspace.
-     - parameter created: The timestamp for creation of the workspace.
-     - parameter updated: The timestamp for the last update to the workspace.
      - parameter workspaceID: The workspace ID.
      - parameter status: The current status of the workspace.
      - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+     - parameter created: The timestamp for creation of the workspace.
+     - parameter updated: The timestamp for the last update to the workspace.
      - parameter intents: An array of intents.
      - parameter entities: An array of entities.
      - parameter counterexamples: An array of counterexamples.
@@ -86,16 +86,16 @@ public struct WorkspaceExport {
 
      - returns: An initialized `WorkspaceExport`.
     */
-    public init(name: String, description: String, language: String, metadata: [String: JSON], created: String, updated: String, workspaceID: String, status: String, learningOptOut: Bool, intents: [IntentExport]? = nil, entities: [EntityExport]? = nil, counterexamples: [Counterexample]? = nil, dialogNodes: [DialogNode]? = nil) {
+    public init(name: String, description: String, language: String, metadata: [String: JSON], workspaceID: String, status: String, learningOptOut: Bool, created: String? = nil, updated: String? = nil, intents: [IntentExport]? = nil, entities: [EntityExport]? = nil, counterexamples: [Counterexample]? = nil, dialogNodes: [DialogNode]? = nil) {
         self.name = name
         self.description = description
         self.language = language
         self.metadata = metadata
-        self.created = created
-        self.updated = updated
         self.workspaceID = workspaceID
         self.status = status
         self.learningOptOut = learningOptOut
+        self.created = created
+        self.updated = updated
         self.intents = intents
         self.entities = entities
         self.counterexamples = counterexamples
@@ -128,8 +128,8 @@ extension WorkspaceExport: Codable {
         description = try container.decode(String.self, forKey: .description)
         language = try container.decode(String.self, forKey: .language)
         metadata = try container.decode([String: JSON].self, forKey: .metadata)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         workspaceID = try container.decode(String.self, forKey: .workspaceID)
         status = try container.decode(String.self, forKey: .status)
         learningOptOut = try container.decode(Bool.self, forKey: .learningOptOut)
@@ -145,8 +145,8 @@ extension WorkspaceExport: Codable {
         try container.encode(description, forKey: .description)
         try container.encode(language, forKey: .language)
         try container.encode(metadata, forKey: .metadata)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encode(workspaceID, forKey: .workspaceID)
         try container.encode(status, forKey: .status)
         try container.encode(learningOptOut, forKey: .learningOptOut)

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -96,7 +96,7 @@ class AssistantTests: XCTestCase {
     func instantiateAssistant() {
         let username = Credentials.AssistantUsername
         let password = Credentials.AssistantPassword
-        let version = "2017-05-26"
+        let version = "2018-02-16"
         assistant = Assistant(username: username, password: password, version: version)
         assistant.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         assistant.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -144,8 +144,8 @@ class AssistantTests: XCTestCase {
             XCTAssertNotNil(response.context.conversationID)
             XCTAssertNotEqual(response.context.conversationID, "")
             XCTAssertNotNil(response.context.system)
-            XCTAssertNotNil(response.context.system.additionalProperties)
-            XCTAssertFalse(response.context.system.additionalProperties.isEmpty)
+            XCTAssertNotNil(response.context.system!.additionalProperties)
+            XCTAssertFalse(response.context.system!.additionalProperties.isEmpty)
 
             // verify entities
             XCTAssertTrue(response.entities.isEmpty)
@@ -185,8 +185,8 @@ class AssistantTests: XCTestCase {
             // verify context
             XCTAssertEqual(response.context.conversationID, context!.conversationID)
             XCTAssertNotNil(response.context.system)
-            XCTAssertNotNil(response.context.system.additionalProperties)
-            XCTAssertFalse(response.context.system.additionalProperties.isEmpty)
+            XCTAssertNotNil(response.context.system!.additionalProperties)
+            XCTAssertFalse(response.context.system!.additionalProperties.isEmpty)
 
             // verify entities
             XCTAssertEqual(response.entities.count, 1)

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -452,8 +452,6 @@ class AssistantTests: XCTestCase {
             XCTAssertEqual(workspace.name, workspaceName)
             XCTAssertEqual(workspace.description, workspaceDescription)
             XCTAssertEqual(workspace.language, workspaceLanguage)
-            XCTAssertNotNil(workspace.created)
-            XCTAssertNotNil(workspace.updated)
             XCTAssertNotNil(workspace.workspaceID)
 
             newWorkspace = workspace.workspaceID
@@ -548,8 +546,6 @@ class AssistantTests: XCTestCase {
             XCTAssertEqual(workspace.name, workspaceName)
             XCTAssertEqual(workspace.description, workspaceDescription)
             XCTAssertEqual(workspace.language, workspaceLanguage)
-            XCTAssertNotNil(workspace.created)
-            XCTAssertNotNil(workspace.updated)
             XCTAssertNotNil(workspace.workspaceID)
 
             newWorkspace = workspace.workspaceID
@@ -572,8 +568,6 @@ class AssistantTests: XCTestCase {
             XCTAssertEqual(workspace.name, newWorkspaceName)
             XCTAssertEqual(workspace.description, newWorkspaceDescription)
             XCTAssertEqual(workspace.language, workspaceLanguage)
-            XCTAssertNotNil(workspace.created)
-            XCTAssertNotNil(workspace.updated)
             XCTAssertNotNil(workspace.workspaceID)
             expectation2.fulfill()
         }
@@ -688,8 +682,6 @@ class AssistantTests: XCTestCase {
         assistant.createIntent(workspaceID: workspaceID, intent: newIntentName, description: newIntentDescription, examples: [example1, example2], failure: failWithError) { intent in
             XCTAssertEqual(intent.intentName, newIntentName)
             XCTAssertEqual(intent.description, newIntentDescription)
-            XCTAssertNotNil(intent.created)
-            XCTAssertNotNil(intent.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -733,8 +725,6 @@ class AssistantTests: XCTestCase {
         assistant.createIntent(workspaceID: workspaceID, intent: newIntentName, description: newIntentDescription, examples: [example1, example2], failure: failWithError) { intent in
             XCTAssertEqual(intent.intentName, newIntentName)
             XCTAssertEqual(intent.description, newIntentDescription)
-            XCTAssertNotNil(intent.created)
-            XCTAssertNotNil(intent.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -748,8 +738,6 @@ class AssistantTests: XCTestCase {
         assistant.updateIntent(workspaceID: workspaceID, intent: newIntentName, newIntent: updatedIntentName, newDescription: updatedIntentDescription, newExamples: [updatedExample1], failure: failWithError) { intent in
             XCTAssertEqual(intent.intentName, updatedIntentName)
             XCTAssertEqual(intent.description, updatedIntentDescription)
-            XCTAssertNotNil(intent.created)
-            XCTAssertNotNil(intent.updated)
             expectation2.fulfill()
         }
         waitForExpectations()
@@ -828,8 +816,6 @@ class AssistantTests: XCTestCase {
 
         let newExample = "swift-sdk-test-example" + UUID().uuidString
         assistant.createExample(workspaceID: workspaceID, intent: "weather", text: newExample, failure: failWithError) { example in
-            XCTAssertNotNil(example.created)
-            XCTAssertNotNil(example.updated)
             XCTAssertEqual(example.exampleText, newExample)
             expectation.fulfill()
         }
@@ -954,8 +940,6 @@ class AssistantTests: XCTestCase {
 
         let newExample = "swift-sdk-test-counterexample" + UUID().uuidString
         assistant.createCounterexample(workspaceID: workspaceID, text: newExample, failure: failWithError) { counterexample in
-            XCTAssertNotNil(counterexample.created)
-            XCTAssertNotNil(counterexample.updated)
             XCTAssertNotNil(counterexample.text)
             expectation.fulfill()
         }
@@ -1107,8 +1091,6 @@ class AssistantTests: XCTestCase {
         assistant.createEntity(workspaceID: workspaceID, properties: entity, failure: failWithError){ entityResponse in
             XCTAssertEqual(entityResponse.entityName, entityName)
             XCTAssertEqual(entityResponse.description, entityDescription)
-            XCTAssertNotNil(entityResponse.created)
-            XCTAssertNotNil(entityResponse.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -1133,8 +1115,6 @@ class AssistantTests: XCTestCase {
         assistant.createEntity(workspaceID: workspaceID, properties: entity, failure: failWithError){ entityResponse in
             XCTAssertEqual(entityResponse.entityName, entityName)
             XCTAssertEqual(entityResponse.description, entityDescription)
-            XCTAssertNotNil(entityResponse.created)
-            XCTAssertNotNil(entityResponse.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -1148,8 +1128,6 @@ class AssistantTests: XCTestCase {
         assistant.updateEntity(workspaceID: workspaceID, entity: entityName, properties: updatedEntity, failure: failWithError){ entityResponse in
             XCTAssertEqual(entityResponse.entityName, updatedEntityName)
             XCTAssertEqual(entityResponse.description, updatedEntityDescription)
-            XCTAssertNotNil(entityResponse.created)
-            XCTAssertNotNil(entityResponse.updated)
             expectationTwo.fulfill()
         }
         waitForExpectations()
@@ -1217,8 +1195,6 @@ class AssistantTests: XCTestCase {
         let value = CreateValue(value: valueName)
         assistant.createValue(workspaceID: workspaceID, entity: entityName, properties: value, failure: failWithError) { value in
             XCTAssertEqual(value.valueText, valueName)
-            XCTAssertNotNil(value.created)
-            XCTAssertNotNil(value.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -1230,8 +1206,6 @@ class AssistantTests: XCTestCase {
         let updatedValue = UpdateValue(value: updatedValueName, metadata: ["oldname": .string(valueName)])
         assistant.updateValue(workspaceID: workspaceID, entity: entityName, value: valueName, properties: updatedValue, failure: failWithError) { value in
             XCTAssertEqual(value.valueText, updatedValueName)
-            XCTAssertNotNil(value.created)
-            XCTAssertNotNil(value.updated)
             XCTAssertNotNil(value.metadata)
             expectationTwo.fulfill()
         }
@@ -1330,8 +1304,6 @@ class AssistantTests: XCTestCase {
 
         let newSynonym = "swift-sdk-test-synonym" + UUID().uuidString
         assistant.createSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym, failure: failWithError) { synonym in
-            XCTAssertNotNil(synonym.created)
-            XCTAssertNotNil(synonym.updated)
             XCTAssertEqual(synonym.synonymText, newSynonym)
             expectation.fulfill()
         }

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -375,7 +375,7 @@ class AssistantTests: XCTestCase {
         let description = "List all workspaces."
         let expectation = self.expectation(description: description)
 
-        assistant.listWorkspaces(failure: failWithError) { workspaceResponse in
+        assistant.listWorkspaces(includeAudit: true, failure: failWithError) { workspaceResponse in
             for workspace in workspaceResponse.workspaces {
                 XCTAssertNotNil(workspace.name)
                 XCTAssertNotNil(workspace.created)
@@ -393,7 +393,7 @@ class AssistantTests: XCTestCase {
         let description = "List all workspaces with page limit specified as 1."
         let expectation = self.expectation(description: description)
 
-        assistant.listWorkspaces(pageLimit: 1, failure: failWithError) { workspaceResponse in
+        assistant.listWorkspaces(pageLimit: 1, includeAudit: true, failure: failWithError) { workspaceResponse in
             XCTAssertEqual(workspaceResponse.workspaces.count, 1)
             for workspace in workspaceResponse.workspaces {
                 XCTAssertNotNil(workspace.name)
@@ -413,7 +413,7 @@ class AssistantTests: XCTestCase {
         let description = "List all workspaces with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        assistant.listWorkspaces(includeCount: true, failure: failWithError) { workspaceResponse in
+        assistant.listWorkspaces(includeCount: true, includeAudit: true, failure: failWithError) { workspaceResponse in
             for workspace in workspaceResponse.workspaces {
                 XCTAssertNotNil(workspace.name)
                 XCTAssertNotNil(workspace.created)
@@ -469,7 +469,7 @@ class AssistantTests: XCTestCase {
         let description2 = "Get the newly created workspace."
         let expectation2 = expectation(description: description2)
 
-        assistant.getWorkspace(workspaceID: newWorkspaceID, export: true, failure: failWithError) { workspace in
+        assistant.getWorkspace(workspaceID: newWorkspaceID, export: true, includeAudit: true, failure: failWithError) { workspace in
             XCTAssertEqual(workspace.name, workspaceName)
             XCTAssertEqual(workspace.description, workspaceDescription)
             XCTAssertEqual(workspace.language, workspaceLanguage)
@@ -517,7 +517,7 @@ class AssistantTests: XCTestCase {
         let description = "List details of a single workspace."
         let expectation = self.expectation(description: description)
 
-        assistant.getWorkspace(workspaceID: workspaceID, export: false, failure: failWithError) { workspace in
+        assistant.getWorkspace(workspaceID: workspaceID, export: false, includeAudit: true, failure: failWithError) { workspace in
             XCTAssertNotNil(workspace.name)
             XCTAssertNotNil(workspace.created)
             XCTAssertNotNil(workspace.updated)
@@ -594,7 +594,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the intents in a workspace."
         let expectation = self.expectation(description: description)
 
-        assistant.listIntents(workspaceID: workspaceID, failure: failWithError) { intents in
+        assistant.listIntents(workspaceID: workspaceID, includeAudit: true, failure: failWithError) { intents in
             for intent in intents.intents {
                 XCTAssertNotNil(intent.intentName)
                 XCTAssertNotNil(intent.created)
@@ -614,7 +614,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the intents in a workspace with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        assistant.listIntents(workspaceID: workspaceID, includeCount: true, failure: failWithError) { intents in
+        assistant.listIntents(workspaceID: workspaceID, includeCount: true, includeAudit: true, failure: failWithError) { intents in
             for intent in intents.intents {
                 XCTAssertNotNil(intent.intentName)
                 XCTAssertNotNil(intent.created)
@@ -635,7 +635,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the intents in a workspace with pageLimit specified as 1."
         let expectation = self.expectation(description: description)
 
-        assistant.listIntents(workspaceID: workspaceID, pageLimit: 1, failure: failWithError) { intents in
+        assistant.listIntents(workspaceID: workspaceID, pageLimit: 1, includeAudit: true, failure: failWithError) { intents in
             XCTAssertEqual(intents.intents.count, 1)
             for intent in intents.intents {
                 XCTAssertNotNil(intent.intentName)
@@ -656,7 +656,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the intents in a workspace with export as true."
         let expectation = self.expectation(description: description)
 
-        assistant.listIntents(workspaceID: workspaceID, export: true, failure: failWithError) { intents in
+        assistant.listIntents(workspaceID: workspaceID, export: true, includeAudit: true, failure: failWithError) { intents in
             for intent in intents.intents {
                 XCTAssertNotNil(intent.intentName)
                 XCTAssertNotNil(intent.created)
@@ -707,7 +707,7 @@ class AssistantTests: XCTestCase {
         let description = "Get details of a specific intent."
         let expectation = self.expectation(description: description)
 
-        assistant.getIntent(workspaceID: workspaceID, intent: "weather", export: true, failure: failWithError) { intent in
+        assistant.getIntent(workspaceID: workspaceID, intent: "weather", export: true, includeAudit: true, failure: failWithError) { intent in
             XCTAssertNotNil(intent.intentName)
             XCTAssertNotNil(intent.created)
             XCTAssertNotNil(intent.updated)
@@ -769,7 +769,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the examples of an intent."
         let expectation = self.expectation(description: description)
 
-        assistant.listExamples(workspaceID: workspaceID, intent: "weather", failure: failWithError) { examples in
+        assistant.listExamples(workspaceID: workspaceID, intent: "weather", includeAudit: true, failure: failWithError) { examples in
             for example in examples.examples {
                 XCTAssertNotNil(example.created)
                 XCTAssertNotNil(example.updated)
@@ -787,7 +787,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the examples for an intent with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        assistant.listExamples(workspaceID: workspaceID, intent: "weather", includeCount: true, failure: failWithError) { examples in
+        assistant.listExamples(workspaceID: workspaceID, intent: "weather", includeCount: true, includeAudit: true, failure: failWithError) { examples in
             for example in examples.examples {
                 XCTAssertNotNil(example.created)
                 XCTAssertNotNil(example.updated)
@@ -806,7 +806,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the examples for an intent with pageLimit specified as 1."
         let expectation = self.expectation(description: description)
 
-        assistant.listExamples(workspaceID: workspaceID, intent: "weather", pageLimit: 1, failure: failWithError) { examples in
+        assistant.listExamples(workspaceID: workspaceID, intent: "weather", pageLimit: 1, includeAudit: true, failure: failWithError) { examples in
             XCTAssertEqual(examples.examples.count, 1)
             for example in examples.examples {
                 XCTAssertNotNil(example.created)
@@ -849,7 +849,7 @@ class AssistantTests: XCTestCase {
         let expectation = self.expectation(description: description)
 
         let exampleText = "tell me the weather"
-        assistant.getExample(workspaceID: workspaceID, intent: "weather", text: exampleText, failure: failWithError) { example in
+        assistant.getExample(workspaceID: workspaceID, intent: "weather", text: exampleText, includeAudit: true, failure: failWithError) { example in
             XCTAssertNotNil(example.created)
             XCTAssertNotNil(example.updated)
             XCTAssertEqual(example.exampleText, exampleText)
@@ -864,8 +864,6 @@ class AssistantTests: XCTestCase {
 
         let newExample = "swift-sdk-test-example" + UUID().uuidString
         assistant.createExample(workspaceID: workspaceID, intent: "weather", text: newExample, failure: failWithError) { example in
-            XCTAssertNotNil(example.created)
-            XCTAssertNotNil(example.updated)
             XCTAssertEqual(example.exampleText, newExample)
             expectation.fulfill()
         }
@@ -876,8 +874,6 @@ class AssistantTests: XCTestCase {
 
         let updatedText = "updated-" + newExample
         assistant.updateExample(workspaceID: workspaceID, intent: "weather", text: newExample, newText: updatedText, failure: failWithError) { example in
-            XCTAssertNotNil(example.created)
-            XCTAssertNotNil(example.updated)
             XCTAssertEqual(example.exampleText, updatedText)
             expectation2.fulfill()
         }
@@ -898,7 +894,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the counterexamples of a workspace."
         let expectation = self.expectation(description: description)
 
-        assistant.listCounterexamples(workspaceID: workspaceID, failure: failWithError) { counterexamples in
+        assistant.listCounterexamples(workspaceID: workspaceID, includeAudit: true, failure: failWithError) { counterexamples in
             for counterexample in counterexamples.counterexamples {
                 XCTAssertNotNil(counterexample.created)
                 XCTAssertNotNil(counterexample.updated)
@@ -917,7 +913,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the counterexamples of a workspace with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        assistant.listCounterexamples(workspaceID: workspaceID, includeCount: true, failure: failWithError) { counterexamples in
+        assistant.listCounterexamples(workspaceID: workspaceID, includeCount: true, includeAudit: true, failure: failWithError) { counterexamples in
             for counterexample in counterexamples.counterexamples {
                 XCTAssertNotNil(counterexample.created)
                 XCTAssertNotNil(counterexample.updated)
@@ -937,7 +933,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the counterexamples of a workspace with pageLimit specified as 1."
         let expectation = self.expectation(description: description)
 
-        assistant.listCounterexamples(workspaceID: workspaceID, pageLimit: 1, failure: failWithError) { counterexamples in
+        assistant.listCounterexamples(workspaceID: workspaceID, pageLimit: 1, includeAudit: true, failure: failWithError) { counterexamples in
             for counterexample in counterexamples.counterexamples {
                 XCTAssertNotNil(counterexample.created)
                 XCTAssertNotNil(counterexample.updated)
@@ -979,7 +975,7 @@ class AssistantTests: XCTestCase {
         let expectation = self.expectation(description: description)
 
         let exampleText = "I want financial advice today."
-        assistant.getCounterexample(workspaceID: workspaceID, text: exampleText, failure: failWithError) { counterexample in
+        assistant.getCounterexample(workspaceID: workspaceID, text: exampleText, includeAudit: true, failure: failWithError) { counterexample in
             XCTAssertNotNil(counterexample.created)
             XCTAssertNotNil(counterexample.updated)
             XCTAssertEqual(counterexample.text, exampleText)
@@ -994,8 +990,6 @@ class AssistantTests: XCTestCase {
 
         let newExample = "swift-sdk-test-counterexample" + UUID().uuidString
         assistant.createCounterexample(workspaceID: workspaceID, text: newExample, failure: failWithError) { counterexample in
-            XCTAssertNotNil(counterexample.created)
-            XCTAssertNotNil(counterexample.updated)
             XCTAssertEqual(counterexample.text, newExample)
             expectation.fulfill()
         }
@@ -1006,8 +1000,6 @@ class AssistantTests: XCTestCase {
 
         let updatedText = "updated-"+newExample
         assistant.updateCounterexample(workspaceID: workspaceID, text: newExample, newText: updatedText, failure: failWithError) { counterexample in
-            XCTAssertNotNil(counterexample.created)
-            XCTAssertNotNil(counterexample.updated)
             XCTAssertEqual(counterexample.text, updatedText)
             expectation2.fulfill()
         }
@@ -1028,7 +1020,7 @@ class AssistantTests: XCTestCase {
         let description = "List all entities"
         let expectation = self.expectation(description: description)
 
-        assistant.listEntities(workspaceID: workspaceID, failure: failWithError){entities in
+        assistant.listEntities(workspaceID: workspaceID, includeAudit: true, failure: failWithError){entities in
             for entity in entities.entities {
                 XCTAssertNotNil(entity.entityName)
                 XCTAssertNotNil(entity.created)
@@ -1048,7 +1040,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the entities in a workspace with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        assistant.listEntities(workspaceID: workspaceID, includeCount: true, failure: failWithError) { entities in
+        assistant.listEntities(workspaceID: workspaceID, includeCount: true, includeAudit: true, failure: failWithError) { entities in
             for entity in entities.entities {
                 XCTAssertNotNil(entity.entityName)
                 XCTAssertNotNil(entity.created)
@@ -1068,7 +1060,7 @@ class AssistantTests: XCTestCase {
         let description = "List all entities with page limit 1"
         let expectation = self.expectation(description: description)
 
-        assistant.listEntities(workspaceID: workspaceID, pageLimit: 1, failure: failWithError){entities in
+        assistant.listEntities(workspaceID: workspaceID, pageLimit: 1, includeAudit: true, failure: failWithError){entities in
             for entity in entities.entities {
                 XCTAssertNotNil(entity.entityName)
                 XCTAssertNotNil(entity.created)
@@ -1089,7 +1081,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the entities in a workspace with export as true."
         let expectation = self.expectation(description: description)
 
-        assistant.listEntities(workspaceID: workspaceID, export: true, failure: failWithError) { entities in
+        assistant.listEntities(workspaceID: workspaceID, export: true, includeAudit: true, failure: failWithError) { entities in
             for entity in entities.entities {
                 XCTAssertNotNil(entity.entityName)
                 XCTAssertNotNil(entity.created)
@@ -1178,7 +1170,7 @@ class AssistantTests: XCTestCase {
         assistant.listEntities(workspaceID: workspaceID, failure: failWithError) {entityCollection in
             XCTAssert(entityCollection.entities.count > 0)
             let entity = entityCollection.entities[0]
-            self.assistant.getEntity(workspaceID: self.workspaceID, entity: entity.entityName, export: true, failure: self.failWithError) { entityExport in
+            self.assistant.getEntity(workspaceID: self.workspaceID, entity: entity.entityName, export: true, includeAudit: true, failure: self.failWithError) { entityExport in
                 XCTAssertEqual(entityExport.entityName, entity.entityName)
                 XCTAssertEqual(entityExport.description, entity.description)
                 XCTAssertNotNil(entityExport.created)
@@ -1200,6 +1192,7 @@ class AssistantTests: XCTestCase {
             entity: entityName,
             export: true,
             includeCount: true,
+            includeAudit: true,
             failure: failWithError) {
                 valueCollection in
                 for value in valueCollection.values {
@@ -1262,7 +1255,7 @@ class AssistantTests: XCTestCase {
         assistant.listValues(workspaceID: workspaceID, entity: entityName, failure: failWithError) { valueCollection in
             XCTAssert(valueCollection.values.count > 0)
             let value = valueCollection.values[0]
-            self.assistant.getValue(workspaceID: self.workspaceID, entity: entityName, value: value.valueText, export: true, failure: self.failWithError) { valueExport in
+            self.assistant.getValue(workspaceID: self.workspaceID, entity: entityName, value: value.valueText, export: true, includeAudit: true, failure: self.failWithError) { valueExport in
                 XCTAssertEqual(valueExport.valueText, value.valueText)
                 XCTAssertNotNil(valueExport.created)
                 XCTAssertNotNil(valueExport.updated)
@@ -1278,7 +1271,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the synonyms for an entity and value."
         let expectation = self.expectation(description: description)
 
-        assistant.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", failure: failWithError) { synonyms in
+        assistant.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", includeAudit: true, failure: failWithError) { synonyms in
             for synonym in synonyms.synonyms {
                 XCTAssertNotNil(synonym.created)
                 XCTAssertNotNil(synonym.updated)
@@ -1296,7 +1289,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the synonyms for an entity and value with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        assistant.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", includeCount: true, failure: failWithError) { synonyms in
+        assistant.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", includeCount: true, includeAudit: true, failure: failWithError) { synonyms in
             for synonym in synonyms.synonyms {
                 XCTAssertNotNil(synonym.created)
                 XCTAssertNotNil(synonym.updated)
@@ -1315,7 +1308,7 @@ class AssistantTests: XCTestCase {
         let description = "List all the synonyms for an entity and value with pageLimit specified as 1."
         let expectation = self.expectation(description: description)
 
-        assistant.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", pageLimit: 1, failure: failWithError) { synonyms in
+        assistant.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", pageLimit: 1, includeAudit: true, failure: failWithError) { synonyms in
             XCTAssertEqual(synonyms.synonyms.count, 1)
             for synonym in synonyms.synonyms {
                 XCTAssertNotNil(synonym.created)
@@ -1358,7 +1351,7 @@ class AssistantTests: XCTestCase {
         let expectation = self.expectation(description: description)
 
         let synonymName = "headlight"
-        assistant.getSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: synonymName, failure: failWithError) { synonym in
+        assistant.getSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: synonymName, includeAudit: true, failure: failWithError) { synonym in
             XCTAssertEqual(synonym.synonymText, synonymName)
             XCTAssertNotNil(synonym.created)
             XCTAssertNotNil(synonym.updated)
@@ -1373,8 +1366,6 @@ class AssistantTests: XCTestCase {
 
         let newSynonym = "swift-sdk-test-synonym" + UUID().uuidString
         assistant.createSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym, failure: failWithError) { synonym in
-            XCTAssertNotNil(synonym.created)
-            XCTAssertNotNil(synonym.updated)
             XCTAssertEqual(synonym.synonymText, newSynonym)
             expectation.fulfill()
         }
@@ -1385,8 +1376,6 @@ class AssistantTests: XCTestCase {
 
         let updatedSynonym = "new-" + newSynonym
         assistant.updateSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym, newSynonym: updatedSynonym, failure: failWithError){ synonym in
-            XCTAssertNotNil(synonym.created)
-            XCTAssertNotNil(synonym.updated)
             XCTAssertEqual(synonym.synonymText, updatedSynonym)
             expectation2.fulfill()
         }


### PR DESCRIPTION
This pull request defines the `created` and `updated` properties to be optional. This is consistent with the `2018-02-16` release of the Assistant service.

The tests also pass when the service date is set to `2017-05-26`.