### PR TITLE
Fix created/updated dates in Conversation service

### DIFF
--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -103,6 +103,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -121,9 +126,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -161,6 +164,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (WorkspaceCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -190,11 +197,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + "/v1/workspaces",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -229,6 +233,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -238,9 +247,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + "/v1/workspaces",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -275,6 +282,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (WorkspaceExport) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -297,11 +308,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -340,6 +348,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -358,9 +371,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -390,6 +401,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -404,11 +419,8 @@ public class Conversation {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -449,6 +461,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (IntentCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -487,11 +503,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -532,6 +545,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -546,9 +564,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -585,6 +601,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (IntentExport) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -607,11 +627,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -655,6 +672,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -669,9 +691,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -703,6 +723,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -717,11 +741,8 @@ public class Conversation {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -761,6 +782,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ExampleCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -795,11 +820,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -838,6 +860,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -852,9 +879,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -890,6 +915,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Example) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -908,11 +937,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -953,6 +979,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -967,9 +998,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1003,6 +1032,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1017,11 +1050,8 @@ public class Conversation {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1059,6 +1089,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (CounterexampleCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1093,11 +1127,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1134,6 +1165,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1148,9 +1184,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1184,6 +1218,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Counterexample) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1202,11 +1240,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1245,6 +1280,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1259,9 +1299,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1293,6 +1331,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1307,11 +1349,8 @@ public class Conversation {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1352,6 +1391,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (EntityCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1390,11 +1433,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1430,6 +1470,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1444,9 +1489,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1483,6 +1526,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (EntityExport) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1505,11 +1552,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1548,6 +1592,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1562,9 +1611,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1596,6 +1643,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1610,11 +1661,8 @@ public class Conversation {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1656,6 +1704,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ValueCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1694,11 +1746,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1736,6 +1785,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1750,9 +1804,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1790,6 +1842,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ValueExport) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1812,11 +1868,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1857,6 +1910,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1871,9 +1929,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -1907,6 +1963,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -1921,11 +1981,8 @@ public class Conversation {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -1967,6 +2024,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (SynonymCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2001,11 +2062,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -2046,6 +2104,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2060,9 +2123,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -2100,6 +2161,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Synonym) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2118,11 +2183,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -2165,6 +2227,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2179,9 +2246,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -2217,6 +2282,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2231,11 +2300,8 @@ public class Conversation {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -2273,6 +2339,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (DialogNodeCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2307,11 +2377,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -2347,6 +2414,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2361,9 +2433,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -2397,6 +2467,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (DialogNode) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2415,11 +2489,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -2457,6 +2528,11 @@ public class Conversation {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2471,9 +2547,7 @@ public class Conversation {
             method: "POST",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -2505,6 +2579,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2519,11 +2597,8 @@ public class Conversation {
             method: "DELETE",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -2560,6 +2635,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (LogCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2590,11 +2669,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + encodedPath,
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request
@@ -2629,6 +2705,10 @@ public class Conversation {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (LogCollection) -> Void)
     {
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -2651,11 +2731,8 @@ public class Conversation {
             method: "GET",
             url: serviceURL + "/v1/logs",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: nil,
-            queryItems: queryParameters,
-            messageBody: nil
+            headerParameters: headers,
+            queryItems: queryParameters
         )
 
         // execute REST request

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -148,6 +148,7 @@ public class Conversation {
      - parameter includeCount: Whether to include information about the number of records returned.
      - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the last object from the previous page of results.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -156,6 +157,7 @@ public class Conversation {
         includeCount: Bool? = nil,
         sort: String? = nil,
         cursor: String? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (WorkspaceCollection) -> Void)
     {
@@ -176,6 +178,10 @@ public class Conversation {
         }
         if let cursor = cursor {
             let queryParameter = URLQueryItem(name: "cursor", value: cursor)
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -258,12 +264,14 @@ public class Conversation {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
     public func getWorkspace(
         workspaceID: String,
         export: Bool? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (WorkspaceExport) -> Void)
     {
@@ -272,6 +280,10 @@ public class Conversation {
         queryParameters.append(URLQueryItem(name: "version", value: version))
         if let export = export {
             let queryParameter = URLQueryItem(name: "export", value: "\(export)")
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -422,6 +434,7 @@ public class Conversation {
      - parameter includeCount: Whether to include information about the number of records returned.
      - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the last object from the previous page of results.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -432,6 +445,7 @@ public class Conversation {
         includeCount: Bool? = nil,
         sort: String? = nil,
         cursor: String? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (IntentCollection) -> Void)
     {
@@ -456,6 +470,10 @@ public class Conversation {
         }
         if let cursor = cursor {
             let queryParameter = URLQueryItem(name: "cursor", value: cursor)
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -555,6 +573,7 @@ public class Conversation {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter intent: The intent name.
      - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -562,6 +581,7 @@ public class Conversation {
         workspaceID: String,
         intent: String,
         export: Bool? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (IntentExport) -> Void)
     {
@@ -570,6 +590,10 @@ public class Conversation {
         queryParameters.append(URLQueryItem(name: "version", value: version))
         if let export = export {
             let queryParameter = URLQueryItem(name: "export", value: "\(export)")
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -722,6 +746,7 @@ public class Conversation {
      - parameter includeCount: Whether to include information about the number of records returned.
      - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the last object from the previous page of results.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -732,6 +757,7 @@ public class Conversation {
         includeCount: Bool? = nil,
         sort: String? = nil,
         cursor: String? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ExampleCollection) -> Void)
     {
@@ -752,6 +778,10 @@ public class Conversation {
         }
         if let cursor = cursor {
             let queryParameter = URLQueryItem(name: "cursor", value: cursor)
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -848,6 +878,7 @@ public class Conversation {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter intent: The intent name.
      - parameter text: The text of the user input example.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -855,12 +886,17 @@ public class Conversation {
         workspaceID: String,
         intent: String,
         text: String,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Example) -> Void)
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
+            queryParameters.append(queryParameter)
+        }
 
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
@@ -1009,6 +1045,7 @@ public class Conversation {
      - parameter includeCount: Whether to include information about the number of records returned.
      - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the last object from the previous page of results.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1018,6 +1055,7 @@ public class Conversation {
         includeCount: Bool? = nil,
         sort: String? = nil,
         cursor: String? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (CounterexampleCollection) -> Void)
     {
@@ -1038,6 +1076,10 @@ public class Conversation {
         }
         if let cursor = cursor {
             let queryParameter = URLQueryItem(name: "cursor", value: cursor)
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -1131,18 +1173,24 @@ public class Conversation {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter text: The text of a user input counterexample (for example, `What are you wearing?`).
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
     public func getCounterexample(
         workspaceID: String,
         text: String,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Counterexample) -> Void)
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
+            queryParameters.append(queryParameter)
+        }
 
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
@@ -1289,6 +1337,7 @@ public class Conversation {
      - parameter includeCount: Whether to include information about the number of records returned.
      - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the last object from the previous page of results.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1299,6 +1348,7 @@ public class Conversation {
         includeCount: Bool? = nil,
         sort: String? = nil,
         cursor: String? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (EntityCollection) -> Void)
     {
@@ -1323,6 +1373,10 @@ public class Conversation {
         }
         if let cursor = cursor {
             let queryParameter = URLQueryItem(name: "cursor", value: cursor)
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -1417,6 +1471,7 @@ public class Conversation {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1424,6 +1479,7 @@ public class Conversation {
         workspaceID: String,
         entity: String,
         export: Bool? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (EntityExport) -> Void)
     {
@@ -1432,6 +1488,10 @@ public class Conversation {
         queryParameters.append(URLQueryItem(name: "version", value: version))
         if let export = export {
             let queryParameter = URLQueryItem(name: "export", value: "\(export)")
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -1580,6 +1640,7 @@ public class Conversation {
      - parameter includeCount: Whether to include information about the number of records returned.
      - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the last object from the previous page of results.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1591,6 +1652,7 @@ public class Conversation {
         includeCount: Bool? = nil,
         sort: String? = nil,
         cursor: String? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ValueCollection) -> Void)
     {
@@ -1615,6 +1677,10 @@ public class Conversation {
         }
         if let cursor = cursor {
             let queryParameter = URLQueryItem(name: "cursor", value: cursor)
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -1711,6 +1777,7 @@ public class Conversation {
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
      - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1719,6 +1786,7 @@ public class Conversation {
         entity: String,
         value: String,
         export: Bool? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ValueExport) -> Void)
     {
@@ -1727,6 +1795,10 @@ public class Conversation {
         queryParameters.append(URLQueryItem(name: "version", value: version))
         if let export = export {
             let queryParameter = URLQueryItem(name: "export", value: "\(export)")
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -1879,6 +1951,7 @@ public class Conversation {
      - parameter includeCount: Whether to include information about the number of records returned.
      - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the last object from the previous page of results.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1890,6 +1963,7 @@ public class Conversation {
         includeCount: Bool? = nil,
         sort: String? = nil,
         cursor: String? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (SynonymCollection) -> Void)
     {
@@ -1910,6 +1984,10 @@ public class Conversation {
         }
         if let cursor = cursor {
             let queryParameter = URLQueryItem(name: "cursor", value: cursor)
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -2009,6 +2087,7 @@ public class Conversation {
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
      - parameter synonym: The text of the synonym.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -2017,12 +2096,17 @@ public class Conversation {
         entity: String,
         value: String,
         synonym: String,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Synonym) -> Void)
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
+            queryParameters.append(queryParameter)
+        }
 
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
@@ -2175,6 +2259,7 @@ public class Conversation {
      - parameter includeCount: Whether to include information about the number of records returned.
      - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the last object from the previous page of results.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -2184,6 +2269,7 @@ public class Conversation {
         includeCount: Bool? = nil,
         sort: String? = nil,
         cursor: String? = nil,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (DialogNodeCollection) -> Void)
     {
@@ -2204,6 +2290,10 @@ public class Conversation {
         }
         if let cursor = cursor {
             let queryParameter = URLQueryItem(name: "cursor", value: cursor)
+            queryParameters.append(queryParameter)
+        }
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
             queryParameters.append(queryParameter)
         }
 
@@ -2296,18 +2386,24 @@ public class Conversation {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter dialogNode: The dialog node ID (for example, `get_order`).
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
     public func getDialogNode(
         workspaceID: String,
         dialogNode: String,
+        includeAudit: Bool? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (DialogNode) -> Void)
     {
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
+        if let includeAudit = includeAudit {
+            let queryParameter = URLQueryItem(name: "include_audit", value: "\(includeAudit)")
+            queryParameters.append(queryParameter)
+        }
 
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -17,8 +17,8 @@
 import Foundation
 
 /**
-   The IBM Watson Conversation service combines machine learning, natural language understanding, and
-  integrated dialog tools to create conversation flows between your apps and your users.
+ The IBM Watson Conversation service combines machine learning, natural language understanding, and integrated dialog
+ tools to create conversation flows between your apps and your users.
  */
 @available(*, deprecated, message: "The IBM Watson Conversation service has been renamed to Assistant. Please use the `Assistant` class instead of `Conversation`. The `Conversation` class will be removed in a future release.")
 public class Conversation {
@@ -39,7 +39,7 @@ public class Conversation {
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date
-       in "YYYY-MM-DD" format.
+     in "YYYY-MM-DD" format.
      */
     public init(username: String, password: String, version: String) {
         self.credentials = .basicAuthentication(username: username, password: password)
@@ -82,10 +82,10 @@ public class Conversation {
     }
 
     /**
-     Get a response to a user's input.
+     Get a response to a user's input.    There is no rate limit for this operation.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter request: The user's input, with optional intents, entities, and other properties from the response.
+     - parameter request: The message to be sent. This includes the user's input, along with optional intents, entities, and context from the last response.
      - parameter nodesVisitedDetails: Whether to include additional diagnostic information about the dialog nodes that were visited during processing of the message.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -141,12 +141,13 @@ public class Conversation {
     /**
      List workspaces.
 
-     List the workspaces associated with a Conversation service instance.
+     List the workspaces associated with a Conversation service instance.    This operation is limited to 500 requests
+     per 30 minutes. For more information, see **Rate limiting**.
 
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
+     - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -203,9 +204,11 @@ public class Conversation {
     /**
      Create workspace.
 
-     Create a workspace based on component objects. You must provide workspace components defining the content of the new workspace.
+     Create a workspace based on component objects. You must provide workspace components defining the content of the
+     new workspace.    This operation is limited to 30 requests per 30 minutes. For more information, see **Rate
+     limiting**.
 
-     - parameter properties: Valid data defining the content of the new workspace.
+     - parameter properties: The content of the new workspace.    The maximum size for this data is 50MB. If you need to import a larger workspace, consider importing the workspace without intents and entities and then adding them separately.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -249,10 +252,12 @@ public class Conversation {
     /**
      Get information about a workspace.
 
-     Get information about a workspace, optionally including all workspace content.
+     Get information about a workspace, optionally including all workspace content.    With **export**=`false`, this
+     operation is limited to 6000 requests per 5 minutes. With **export**=`true`, the limit is 20 requests per 30
+     minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter export: Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -300,11 +305,13 @@ public class Conversation {
     /**
      Update workspace.
 
-     Update an existing workspace with new or modified data. You must provide component objects defining the content of the updated workspace.
+     Update an existing workspace with new or modified data. You must provide component objects defining the content of
+     the updated workspace.    This operation is limited to 30 request per 30 minutes. For more information, see **Rate
+     limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter properties: Valid data defining the new workspace content. Any elements included in the new data will completely replace the existing elements, including all subelements. Previously existing subelements are not retained unless they are included in the new data.
-     - parameter append: Specifies that the elements included in the request body are to be appended to the existing data in the workspace. The default value is `false`.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter properties: Valid data defining the new and updated workspace content.    The maximum size for this data is 50MB. If you need to import a larger amount of workspace data, consider importing components such as intents and entities using separate operations.
+     - parameter append: Whether the new data is to be appended to the existing data in the workspace. If **append**=`false`, elements included in the new data completely replace the corresponding existing elements, including all subelements. For example, if the new data includes **entities** and **append**=`false`, all existing entities in the workspace are discarded and replaced with the new entities.    If **append**=`true`, existing elements are preserved, and the new elements are added. If any elements in the new data collide with existing elements, the update request fails.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -359,9 +366,10 @@ public class Conversation {
     /**
      Delete workspace.
 
-     Delete a workspace from the service instance.
+     Delete a workspace from the service instance.    This operation is limited to 30 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -404,14 +412,16 @@ public class Conversation {
     /**
      List intents.
 
-     List the intents for a workspace.
+     List the intents for a workspace.    With **export**=`false`, this operation is limited to 2000 requests per 30
+     minutes. With **export**=`true`, the limit is 400 requests per 30 minutes. For more information, see **Rate
+     limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter export: Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -479,12 +489,13 @@ public class Conversation {
     /**
      Create intent.
 
-     Create a new intent.
+     Create a new intent.    This operation is limited to 2000 requests per 30 minutes. For more information, see **Rate
+     limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter intent: The name of the intent.
-     - parameter description: The description of the intent.
-     - parameter examples: An array of user input examples.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
+     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+     - parameter examples: An array of user input examples for the intent.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -537,11 +548,13 @@ public class Conversation {
     /**
      Get intent.
 
-     Get information about an intent, optionally including all intent content.
+     Get information about an intent, optionally including all intent content.    With **export**=`false`, this
+     operation is limited to 6000 requests per 5 minutes. With **export**=`true`, the limit is 400 requests per 30
+     minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter intent: The intent name (for example, `pizza_order`).
-     - parameter export: Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter intent: The intent name.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -590,11 +603,13 @@ public class Conversation {
     /**
      Update intent.
 
-     Update an existing intent with new or modified data. You must provide data defining the content of the updated intent.
+     Update an existing intent with new or modified data. You must provide component objects defining the content of the
+     updated intent.    This operation is limited to 2000 requests per 30 minutes. For more information, see **Rate
+     limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter intent: The intent name (for example, `pizza_order`).
-     - parameter newIntent: The name of the intent.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter intent: The intent name.
+     - parameter newIntent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
      - parameter newDescription: The description of the intent.
      - parameter newExamples: An array of user input examples for the intent.
      - parameter failure: A function executed if an error occurs.
@@ -650,10 +665,11 @@ public class Conversation {
     /**
      Delete intent.
 
-     Delete an intent from a workspace.
+     Delete an intent from a workspace.    This operation is limited to 2000 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter intent: The intent name (for example, `pizza_order`).
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter intent: The intent name.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -697,14 +713,15 @@ public class Conversation {
     /**
      List user input examples.
 
-     List the user input examples for an intent.
+     List the user input examples for an intent.    This operation is limited to 2500 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter intent: The intent name (for example, `pizza_order`).
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter intent: The intent name.
+     - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -768,11 +785,12 @@ public class Conversation {
     /**
      Create user input example.
 
-     Add a new user input example to an intent.
+     Add a new user input example to an intent.    This operation is limited to 1000 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter intent: The intent name (for example, `pizza_order`).
-     - parameter text: The text of a user input example.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter intent: The intent name.
+     - parameter text: The text of a user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -824,10 +842,11 @@ public class Conversation {
     /**
      Get user input example.
 
-     Get information about a user input example.
+     Get information about a user input example.    This operation is limited to 6000 requests per 5 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter intent: The intent name (for example, `pizza_order`).
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter intent: The intent name.
      - parameter text: The text of the user input example.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -873,12 +892,13 @@ public class Conversation {
     /**
      Update user input example.
 
-     Update the text of a user input example.
+     Update the text of a user input example.    This operation is limited to 1000 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter intent: The intent name (for example, `pizza_order`).
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter intent: The intent name.
      - parameter text: The text of the user input example.
-     - parameter newText: The text of the user input example.
+     - parameter newText: The text of the user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -931,10 +951,11 @@ public class Conversation {
     /**
      Delete user input example.
 
-     Delete a user input example from an intent.
+     Delete a user input example from an intent.    This operation is limited to 1000 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter intent: The intent name (for example, `pizza_order`).
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter intent: The intent name.
      - parameter text: The text of the user input example.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -981,12 +1002,13 @@ public class Conversation {
      List counterexamples.
 
      List the counterexamples for a workspace. Counterexamples are examples that have been marked as irrelevant input.
+     This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1050,9 +1072,10 @@ public class Conversation {
      Create counterexample.
 
      Add a new counterexample to a workspace. Counterexamples are examples that have been marked as irrelevant input.
+     This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter text: The text of a user input marked as irrelevant input.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters  - It cannot consist of only whitespace characters  - It must be no longer than 1024 characters.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1104,8 +1127,9 @@ public class Conversation {
      Get counterexample.
 
      Get information about a counterexample. Counterexamples are examples that have been marked as irrelevant input.
+     This operation is limited to 6000 requests per 5 minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter text: The text of a user input counterexample (for example, `What are you wearing?`).
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1151,10 +1175,11 @@ public class Conversation {
      Update counterexample.
 
      Update the text of a counterexample. Counterexamples are examples that have been marked as irrelevant input.
+     This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter text: The text of a user input counterexample (for example, `What are you wearing?`).
-     - parameter newText: The text of the example to be marked as irrelevant input.
+     - parameter newText: The text of a user input counterexample.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1207,8 +1232,9 @@ public class Conversation {
      Delete counterexample.
 
      Delete a counterexample from a workspace. Counterexamples are examples that have been marked as irrelevant input.
+     This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter text: The text of a user input counterexample (for example, `What are you wearing?`).
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1253,14 +1279,16 @@ public class Conversation {
     /**
      List entities.
 
-     List the entities for a workspace.
+     List the entities for a workspace.    With **export**=`false`, this operation is limited to 1000 requests per 30
+     minutes. With **export**=`true`, the limit is 200 requests per 30 minutes. For more information, see **Rate
+     limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter export: Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1328,10 +1356,11 @@ public class Conversation {
     /**
      Create entity.
 
-     Create a new entity.
+     Create a new entity.    This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate
+     limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter properties: A CreateEntity object defining the content of the new entity.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter properties: The content of the new entity.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1381,11 +1410,13 @@ public class Conversation {
     /**
      Get entity.
 
-     Get information about an entity, optionally including all entity content.
+     Get information about an entity, optionally including all entity content.    With **export**=`false`, this
+     operation is limited to 6000 requests per 5 minutes. With **export**=`true`, the limit is 200 requests per 30
+     minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter export: Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1434,11 +1465,13 @@ public class Conversation {
     /**
      Update entity.
 
-     Update an existing entity with new or modified data.
+     Update an existing entity with new or modified data. You must provide component objects defining the content of the
+     updated entity.    This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate
+     limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter properties: An UpdateEntity object defining the updated content of the entity.
+     - parameter properties: The updated content of the entity. Any elements included in the new data will completely replace the equivalent existing elements, including all subelements. (Previously existing subelements are not retained unless they are also included in the new data.) For example, if you update the values for an entity, the previously existing values are discarded and replaced with the new values specified in the update.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1489,9 +1522,10 @@ public class Conversation {
     /**
      Delete entity.
 
-     Delete an entity from a workspace.
+     Delete an entity from a workspace.    This operation is limited to 1000 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1536,15 +1570,16 @@ public class Conversation {
     /**
      List entity values.
 
-     List the values for an entity.
+     List the values for an entity.    This operation is limited to 2500 requests per 30 minutes. For more information,
+     see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter export: Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1613,11 +1648,12 @@ public class Conversation {
     /**
      Add entity value.
 
-     Create a new value for an entity.
+     Create a new value for an entity.    This operation is limited to 1000 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter properties: A CreateValue object defining the content of the new value for the entity.
+     - parameter properties: The new entity value.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1668,12 +1704,13 @@ public class Conversation {
     /**
      Get entity value.
 
-     Get information about an entity value.
+     Get information about an entity value.    This operation is limited to 6000 requests per 5 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
-     - parameter export: Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1723,12 +1760,14 @@ public class Conversation {
     /**
      Update entity value.
 
-     Update the content of a value for an entity.
+     Update an existing entity value with new or modified data. You must provide component objects defining the content
+     of the updated entity value.    This operation is limited to 1000 requests per 30 minutes. For more information,
+     see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
-     - parameter properties: An UpdateValue object defining the new content for value for the entity.
+     - parameter properties: The updated content of the entity value.    Any elements included in the new data will completely replace the equivalent existing elements, including all subelements. (Previously existing subelements are not retained unless they are also included in the new data.) For example, if you update the synonyms for an entity value, the previously existing synonyms are discarded and replaced with the new synonyms specified in the update.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1780,9 +1819,10 @@ public class Conversation {
     /**
      Delete entity value.
 
-     Delete a value for an entity.
+     Delete a value from an entity.    This operation is limited to 1000 requests per 30 minutes. For more information,
+     see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
      - parameter failure: A function executed if an error occurs.
@@ -1829,15 +1869,16 @@ public class Conversation {
     /**
      List entity value synonyms.
 
-     List the synonyms for an entity value.
+     List the synonyms for an entity value.    This operation is limited to 2500 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
+     - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1902,12 +1943,13 @@ public class Conversation {
     /**
      Add entity value synonym.
 
-     Add a new synonym to an entity value.
+     Add a new synonym to an entity value.    This operation is limited to 1000 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
-     - parameter synonym: The text of the synonym.
+     - parameter synonym: The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -1960,9 +2002,10 @@ public class Conversation {
     /**
      Get entity value synonym.
 
-     Get information about a synonym for an entity value.
+     Get information about a synonym of an entity value.    This operation is limited to 6000 requests per 5 minutes.
+     For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
      - parameter synonym: The text of the synonym.
@@ -2011,13 +2054,14 @@ public class Conversation {
     /**
      Update entity value synonym.
 
-     Update the information about a synonym for an entity value.
+     Update an existing entity value synonym with new text.    This operation is limited to 1000 requests per 30
+     minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
      - parameter synonym: The text of the synonym.
-     - parameter newSynonym: The text of the synonym.
+     - parameter newSynonym: The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -2071,9 +2115,10 @@ public class Conversation {
     /**
      Delete entity value synonym.
 
-     Delete a synonym for an entity value.
+     Delete a synonym from an entity value.    This operation is limited to 1000 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
      - parameter synonym: The text of the synonym.
@@ -2122,13 +2167,14 @@ public class Conversation {
     /**
      List dialog nodes.
 
-     List the dialog nodes in the workspace.
+     List the dialog nodes for a workspace.    This operation is limited to 2500 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -2191,9 +2237,10 @@ public class Conversation {
     /**
      Create dialog node.
 
-     Create a dialog node.
+     Create a new dialog node.    This operation is limited to 500 requests per 30 minutes. For more information, see
+     **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter properties: A CreateDialogNode object defining the content of the new dialog node.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2244,9 +2291,10 @@ public class Conversation {
     /**
      Get dialog node.
 
-     Get information about a dialog node.
+     Get information about a dialog node.    This operation is limited to 6000 requests per 5 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter dialogNode: The dialog node ID (for example, `get_order`).
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2291,11 +2339,12 @@ public class Conversation {
     /**
      Update dialog node.
 
-     Update information for a dialog node.
+     Update an existing dialog node with new or modified data.    This operation is limited to 500 requests per 30
+     minutes. For more information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter dialogNode: The dialog node ID (for example, `get_order`).
-     - parameter properties: An UpdateDialogNode object defining the new contents of the dialog node.
+     - parameter properties: The updated content of the dialog node.    Any elements included in the new data will completely replace the equivalent existing elements, including all subelements. (Previously existing subelements are not retained unless they are also included in the new data.) For example, if you update the actions for a dialog node, the previously existing actions are discarded and replaced with the new actions specified in the update.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -2346,9 +2395,10 @@ public class Conversation {
     /**
      Delete dialog node.
 
-     Delete a dialog node from the workspace.
+     Delete a dialog node from a workspace.    This operation is limited to 500 requests per 30 minutes. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: Unique identifier of the workspace.
      - parameter dialogNode: The dialog node ID (for example, `get_order`).
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2393,13 +2443,15 @@ public class Conversation {
     /**
      List log events in a workspace.
 
-     List log events in a specific workspace.
+     List the events from the log of a specific workspace.    If **cursor** is not specified, this operation is limited
+     to 40 requests per 30 minutes. If **cursor** is specified, the limit is 120 requests per minute. For more
+     information, see **Rate limiting**.
 
-     - parameter workspaceID: The workspace ID.
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
+     - parameter workspaceID: Unique identifier of the workspace.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. For more information, see the [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter pageLimit: The number of records to return in each page of results.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -2462,15 +2514,17 @@ public class Conversation {
     /**
      List log events in all workspaces.
 
-     List log events in all workspaces in the service instance.
+     List the events from the logs of all workspaces in the service instance.    If **cursor** is not specified, this
+     operation is limited to 40 requests per 30 minutes. If **cursor** is specified, the limit is 120 requests per
+     minute. For more information, see **Rate limiting**.
 
      - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. You must specify a filter query that includes a value for `language`, as well as a value for `workspace_id` or `request.context.metadata.deployment`. For more information, see the [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
-     - parameter sort: Sorts the response according to the value of the specified property, in ascending or descending order.
-     - parameter pageLimit: The number of records to return in each page of results. The default page limit is 100.
-     - parameter cursor: A token identifying the last value from the previous page of results.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter pageLimit: The number of records to return in each page of results.
+     - parameter cursor: A token identifying the last object from the previous page of results.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
-    */
+     */
     public func listAllLogs(
         filter: String,
         sort: String? = nil,

--- a/Source/ConversationV1/Models/Context.swift
+++ b/Source/ConversationV1/Models/Context.swift
@@ -16,14 +16,14 @@
 
 import Foundation
 
-/** Context information for the message. Include the context from the previous response to maintain state for the conversation. */
+/** State information for the conversation. To maintain state, include the context from the previous response. */
 public struct Context {
 
     /// The unique identifier of the conversation.
-    public var conversationID: String
+    public var conversationID: String?
 
     /// For internal use only.
-    public var system: SystemResponse
+    public var system: SystemResponse?
 
     /// Additional properties associated with this model.
     public var additionalProperties: [String: JSON]
@@ -36,7 +36,7 @@ public struct Context {
 
      - returns: An initialized `Context`.
     */
-    public init(conversationID: String, system: SystemResponse, additionalProperties: [String: JSON] = [:]) {
+    public init(conversationID: String? = nil, system: SystemResponse? = nil, additionalProperties: [String: JSON] = [:]) {
         self.conversationID = conversationID
         self.system = system
         self.additionalProperties = additionalProperties
@@ -53,16 +53,16 @@ extension Context: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        conversationID = try container.decode(String.self, forKey: .conversationID)
-        system = try container.decode(SystemResponse.self, forKey: .system)
+        conversationID = try container.decodeIfPresent(String.self, forKey: .conversationID)
+        system = try container.decodeIfPresent(SystemResponse.self, forKey: .system)
         let dynamicContainer = try decoder.container(keyedBy: DynamicKeys.self)
         additionalProperties = try dynamicContainer.decode([String: JSON].self, excluding: CodingKeys.allValues)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(conversationID, forKey: .conversationID)
-        try container.encode(system, forKey: .system)
+        try container.encodeIfPresent(conversationID, forKey: .conversationID)
+        try container.encodeIfPresent(system, forKey: .system)
         var dynamicContainer = encoder.container(keyedBy: DynamicKeys.self)
         try dynamicContainer.encodeIfPresent(additionalProperties)
     }

--- a/Source/ConversationV1/Models/Counterexample.swift
+++ b/Source/ConversationV1/Models/Counterexample.swift
@@ -23,10 +23,10 @@ public struct Counterexample {
     public var text: String
 
     /// The timestamp for creation of the counterexample.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the counterexample.
-    public var updated: String
+    public var updated: String?
 
     /**
      Initialize a `Counterexample` with member variables.
@@ -37,7 +37,7 @@ public struct Counterexample {
 
      - returns: An initialized `Counterexample`.
     */
-    public init(text: String, created: String, updated: String) {
+    public init(text: String, created: String? = nil, updated: String? = nil) {
         self.text = text
         self.created = created
         self.updated = updated
@@ -56,15 +56,15 @@ extension Counterexample: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         text = try container.decode(String.self, forKey: .text)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(text, forKey: .text)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
     }
 
 }

--- a/Source/ConversationV1/Models/CounterexampleCollection.swift
+++ b/Source/ConversationV1/Models/CounterexampleCollection.swift
@@ -22,14 +22,14 @@ public struct CounterexampleCollection {
     /// An array of objects describing the examples marked as irrelevant input.
     public var counterexamples: [Counterexample]
 
-    /// An object defining the pagination data for the returned objects.
+    /// The pagination data for the returned objects.
     public var pagination: Pagination
 
     /**
      Initialize a `CounterexampleCollection` with member variables.
 
      - parameter counterexamples: An array of objects describing the examples marked as irrelevant input.
-     - parameter pagination: An object defining the pagination data for the returned objects.
+     - parameter pagination: The pagination data for the returned objects.
 
      - returns: An initialized `CounterexampleCollection`.
     */

--- a/Source/ConversationV1/Models/CreateCounterexample.swift
+++ b/Source/ConversationV1/Models/CreateCounterexample.swift
@@ -19,13 +19,13 @@ import Foundation
 /** CreateCounterexample. */
 public struct CreateCounterexample {
 
-    /// The text of a user input marked as irrelevant input.
+    /// The text of a user input marked as irrelevant input. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters  - It cannot consist of only whitespace characters  - It must be no longer than 1024 characters.
     public var text: String
 
     /**
      Initialize a `CreateCounterexample` with member variables.
 
-     - parameter text: The text of a user input marked as irrelevant input.
+     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters  - It cannot consist of only whitespace characters  - It must be no longer than 1024 characters.
 
      - returns: An initialized `CreateCounterexample`.
     */

--- a/Source/ConversationV1/Models/CreateDialogNode.swift
+++ b/Source/ConversationV1/Models/CreateDialogNode.swift
@@ -26,6 +26,7 @@ public struct CreateDialogNode {
         case frame = "frame"
         case slot = "slot"
         case responseCondition = "response_condition"
+        case folder = "folder"
     }
 
     /// How an `event_handler` node is processed.
@@ -40,22 +41,43 @@ public struct CreateDialogNode {
         case nomatchResponsesDepleted = "nomatch_responses_depleted"
     }
 
-    /// The dialog node ID.
+    /// Whether this top-level dialog node can be digressed into.
+    public enum DigressIn: String {
+        case notAvailable = "not_available"
+        case returns = "returns"
+        case doesNotReturn = "does_not_return"
+    }
+
+    /// Whether this dialog node can be returned to after a digression.
+    public enum DigressOut: String {
+        case returning = "allow_returning"
+        case all = "allow_all"
+        case allNeverReturn = "allow_all_never_return"
+    }
+
+    /// Whether the user can digress to top-level nodes while filling out slots.
+    public enum DigressOutSlots: String {
+        case notAllowed = "not_allowed"
+        case allowReturning = "allow_returning"
+        case allowAll = "allow_all"
+    }
+
+    /// The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
     public var dialogNode: String
 
-    /// The description of the dialog node.
+    /// The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
     public var description: String?
 
-    /// The condition that will trigger the dialog node.
+    /// The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
     public var conditions: String?
 
-    /// The ID of the parent dialog node (if any).
+    /// The ID of the parent dialog node.
     public var parent: String?
 
-    /// The previous dialog node.
+    /// The ID of the previous dialog node.
     public var previousSibling: String?
 
-    /// The output of the dialog node.
+    /// The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
     public var output: [String: JSON]?
 
     /// The context for the dialog node.
@@ -64,13 +86,13 @@ public struct CreateDialogNode {
     /// The metadata for the dialog node.
     public var metadata: [String: JSON]?
 
-    /// The next step to execute following this dialog node.
+    /// The next step to be executed in dialog processing.
     public var nextStep: DialogNodeNextStep?
 
-    /// The actions for the dialog node.
+    /// An array of objects describing any actions to be invoked by the dialog node.
     public var actions: [DialogNodeAction]?
 
-    /// The alias used to identify the dialog node.
+    /// The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
     public var title: String?
 
     /// How the dialog node is processed.
@@ -82,27 +104,39 @@ public struct CreateDialogNode {
     /// The location in the dialog context where output is stored.
     public var variable: String?
 
+    /// Whether this top-level dialog node can be digressed into.
+    public var digressIn: String?
+
+    /// Whether this dialog node can be returned to after a digression.
+    public var digressOut: String?
+
+    /// Whether the user can digress to top-level nodes while filling out slots.
+    public var digressOutSlots: String?
+
     /**
      Initialize a `CreateDialogNode` with member variables.
 
-     - parameter dialogNode: The dialog node ID.
-     - parameter description: The description of the dialog node.
-     - parameter conditions: The condition that will trigger the dialog node.
-     - parameter parent: The ID of the parent dialog node (if any).
-     - parameter previousSibling: The previous dialog node.
-     - parameter output: The output of the dialog node.
+     - parameter dialogNode: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
+     - parameter description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+     - parameter parent: The ID of the parent dialog node.
+     - parameter previousSibling: The ID of the previous dialog node.
+     - parameter output: The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
      - parameter context: The context for the dialog node.
      - parameter metadata: The metadata for the dialog node.
-     - parameter nextStep: The next step to execute following this dialog node.
-     - parameter actions: The actions for the dialog node.
-     - parameter title: The alias used to identify the dialog node.
+     - parameter nextStep: The next step to be executed in dialog processing.
+     - parameter actions: An array of objects describing any actions to be invoked by the dialog node.
+     - parameter title: The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
      - parameter nodeType: How the dialog node is processed.
      - parameter eventName: How an `event_handler` node is processed.
      - parameter variable: The location in the dialog context where output is stored.
+     - parameter digressIn: Whether this top-level dialog node can be digressed into.
+     - parameter digressOut: Whether this dialog node can be returned to after a digression.
+     - parameter digressOutSlots: Whether the user can digress to top-level nodes while filling out slots.
 
      - returns: An initialized `CreateDialogNode`.
     */
-    public init(dialogNode: String, description: String? = nil, conditions: String? = nil, parent: String? = nil, previousSibling: String? = nil, output: [String: JSON]? = nil, context: [String: JSON]? = nil, metadata: [String: JSON]? = nil, nextStep: DialogNodeNextStep? = nil, actions: [DialogNodeAction]? = nil, title: String? = nil, nodeType: String? = nil, eventName: String? = nil, variable: String? = nil) {
+    public init(dialogNode: String, description: String? = nil, conditions: String? = nil, parent: String? = nil, previousSibling: String? = nil, output: [String: JSON]? = nil, context: [String: JSON]? = nil, metadata: [String: JSON]? = nil, nextStep: DialogNodeNextStep? = nil, actions: [DialogNodeAction]? = nil, title: String? = nil, nodeType: String? = nil, eventName: String? = nil, variable: String? = nil, digressIn: String? = nil, digressOut: String? = nil, digressOutSlots: String? = nil) {
         self.dialogNode = dialogNode
         self.description = description
         self.conditions = conditions
@@ -117,6 +151,9 @@ public struct CreateDialogNode {
         self.nodeType = nodeType
         self.eventName = eventName
         self.variable = variable
+        self.digressIn = digressIn
+        self.digressOut = digressOut
+        self.digressOutSlots = digressOutSlots
     }
 }
 
@@ -137,7 +174,10 @@ extension CreateDialogNode: Codable {
         case nodeType = "type"
         case eventName = "event_name"
         case variable = "variable"
-        static let allValues = [dialogNode, description, conditions, parent, previousSibling, output, context, metadata, nextStep, actions, title, nodeType, eventName, variable]
+        case digressIn = "digress_in"
+        case digressOut = "digress_out"
+        case digressOutSlots = "digress_out_slots"
+        static let allValues = [dialogNode, description, conditions, parent, previousSibling, output, context, metadata, nextStep, actions, title, nodeType, eventName, variable, digressIn, digressOut, digressOutSlots]
     }
 
     public init(from decoder: Decoder) throws {
@@ -156,6 +196,9 @@ extension CreateDialogNode: Codable {
         nodeType = try container.decodeIfPresent(String.self, forKey: .nodeType)
         eventName = try container.decodeIfPresent(String.self, forKey: .eventName)
         variable = try container.decodeIfPresent(String.self, forKey: .variable)
+        digressIn = try container.decodeIfPresent(String.self, forKey: .digressIn)
+        digressOut = try container.decodeIfPresent(String.self, forKey: .digressOut)
+        digressOutSlots = try container.decodeIfPresent(String.self, forKey: .digressOutSlots)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -174,6 +217,9 @@ extension CreateDialogNode: Codable {
         try container.encodeIfPresent(nodeType, forKey: .nodeType)
         try container.encodeIfPresent(eventName, forKey: .eventName)
         try container.encodeIfPresent(variable, forKey: .variable)
+        try container.encodeIfPresent(digressIn, forKey: .digressIn)
+        try container.encodeIfPresent(digressOut, forKey: .digressOut)
+        try container.encodeIfPresent(digressOutSlots, forKey: .digressOutSlots)
     }
 
 }

--- a/Source/ConversationV1/Models/CreateEntity.swift
+++ b/Source/ConversationV1/Models/CreateEntity.swift
@@ -19,16 +19,16 @@ import Foundation
 /** CreateEntity. */
 public struct CreateEntity {
 
-    /// The name of the entity.
+    /// The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
     public var entity: String
 
-    /// The description of the entity.
+    /// The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
     public var description: String?
 
     /// Any metadata related to the value.
     public var metadata: [String: JSON]?
 
-    /// An array of entity values.
+    /// An array of objects describing the entity values.
     public var values: [CreateValue]?
 
     /// Whether to use fuzzy matching for the entity.
@@ -37,10 +37,10 @@ public struct CreateEntity {
     /**
      Initialize a `CreateEntity` with member variables.
 
-     - parameter entity: The name of the entity.
-     - parameter description: The description of the entity.
+     - parameter entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
+     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
      - parameter metadata: Any metadata related to the value.
-     - parameter values: An array of entity values.
+     - parameter values: An array of objects describing the entity values.
      - parameter fuzzyMatch: Whether to use fuzzy matching for the entity.
 
      - returns: An initialized `CreateEntity`.

--- a/Source/ConversationV1/Models/CreateExample.swift
+++ b/Source/ConversationV1/Models/CreateExample.swift
@@ -19,13 +19,13 @@ import Foundation
 /** CreateExample. */
 public struct CreateExample {
 
-    /// The text of a user input example.
+    /// The text of a user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
     public var text: String
 
     /**
      Initialize a `CreateExample` with member variables.
 
-     - parameter text: The text of a user input example.
+     - parameter text: The text of a user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
 
      - returns: An initialized `CreateExample`.
     */

--- a/Source/ConversationV1/Models/CreateIntent.swift
+++ b/Source/ConversationV1/Models/CreateIntent.swift
@@ -19,21 +19,21 @@ import Foundation
 /** CreateIntent. */
 public struct CreateIntent {
 
-    /// The name of the intent.
+    /// The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
     public var intent: String
 
-    /// The description of the intent.
+    /// The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
     public var description: String?
 
-    /// An array of user input examples.
+    /// An array of user input examples for the intent.
     public var examples: [CreateExample]?
 
     /**
      Initialize a `CreateIntent` with member variables.
 
-     - parameter intent: The name of the intent.
-     - parameter description: The description of the intent.
-     - parameter examples: An array of user input examples.
+     - parameter intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
+     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+     - parameter examples: An array of user input examples for the intent.
 
      - returns: An initialized `CreateIntent`.
     */

--- a/Source/ConversationV1/Models/CreateSynonym.swift
+++ b/Source/ConversationV1/Models/CreateSynonym.swift
@@ -19,13 +19,13 @@ import Foundation
 /** CreateSynonym. */
 public struct CreateSynonym {
 
-    /// The text of the synonym.
+    /// The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
     public var synonym: String
 
     /**
      Initialize a `CreateSynonym` with member variables.
 
-     - parameter synonym: The text of the synonym.
+     - parameter synonym: The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
 
      - returns: An initialized `CreateSynonym`.
     */

--- a/Source/ConversationV1/Models/CreateValue.swift
+++ b/Source/ConversationV1/Models/CreateValue.swift
@@ -19,35 +19,35 @@ import Foundation
 /** CreateValue. */
 public struct CreateValue {
 
-    /// Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
+    /// Specifies the type of value.
     public enum ValueType: String {
         case synonyms = "synonyms"
         case patterns = "patterns"
     }
 
-    /// The text of the entity value.
+    /// The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
     public var value: String
 
     /// Any metadata related to the entity value.
     public var metadata: [String: JSON]?
 
-    /// An array of synonyms for the entity value.
+    /// An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
     public var synonyms: [String]?
 
-    /// An array of patterns for the entity value. A pattern is specified as a regular expression.
+    /// An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
     public var patterns: [String]?
 
-    /// Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
+    /// Specifies the type of value.
     public var valueType: String?
 
     /**
      Initialize a `CreateValue` with member variables.
 
-     - parameter value: The text of the entity value.
+     - parameter value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
      - parameter metadata: Any metadata related to the entity value.
-     - parameter synonyms: An array of synonyms for the entity value.
-     - parameter patterns: An array of patterns for the entity value. A pattern is specified as a regular expression.
-     - parameter valueType: Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
+     - parameter synonyms: An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+     - parameter valueType: Specifies the type of value.
 
      - returns: An initialized `CreateValue`.
     */

--- a/Source/ConversationV1/Models/CreateWorkspace.swift
+++ b/Source/ConversationV1/Models/CreateWorkspace.swift
@@ -19,10 +19,10 @@ import Foundation
 /** CreateWorkspace. */
 public struct CreateWorkspace {
 
-    /// The name of the workspace.
+    /// The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 64 characters.
     public var name: String?
 
-    /// The description of the workspace.
+    /// The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
     public var description: String?
 
     /// The language of the workspace.
@@ -49,8 +49,8 @@ public struct CreateWorkspace {
     /**
      Initialize a `CreateWorkspace` with member variables.
 
-     - parameter name: The name of the workspace.
-     - parameter description: The description of the workspace.
+     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 64 characters.
+     - parameter description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
      - parameter language: The language of the workspace.
      - parameter intents: An array of objects defining the intents for the workspace.
      - parameter entities: An array of objects defining the entities for the workspace.

--- a/Source/ConversationV1/Models/DialogNode.swift
+++ b/Source/ConversationV1/Models/DialogNode.swift
@@ -26,6 +26,7 @@ public struct DialogNode {
         case frame = "frame"
         case slot = "slot"
         case responseCondition = "response_condition"
+        case folder = "folder"
     }
 
     /// How an `event_handler` node is processed.
@@ -40,6 +41,27 @@ public struct DialogNode {
         case nomatchResponsesDepleted = "nomatch_responses_depleted"
     }
 
+    /// Whether this top-level dialog node can be digressed into.
+    public enum DigressIn: String {
+        case notAvailable = "not_available"
+        case returns = "returns"
+        case doesNotReturn = "does_not_return"
+    }
+
+    /// Whether this dialog node can be returned to after a digression.
+    public enum DigressOut: String {
+        case returning = "allow_returning"
+        case all = "allow_all"
+        case allNeverReturn = "allow_all_never_return"
+    }
+
+    /// Whether the user can digress to top-level nodes while filling out slots.
+    public enum DigressOutSlots: String {
+        case notAllowed = "not_allowed"
+        case allowReturning = "allow_returning"
+        case allowAll = "allow_all"
+    }
+
     /// The dialog node ID.
     public var dialogNodeID: String
 
@@ -49,10 +71,10 @@ public struct DialogNode {
     /// The condition that triggers the dialog node.
     public var conditions: String?
 
-    /// The ID of the parent dialog node.
+    /// The ID of the parent dialog node. This property is not returned if the dialog node has no parent.
     public var parent: String?
 
-    /// The ID of the previous sibling dialog node.
+    /// The ID of the previous sibling dialog node. This property is not returned if the dialog node has no previous sibling.
     public var previousSibling: String?
 
     /// The output of the dialog node.
@@ -61,17 +83,17 @@ public struct DialogNode {
     /// The context (if defined) for the dialog node.
     public var context: [String: JSON]?
 
-    /// The metadata (if any) for the dialog node.
+    /// Any metadata for the dialog node.
     public var metadata: [String: JSON]?
 
     /// The next step to execute following this dialog node.
     public var nextStep: DialogNodeNextStep?
 
     /// The timestamp for creation of the dialog node.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the most recent update to the dialog node.
-    public var updated: String
+    public var updated: String?
 
     /// The actions for the dialog node.
     public var actions: [DialogNodeAction]?
@@ -88,32 +110,42 @@ public struct DialogNode {
     /// The location in the dialog context where output is stored.
     public var variable: String?
 
+    /// Whether this top-level dialog node can be digressed into.
+    public var digressIn: String?
+
+    /// Whether this dialog node can be returned to after a digression.
+    public var digressOut: String?
+
+    /// Whether the user can digress to top-level nodes while filling out slots.
+    public var digressOutSlots: String?
+
     /**
      Initialize a `DialogNode` with member variables.
 
      - parameter dialogNodeID: The dialog node ID.
-     - parameter created: The timestamp for creation of the dialog node.
-     - parameter updated: The timestamp for the most recent update to the dialog node.
      - parameter description: The description of the dialog node.
      - parameter conditions: The condition that triggers the dialog node.
-     - parameter parent: The ID of the parent dialog node.
-     - parameter previousSibling: The ID of the previous sibling dialog node.
+     - parameter parent: The ID of the parent dialog node. This property is not returned if the dialog node has no parent.
+     - parameter previousSibling: The ID of the previous sibling dialog node. This property is not returned if the dialog node has no previous sibling.
      - parameter output: The output of the dialog node.
      - parameter context: The context (if defined) for the dialog node.
-     - parameter metadata: The metadata (if any) for the dialog node.
+     - parameter metadata: Any metadata for the dialog node.
      - parameter nextStep: The next step to execute following this dialog node.
+     - parameter created: The timestamp for creation of the dialog node.
+     - parameter updated: The timestamp for the most recent update to the dialog node.
      - parameter actions: The actions for the dialog node.
      - parameter title: The alias used to identify the dialog node.
      - parameter nodeType: How the dialog node is processed.
      - parameter eventName: How an `event_handler` node is processed.
      - parameter variable: The location in the dialog context where output is stored.
+     - parameter digressIn: Whether this top-level dialog node can be digressed into.
+     - parameter digressOut: Whether this dialog node can be returned to after a digression.
+     - parameter digressOutSlots: Whether the user can digress to top-level nodes while filling out slots.
 
      - returns: An initialized `DialogNode`.
     */
-    public init(dialogNodeID: String, created: String, updated: String, description: String? = nil, conditions: String? = nil, parent: String? = nil, previousSibling: String? = nil, output: [String: JSON]? = nil, context: [String: JSON]? = nil, metadata: [String: JSON]? = nil, nextStep: DialogNodeNextStep? = nil, actions: [DialogNodeAction]? = nil, title: String? = nil, nodeType: String? = nil, eventName: String? = nil, variable: String? = nil) {
+    public init(dialogNodeID: String, description: String? = nil, conditions: String? = nil, parent: String? = nil, previousSibling: String? = nil, output: [String: JSON]? = nil, context: [String: JSON]? = nil, metadata: [String: JSON]? = nil, nextStep: DialogNodeNextStep? = nil, created: String? = nil, updated: String? = nil, actions: [DialogNodeAction]? = nil, title: String? = nil, nodeType: String? = nil, eventName: String? = nil, variable: String? = nil, digressIn: String? = nil, digressOut: String? = nil, digressOutSlots: String? = nil) {
         self.dialogNodeID = dialogNodeID
-        self.created = created
-        self.updated = updated
         self.description = description
         self.conditions = conditions
         self.parent = parent
@@ -122,11 +154,16 @@ public struct DialogNode {
         self.context = context
         self.metadata = metadata
         self.nextStep = nextStep
+        self.created = created
+        self.updated = updated
         self.actions = actions
         self.title = title
         self.nodeType = nodeType
         self.eventName = eventName
         self.variable = variable
+        self.digressIn = digressIn
+        self.digressOut = digressOut
+        self.digressOutSlots = digressOutSlots
     }
 }
 
@@ -149,7 +186,10 @@ extension DialogNode: Codable {
         case nodeType = "type"
         case eventName = "event_name"
         case variable = "variable"
-        static let allValues = [dialogNodeID, description, conditions, parent, previousSibling, output, context, metadata, nextStep, created, updated, actions, title, nodeType, eventName, variable]
+        case digressIn = "digress_in"
+        case digressOut = "digress_out"
+        case digressOutSlots = "digress_out_slots"
+        static let allValues = [dialogNodeID, description, conditions, parent, previousSibling, output, context, metadata, nextStep, created, updated, actions, title, nodeType, eventName, variable, digressIn, digressOut, digressOutSlots]
     }
 
     public init(from decoder: Decoder) throws {
@@ -163,13 +203,16 @@ extension DialogNode: Codable {
         context = try container.decodeIfPresent([String: JSON].self, forKey: .context)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
         nextStep = try container.decodeIfPresent(DialogNodeNextStep.self, forKey: .nextStep)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         actions = try container.decodeIfPresent([DialogNodeAction].self, forKey: .actions)
         title = try container.decodeIfPresent(String.self, forKey: .title)
         nodeType = try container.decodeIfPresent(String.self, forKey: .nodeType)
         eventName = try container.decodeIfPresent(String.self, forKey: .eventName)
         variable = try container.decodeIfPresent(String.self, forKey: .variable)
+        digressIn = try container.decodeIfPresent(String.self, forKey: .digressIn)
+        digressOut = try container.decodeIfPresent(String.self, forKey: .digressOut)
+        digressOutSlots = try container.decodeIfPresent(String.self, forKey: .digressOutSlots)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -183,13 +226,16 @@ extension DialogNode: Codable {
         try container.encodeIfPresent(context, forKey: .context)
         try container.encodeIfPresent(metadata, forKey: .metadata)
         try container.encodeIfPresent(nextStep, forKey: .nextStep)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(actions, forKey: .actions)
         try container.encodeIfPresent(title, forKey: .title)
         try container.encodeIfPresent(nodeType, forKey: .nodeType)
         try container.encodeIfPresent(eventName, forKey: .eventName)
         try container.encodeIfPresent(variable, forKey: .variable)
+        try container.encodeIfPresent(digressIn, forKey: .digressIn)
+        try container.encodeIfPresent(digressOut, forKey: .digressOut)
+        try container.encodeIfPresent(digressOutSlots, forKey: .digressOutSlots)
     }
 
 }

--- a/Source/ConversationV1/Models/DialogNodeCollection.swift
+++ b/Source/ConversationV1/Models/DialogNodeCollection.swift
@@ -16,19 +16,20 @@
 
 import Foundation
 
-/** DialogNodeCollection. */
+/** An array of dialog nodes. */
 public struct DialogNodeCollection {
 
+    /// An array of objects describing the dialog nodes defined for the workspace.
     public var dialogNodes: [DialogNode]
 
-    /// An object defining the pagination data for the returned objects.
+    /// The pagination data for the returned objects.
     public var pagination: Pagination
 
     /**
      Initialize a `DialogNodeCollection` with member variables.
 
-     - parameter dialogNodes:
-     - parameter pagination: An object defining the pagination data for the returned objects.
+     - parameter dialogNodes: An array of objects describing the dialog nodes defined for the workspace.
+     - parameter pagination: The pagination data for the returned objects.
 
      - returns: An initialized `DialogNodeCollection`.
     */

--- a/Source/ConversationV1/Models/DialogNodeNextStep.swift
+++ b/Source/ConversationV1/Models/DialogNodeNextStep.swift
@@ -19,10 +19,14 @@ import Foundation
 /** The next step to execute following this dialog node. */
 public struct DialogNodeNextStep {
 
-    /// How the `next_step` reference is processed.
+    /// What happens after the dialog node completes. The valid values depend on the node type:  - The following values are valid for any node:    - `get_user_input`    - `skip_user_input`    - `jump_to`  - If the node is of type `event_handler` and its parent node is of type `slot` or `frame`, additional values are also valid:    - if **event_name**=`filled` and the type of the parent node is `slot`:      - `reprompt`      - `skip_all_slots`  - if **event_name**=`nomatch` and the type of the parent node is `slot`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`  - if **event_name**=`generic` and the type of the parent node is `frame`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`        If you specify `jump_to`, then you must also specify a value for the `dialog_node` property.
     public enum Behavior: String {
-        // swiftlint:disable:next identifier_name
-        case to = "jump_to"
+        case getUserInput = "get_user_input"
+        case skipUserInput = "skip_user_input"
+        case jumpTo = "jump_to"
+        case reprompt = "reprompt"
+        case skipSlot = "skip_slot"
+        case skipAllSlots = "skip_all_slots"
     }
 
     /// Which part of the dialog node to process next.
@@ -33,10 +37,10 @@ public struct DialogNodeNextStep {
         case body = "body"
     }
 
-    /// How the `next_step` reference is processed.
+    /// What happens after the dialog node completes. The valid values depend on the node type:  - The following values are valid for any node:    - `get_user_input`    - `skip_user_input`    - `jump_to`  - If the node is of type `event_handler` and its parent node is of type `slot` or `frame`, additional values are also valid:    - if **event_name**=`filled` and the type of the parent node is `slot`:      - `reprompt`      - `skip_all_slots`  - if **event_name**=`nomatch` and the type of the parent node is `slot`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`  - if **event_name**=`generic` and the type of the parent node is `frame`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`        If you specify `jump_to`, then you must also specify a value for the `dialog_node` property.
     public var behavior: String
 
-    /// The ID of the dialog node to process next.
+    /// The ID of the dialog node to process next. This parameter is required if **behavior**=`jump_to`.
     public var dialogNode: String?
 
     /// Which part of the dialog node to process next.
@@ -45,8 +49,8 @@ public struct DialogNodeNextStep {
     /**
      Initialize a `DialogNodeNextStep` with member variables.
 
-     - parameter behavior: How the `next_step` reference is processed.
-     - parameter dialogNode: The ID of the dialog node to process next.
+     - parameter behavior: What happens after the dialog node completes. The valid values depend on the node type:  - The following values are valid for any node:    - `get_user_input`    - `skip_user_input`    - `jump_to`  - If the node is of type `event_handler` and its parent node is of type `slot` or `frame`, additional values are also valid:    - if **event_name**=`filled` and the type of the parent node is `slot`:      - `reprompt`      - `skip_all_slots`  - if **event_name**=`nomatch` and the type of the parent node is `slot`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`  - if **event_name**=`generic` and the type of the parent node is `frame`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`        If you specify `jump_to`, then you must also specify a value for the `dialog_node` property.
+     - parameter dialogNode: The ID of the dialog node to process next. This parameter is required if **behavior**=`jump_to`.
      - parameter selector: Which part of the dialog node to process next.
 
      - returns: An initialized `DialogNodeNextStep`.

--- a/Source/ConversationV1/Models/Entity.swift
+++ b/Source/ConversationV1/Models/Entity.swift
@@ -23,10 +23,10 @@ public struct Entity {
     public var entityName: String
 
     /// The timestamp for creation of the entity.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the entity.
-    public var updated: String
+    public var updated: String?
 
     /// The description of the entity.
     public var description: String?
@@ -49,7 +49,7 @@ public struct Entity {
 
      - returns: An initialized `Entity`.
     */
-    public init(entityName: String, created: String, updated: String, description: String? = nil, metadata: [String: JSON]? = nil, fuzzyMatch: Bool? = nil) {
+    public init(entityName: String, created: String? = nil, updated: String? = nil, description: String? = nil, metadata: [String: JSON]? = nil, fuzzyMatch: Bool? = nil) {
         self.entityName = entityName
         self.created = created
         self.updated = updated
@@ -74,8 +74,8 @@ extension Entity: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         entityName = try container.decode(String.self, forKey: .entityName)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
         fuzzyMatch = try container.decodeIfPresent(Bool.self, forKey: .fuzzyMatch)
@@ -84,8 +84,8 @@ extension Entity: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(entityName, forKey: .entityName)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(metadata, forKey: .metadata)
         try container.encodeIfPresent(fuzzyMatch, forKey: .fuzzyMatch)

--- a/Source/ConversationV1/Models/EntityCollection.swift
+++ b/Source/ConversationV1/Models/EntityCollection.swift
@@ -19,17 +19,17 @@ import Foundation
 /** An array of entities. */
 public struct EntityCollection {
 
-    /// An array of entities.
+    /// An array of objects describing the entities defined for the workspace.
     public var entities: [EntityExport]
 
-    /// An object defining the pagination data for the returned objects.
+    /// The pagination data for the returned objects.
     public var pagination: Pagination
 
     /**
      Initialize a `EntityCollection` with member variables.
 
-     - parameter entities: An array of entities.
-     - parameter pagination: An object defining the pagination data for the returned objects.
+     - parameter entities: An array of objects describing the entities defined for the workspace.
+     - parameter pagination: The pagination data for the returned objects.
 
      - returns: An initialized `EntityCollection`.
     */

--- a/Source/ConversationV1/Models/EntityExport.swift
+++ b/Source/ConversationV1/Models/EntityExport.swift
@@ -23,10 +23,10 @@ public struct EntityExport {
     public var entityName: String
 
     /// The timestamp for creation of the entity.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the entity.
-    public var updated: String
+    public var updated: String?
 
     /// The description of the entity.
     public var description: String?
@@ -37,7 +37,7 @@ public struct EntityExport {
     /// Whether fuzzy matching is used for the entity.
     public var fuzzyMatch: Bool?
 
-    /// An array of entity values.
+    /// An array objects describing the entity values.
     public var values: [ValueExport]?
 
     /**
@@ -49,11 +49,11 @@ public struct EntityExport {
      - parameter description: The description of the entity.
      - parameter metadata: Any metadata related to the entity.
      - parameter fuzzyMatch: Whether fuzzy matching is used for the entity.
-     - parameter values: An array of entity values.
+     - parameter values: An array objects describing the entity values.
 
      - returns: An initialized `EntityExport`.
     */
-    public init(entityName: String, created: String, updated: String, description: String? = nil, metadata: [String: JSON]? = nil, fuzzyMatch: Bool? = nil, values: [ValueExport]? = nil) {
+    public init(entityName: String, created: String? = nil, updated: String? = nil, description: String? = nil, metadata: [String: JSON]? = nil, fuzzyMatch: Bool? = nil, values: [ValueExport]? = nil) {
         self.entityName = entityName
         self.created = created
         self.updated = updated
@@ -80,8 +80,8 @@ extension EntityExport: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         entityName = try container.decode(String.self, forKey: .entityName)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
         fuzzyMatch = try container.decodeIfPresent(Bool.self, forKey: .fuzzyMatch)
@@ -91,8 +91,8 @@ extension EntityExport: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(entityName, forKey: .entityName)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(metadata, forKey: .metadata)
         try container.encodeIfPresent(fuzzyMatch, forKey: .fuzzyMatch)

--- a/Source/ConversationV1/Models/Example.swift
+++ b/Source/ConversationV1/Models/Example.swift
@@ -19,25 +19,25 @@ import Foundation
 /** Example. */
 public struct Example {
 
-    /// The text of the example.
+    /// The text of the user input example.
     public var exampleText: String
 
     /// The timestamp for creation of the example.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the example.
-    public var updated: String
+    public var updated: String?
 
     /**
      Initialize a `Example` with member variables.
 
-     - parameter exampleText: The text of the example.
+     - parameter exampleText: The text of the user input example.
      - parameter created: The timestamp for creation of the example.
      - parameter updated: The timestamp for the last update to the example.
 
      - returns: An initialized `Example`.
     */
-    public init(exampleText: String, created: String, updated: String) {
+    public init(exampleText: String, created: String? = nil, updated: String? = nil) {
         self.exampleText = exampleText
         self.created = created
         self.updated = updated
@@ -56,15 +56,15 @@ extension Example: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         exampleText = try container.decode(String.self, forKey: .exampleText)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(exampleText, forKey: .exampleText)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
     }
 
 }

--- a/Source/ConversationV1/Models/ExampleCollection.swift
+++ b/Source/ConversationV1/Models/ExampleCollection.swift
@@ -19,17 +19,17 @@ import Foundation
 /** ExampleCollection. */
 public struct ExampleCollection {
 
-    /// An array of Example objects describing the examples defined for the intent.
+    /// An array of objects describing the examples defined for the intent.
     public var examples: [Example]
 
-    /// An object defining the pagination data for the returned objects.
+    /// The pagination data for the returned objects.
     public var pagination: Pagination
 
     /**
      Initialize a `ExampleCollection` with member variables.
 
-     - parameter examples: An array of Example objects describing the examples defined for the intent.
-     - parameter pagination: An object defining the pagination data for the returned objects.
+     - parameter examples: An array of objects describing the examples defined for the intent.
+     - parameter pagination: The pagination data for the returned objects.
 
      - returns: An initialized `ExampleCollection`.
     */

--- a/Source/ConversationV1/Models/InputData.swift
+++ b/Source/ConversationV1/Models/InputData.swift
@@ -16,16 +16,16 @@
 
 import Foundation
 
-/** An object defining the user input. */
+/** The user input. */
 public struct InputData {
 
-    /// The text of the user input.
+    /// The text of the user input. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
     public var text: String
 
     /**
      Initialize a `InputData` with member variables.
 
-     - parameter text: The text of the user input.
+     - parameter text: The text of the user input. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
 
      - returns: An initialized `InputData`.
     */

--- a/Source/ConversationV1/Models/Intent.swift
+++ b/Source/ConversationV1/Models/Intent.swift
@@ -23,10 +23,10 @@ public struct Intent {
     public var intentName: String
 
     /// The timestamp for creation of the intent.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the intent.
-    public var updated: String
+    public var updated: String?
 
     /// The description of the intent.
     public var description: String?
@@ -41,7 +41,7 @@ public struct Intent {
 
      - returns: An initialized `Intent`.
     */
-    public init(intentName: String, created: String, updated: String, description: String? = nil) {
+    public init(intentName: String, created: String? = nil, updated: String? = nil, description: String? = nil) {
         self.intentName = intentName
         self.created = created
         self.updated = updated
@@ -62,16 +62,16 @@ extension Intent: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         intentName = try container.decode(String.self, forKey: .intentName)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         description = try container.decodeIfPresent(String.self, forKey: .description)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(intentName, forKey: .intentName)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(description, forKey: .description)
     }
 

--- a/Source/ConversationV1/Models/IntentCollection.swift
+++ b/Source/ConversationV1/Models/IntentCollection.swift
@@ -19,17 +19,17 @@ import Foundation
 /** IntentCollection. */
 public struct IntentCollection {
 
-    /// An array of intents.
+    /// An array of objects describing the intents defined for the workspace.
     public var intents: [IntentExport]
 
-    /// An object defining the pagination data for the returned objects.
+    /// The pagination data for the returned objects.
     public var pagination: Pagination
 
     /**
      Initialize a `IntentCollection` with member variables.
 
-     - parameter intents: An array of intents.
-     - parameter pagination: An object defining the pagination data for the returned objects.
+     - parameter intents: An array of objects describing the intents defined for the workspace.
+     - parameter pagination: The pagination data for the returned objects.
 
      - returns: An initialized `IntentCollection`.
     */

--- a/Source/ConversationV1/Models/IntentExport.swift
+++ b/Source/ConversationV1/Models/IntentExport.swift
@@ -23,15 +23,15 @@ public struct IntentExport {
     public var intentName: String
 
     /// The timestamp for creation of the intent.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the intent.
-    public var updated: String
+    public var updated: String?
 
     /// The description of the intent.
     public var description: String?
 
-    /// An array of user input examples.
+    /// An array of objects describing the user input examples for the intent.
     public var examples: [Example]?
 
     /**
@@ -41,11 +41,11 @@ public struct IntentExport {
      - parameter created: The timestamp for creation of the intent.
      - parameter updated: The timestamp for the last update to the intent.
      - parameter description: The description of the intent.
-     - parameter examples: An array of user input examples.
+     - parameter examples: An array of objects describing the user input examples for the intent.
 
      - returns: An initialized `IntentExport`.
     */
-    public init(intentName: String, created: String, updated: String, description: String? = nil, examples: [Example]? = nil) {
+    public init(intentName: String, created: String? = nil, updated: String? = nil, description: String? = nil, examples: [Example]? = nil) {
         self.intentName = intentName
         self.created = created
         self.updated = updated
@@ -68,8 +68,8 @@ extension IntentExport: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         intentName = try container.decode(String.self, forKey: .intentName)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         examples = try container.decodeIfPresent([Example].self, forKey: .examples)
     }
@@ -77,8 +77,8 @@ extension IntentExport: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(intentName, forKey: .intentName)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(examples, forKey: .examples)
     }

--- a/Source/ConversationV1/Models/LogCollection.swift
+++ b/Source/ConversationV1/Models/LogCollection.swift
@@ -19,17 +19,17 @@ import Foundation
 /** LogCollection. */
 public struct LogCollection {
 
-    /// An array of log events.
+    /// An array of objects describing log events.
     public var logs: [LogExport]
 
-    /// An object defining the pagination data for the returned objects.
+    /// The pagination data for the returned objects.
     public var pagination: LogPagination
 
     /**
      Initialize a `LogCollection` with member variables.
 
-     - parameter logs: An array of log events.
-     - parameter pagination: An object defining the pagination data for the returned objects.
+     - parameter logs: An array of objects describing log events.
+     - parameter pagination: The pagination data for the returned objects.
 
      - returns: An initialized `LogCollection`.
     */

--- a/Source/ConversationV1/Models/LogExport.swift
+++ b/Source/ConversationV1/Models/LogExport.swift
@@ -19,13 +19,13 @@ import Foundation
 /** LogExport. */
 public struct LogExport {
 
-    /// A request formatted for the Conversation service.
+    /// A request received by the workspace, including the user input and context.
     public var request: MessageRequest
 
-    /// A response from the Conversation service.
+    /// The response sent by the workspace, including the output text, detected intents and entities, and context.
     public var response: MessageResponse
 
-    /// A unique identifier for the logged message.
+    /// A unique identifier for the logged event.
     public var logID: String
 
     /// The timestamp for receipt of the message.
@@ -34,7 +34,7 @@ public struct LogExport {
     /// The timestamp for the system response to the message.
     public var responseTimestamp: String
 
-    /// The workspace ID.
+    /// The unique identifier of the workspace where the request was made.
     public var workspaceID: String
 
     /// The language of the workspace where the message request was made.
@@ -43,12 +43,12 @@ public struct LogExport {
     /**
      Initialize a `LogExport` with member variables.
 
-     - parameter request: A request formatted for the Conversation service.
-     - parameter response: A response from the Conversation service.
-     - parameter logID: A unique identifier for the logged message.
+     - parameter request: A request received by the workspace, including the user input and context.
+     - parameter response: The response sent by the workspace, including the output text, detected intents and entities, and context.
+     - parameter logID: A unique identifier for the logged event.
      - parameter requestTimestamp: The timestamp for receipt of the message.
      - parameter responseTimestamp: The timestamp for the system response to the message.
-     - parameter workspaceID: The workspace ID.
+     - parameter workspaceID: The unique identifier of the workspace where the request was made.
      - parameter language: The language of the workspace where the message request was made.
 
      - returns: An initialized `LogExport`.

--- a/Source/ConversationV1/Models/LogMessage.swift
+++ b/Source/ConversationV1/Models/LogMessage.swift
@@ -19,17 +19,17 @@ import Foundation
 /** Log message details. */
 public struct LogMessage {
 
-    /// The severity of the message.
+    /// The severity of the log message.
     public enum Level: String {
         case info = "info"
         case error = "error"
         case warn = "warn"
     }
 
-    /// The severity of the message.
+    /// The severity of the log message.
     public var level: String
 
-    /// The text of the message.
+    /// The text of the log message.
     public var msg: String
 
     /// Additional properties associated with this model.
@@ -38,8 +38,8 @@ public struct LogMessage {
     /**
      Initialize a `LogMessage` with member variables.
 
-     - parameter level: The severity of the message.
-     - parameter msg: The text of the message.
+     - parameter level: The severity of the log message.
+     - parameter msg: The text of the log message.
 
      - returns: An initialized `LogMessage`.
     */

--- a/Source/ConversationV1/Models/LogPagination.swift
+++ b/Source/ConversationV1/Models/LogPagination.swift
@@ -19,7 +19,7 @@ import Foundation
 /** The pagination data for the returned objects. */
 public struct LogPagination {
 
-    /// The URL that will return the next page of results.
+    /// The URL that will return the next page of results, if any.
     public var nextUrl: String?
 
     /// Reserved for future use.
@@ -28,7 +28,7 @@ public struct LogPagination {
     /**
      Initialize a `LogPagination` with member variables.
 
-     - parameter nextUrl: The URL that will return the next page of results.
+     - parameter nextUrl: The URL that will return the next page of results, if any.
      - parameter matched: Reserved for future use.
 
      - returns: An initialized `LogPagination`.

--- a/Source/ConversationV1/Models/MessageInput.swift
+++ b/Source/ConversationV1/Models/MessageInput.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-/** An input object that includes the input text. */
+/** The text of the user input. */
 public struct MessageInput {
 
     /// The user's input.

--- a/Source/ConversationV1/Models/MessageRequest.swift
+++ b/Source/ConversationV1/Models/MessageRequest.swift
@@ -28,13 +28,13 @@ public struct MessageRequest {
     /// State information for the conversation. Continue a conversation by including the context object from the previous response.
     public var context: Context?
 
-    /// Include the entities from the previous response when they do not need to change and to prevent Watson from trying to identify them.
+    /// Entities to use when evaluating the message. Include entities from the previous response to continue using those entities rather than detecting entities in the new input.
     public var entities: [RuntimeEntity]?
 
-    /// An array of name-confidence pairs for the user input. Include the intents from the previous response when they do not need to change and to prevent Watson from trying to identify them.
+    /// Intents to use when evaluating the user input. Include intents from the previous response to continue using those intents rather than trying to recognize intents in the new input.
     public var intents: [RuntimeIntent]?
 
-    /// System output. Include the output from the request when you have several requests within the same Dialog turn to pass back in the intermediate information.
+    /// System output. Include the output from the previous response to maintain intermediate information over multiple requests.
     public var output: OutputData?
 
     /**
@@ -43,9 +43,9 @@ public struct MessageRequest {
      - parameter input: An input object that includes the input text.
      - parameter alternateIntents: Whether to return more than one intent. Set to `true` to return all matching intents.
      - parameter context: State information for the conversation. Continue a conversation by including the context object from the previous response.
-     - parameter entities: Include the entities from the previous response when they do not need to change and to prevent Watson from trying to identify them.
-     - parameter intents: An array of name-confidence pairs for the user input. Include the intents from the previous response when they do not need to change and to prevent Watson from trying to identify them.
-     - parameter output: System output. Include the output from the request when you have several requests within the same Dialog turn to pass back in the intermediate information.
+     - parameter entities: Entities to use when evaluating the message. Include entities from the previous response to continue using those entities rather than detecting entities in the new input.
+     - parameter intents: Intents to use when evaluating the user input. Include intents from the previous response to continue using those intents rather than trying to recognize intents in the new input.
+     - parameter output: System output. Include the output from the previous response to maintain intermediate information over multiple requests.
 
      - returns: An initialized `MessageRequest`.
     */

--- a/Source/ConversationV1/Models/MessageResponse.swift
+++ b/Source/ConversationV1/Models/MessageResponse.swift
@@ -28,7 +28,7 @@ public struct MessageResponse {
     /// An array of entities identified in the user input.
     public var entities: [RuntimeEntity]
 
-    /// Whether to return more than one intent. `true` indicates that all matching intents are returned.
+    /// Whether to return more than one intent. A value of `true` indicates that all matching intents are returned.
     public var alternateIntents: Bool?
 
     /// State information for the conversation.
@@ -48,7 +48,7 @@ public struct MessageResponse {
      - parameter context: State information for the conversation.
      - parameter output: Output from the dialog, including the response to the user, the nodes that were triggered, and log messages.
      - parameter input: The user input from the request.
-     - parameter alternateIntents: Whether to return more than one intent. `true` indicates that all matching intents are returned.
+     - parameter alternateIntents: Whether to return more than one intent. A value of `true` indicates that all matching intents are returned.
 
      - returns: An initialized `MessageResponse`.
     */

--- a/Source/ConversationV1/Models/OutputData.swift
+++ b/Source/ConversationV1/Models/OutputData.swift
@@ -19,16 +19,16 @@ import Foundation
 /** An output object that includes the response to the user, the nodes that were hit, and messages from the log. */
 public struct OutputData {
 
-    /// Up to 50 messages logged with the request.
+    /// An array of up to 50 messages logged with the request.
     public var logMessages: [LogMessage]
 
     /// An array of responses to the user.
     public var text: [String]
 
-    /// An array of the nodes that were triggered to create the response.
+    /// An array of the nodes that were triggered to create the response, in the order in which they were visited. This information is useful for debugging and for tracing the path taken through the node tree.
     public var nodesVisited: [String]?
 
-    /// An array of objects containing detailed diagnostic information about the nodes that were triggered during processing of the input message.
+    /// An array of objects containing detailed diagnostic information about the nodes that were triggered during processing of the input message. Included only if **nodes_visited_details** is set to `true` in the message request.
     public var nodesVisitedDetails: [DialogNodeVisitedDetails]?
 
     /// Additional properties associated with this model.
@@ -37,10 +37,10 @@ public struct OutputData {
     /**
      Initialize a `OutputData` with member variables.
 
-     - parameter logMessages: Up to 50 messages logged with the request.
+     - parameter logMessages: An array of up to 50 messages logged with the request.
      - parameter text: An array of responses to the user.
-     - parameter nodesVisited: An array of the nodes that were triggered to create the response.
-     - parameter nodesVisitedDetails: An array of objects containing detailed diagnostic information about the nodes that were triggered during processing of the input message.
+     - parameter nodesVisited: An array of the nodes that were triggered to create the response, in the order in which they were visited. This information is useful for debugging and for tracing the path taken through the node tree.
+     - parameter nodesVisitedDetails: An array of objects containing detailed diagnostic information about the nodes that were triggered during processing of the input message. Included only if **nodes_visited_details** is set to `true` in the message request.
 
      - returns: An initialized `OutputData`.
     */

--- a/Source/ConversationV1/Models/RuntimeEntity.swift
+++ b/Source/ConversationV1/Models/RuntimeEntity.swift
@@ -19,19 +19,19 @@ import Foundation
 /** A term from the request that was identified as an entity. */
 public struct RuntimeEntity {
 
-    /// The recognized entity from a term in the input.
+    /// An entity detected in the input.
     public var entity: String
 
-    /// Zero-based character offsets that indicate where the entity value begins and ends in the input text.
+    /// An array of zero-based character offsets that indicate where the detected entity values begin and end in the input text.
     public var location: [Int]
 
-    /// The term in the input text that was recognized.
+    /// The term in the input text that was recognized as an entity value.
     public var value: String
 
     /// A decimal percentage that represents Watson's confidence in the entity.
     public var confidence: Double?
 
-    /// The metadata for the entity.
+    /// Any metadata for the entity.
     public var metadata: [String: JSON]?
 
     /// The recognized capture groups for the entity, as defined by the entity pattern.
@@ -43,11 +43,11 @@ public struct RuntimeEntity {
     /**
      Initialize a `RuntimeEntity` with member variables.
 
-     - parameter entity: The recognized entity from a term in the input.
-     - parameter location: Zero-based character offsets that indicate where the entity value begins and ends in the input text.
-     - parameter value: The term in the input text that was recognized.
+     - parameter entity: An entity detected in the input.
+     - parameter location: An array of zero-based character offsets that indicate where the detected entity values begin and end in the input text.
+     - parameter value: The term in the input text that was recognized as an entity value.
      - parameter confidence: A decimal percentage that represents Watson's confidence in the entity.
-     - parameter metadata: The metadata for the entity.
+     - parameter metadata: Any metadata for the entity.
      - parameter groups: The recognized capture groups for the entity, as defined by the entity pattern.
 
      - returns: An initialized `RuntimeEntity`.

--- a/Source/ConversationV1/Models/Synonym.swift
+++ b/Source/ConversationV1/Models/Synonym.swift
@@ -23,10 +23,10 @@ public struct Synonym {
     public var synonymText: String
 
     /// The timestamp for creation of the synonym.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the most recent update to the synonym.
-    public var updated: String
+    public var updated: String?
 
     /**
      Initialize a `Synonym` with member variables.
@@ -37,7 +37,7 @@ public struct Synonym {
 
      - returns: An initialized `Synonym`.
     */
-    public init(synonymText: String, created: String, updated: String) {
+    public init(synonymText: String, created: String? = nil, updated: String? = nil) {
         self.synonymText = synonymText
         self.created = created
         self.updated = updated
@@ -56,15 +56,15 @@ extension Synonym: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         synonymText = try container.decode(String.self, forKey: .synonymText)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(synonymText, forKey: .synonymText)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
     }
 
 }

--- a/Source/ConversationV1/Models/SynonymCollection.swift
+++ b/Source/ConversationV1/Models/SynonymCollection.swift
@@ -22,14 +22,14 @@ public struct SynonymCollection {
     /// An array of synonyms.
     public var synonyms: [Synonym]
 
-    /// An object defining the pagination data for the returned objects.
+    /// The pagination data for the returned objects.
     public var pagination: Pagination
 
     /**
      Initialize a `SynonymCollection` with member variables.
 
      - parameter synonyms: An array of synonyms.
-     - parameter pagination: An object defining the pagination data for the returned objects.
+     - parameter pagination: The pagination data for the returned objects.
 
      - returns: An initialized `SynonymCollection`.
     */

--- a/Source/ConversationV1/Models/UpdateCounterexample.swift
+++ b/Source/ConversationV1/Models/UpdateCounterexample.swift
@@ -19,13 +19,13 @@ import Foundation
 /** UpdateCounterexample. */
 public struct UpdateCounterexample {
 
-    /// The text of the example to be marked as irrelevant input.
+    /// The text of a user input counterexample.
     public var text: String?
 
     /**
      Initialize a `UpdateCounterexample` with member variables.
 
-     - parameter text: The text of the example to be marked as irrelevant input.
+     - parameter text: The text of a user input counterexample.
 
      - returns: An initialized `UpdateCounterexample`.
     */

--- a/Source/ConversationV1/Models/UpdateDialogNode.swift
+++ b/Source/ConversationV1/Models/UpdateDialogNode.swift
@@ -26,6 +26,7 @@ public struct UpdateDialogNode {
         case frame = "frame"
         case slot = "slot"
         case responseCondition = "response_condition"
+        case folder = "folder"
     }
 
     /// How an `event_handler` node is processed.
@@ -40,22 +41,43 @@ public struct UpdateDialogNode {
         case nomatchResponsesDepleted = "nomatch_responses_depleted"
     }
 
-    /// The dialog node ID.
-    public var dialogNode: String
+    /// Whether this top-level dialog node can be digressed into.
+    public enum DigressIn: String {
+        case notAvailable = "not_available"
+        case returns = "returns"
+        case doesNotReturn = "does_not_return"
+    }
 
-    /// The description of the dialog node.
+    /// Whether this dialog node can be returned to after a digression.
+    public enum DigressOut: String {
+        case returning = "allow_returning"
+        case all = "allow_all"
+        case allNeverReturn = "allow_all_never_return"
+    }
+
+    /// Whether the user can digress to top-level nodes while filling out slots.
+    public enum DigressOutSlots: String {
+        case notAllowed = "not_allowed"
+        case allowReturning = "allow_returning"
+        case allowAll = "allow_all"
+    }
+
+    /// The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
+    public var dialogNode: String?
+
+    /// The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
     public var description: String?
 
-    /// The condition that will trigger the dialog node.
+    /// The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
     public var conditions: String?
 
-    /// The ID of the parent dialog node (if any).
+    /// The ID of the parent dialog node.
     public var parent: String?
 
-    /// The previous dialog node.
+    /// The ID of the previous sibling dialog node.
     public var previousSibling: String?
 
-    /// The output of the dialog node.
+    /// The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
     public var output: [String: JSON]?
 
     /// The context for the dialog node.
@@ -64,10 +86,10 @@ public struct UpdateDialogNode {
     /// The metadata for the dialog node.
     public var metadata: [String: JSON]?
 
-    /// The next step to execute following this dialog node.
+    /// The next step to be executed in dialog processing.
     public var nextStep: DialogNodeNextStep?
 
-    /// The alias used to identify the dialog node.
+    /// The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
     public var title: String?
 
     /// How the dialog node is processed.
@@ -79,30 +101,42 @@ public struct UpdateDialogNode {
     /// The location in the dialog context where output is stored.
     public var variable: String?
 
-    /// The actions for the dialog node.
+    /// An array of objects describing any actions to be invoked by the dialog node.
     public var actions: [DialogNodeAction]?
+
+    /// Whether this top-level dialog node can be digressed into.
+    public var digressIn: String?
+
+    /// Whether this dialog node can be returned to after a digression.
+    public var digressOut: String?
+
+    /// Whether the user can digress to top-level nodes while filling out slots.
+    public var digressOutSlots: String?
 
     /**
      Initialize a `UpdateDialogNode` with member variables.
 
-     - parameter dialogNode: The dialog node ID.
-     - parameter description: The description of the dialog node.
-     - parameter conditions: The condition that will trigger the dialog node.
-     - parameter parent: The ID of the parent dialog node (if any).
-     - parameter previousSibling: The previous dialog node.
-     - parameter output: The output of the dialog node.
+     - parameter dialogNode: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
+     - parameter description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+     - parameter parent: The ID of the parent dialog node.
+     - parameter previousSibling: The ID of the previous sibling dialog node.
+     - parameter output: The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
      - parameter context: The context for the dialog node.
      - parameter metadata: The metadata for the dialog node.
-     - parameter nextStep: The next step to execute following this dialog node.
-     - parameter title: The alias used to identify the dialog node.
+     - parameter nextStep: The next step to be executed in dialog processing.
+     - parameter title: The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
      - parameter nodeType: How the dialog node is processed.
      - parameter eventName: How an `event_handler` node is processed.
      - parameter variable: The location in the dialog context where output is stored.
-     - parameter actions: The actions for the dialog node.
+     - parameter actions: An array of objects describing any actions to be invoked by the dialog node.
+     - parameter digressIn: Whether this top-level dialog node can be digressed into.
+     - parameter digressOut: Whether this dialog node can be returned to after a digression.
+     - parameter digressOutSlots: Whether the user can digress to top-level nodes while filling out slots.
 
      - returns: An initialized `UpdateDialogNode`.
     */
-    public init(dialogNode: String, description: String? = nil, conditions: String? = nil, parent: String? = nil, previousSibling: String? = nil, output: [String: JSON]? = nil, context: [String: JSON]? = nil, metadata: [String: JSON]? = nil, nextStep: DialogNodeNextStep? = nil, title: String? = nil, nodeType: String? = nil, eventName: String? = nil, variable: String? = nil, actions: [DialogNodeAction]? = nil) {
+    public init(dialogNode: String? = nil, description: String? = nil, conditions: String? = nil, parent: String? = nil, previousSibling: String? = nil, output: [String: JSON]? = nil, context: [String: JSON]? = nil, metadata: [String: JSON]? = nil, nextStep: DialogNodeNextStep? = nil, title: String? = nil, nodeType: String? = nil, eventName: String? = nil, variable: String? = nil, actions: [DialogNodeAction]? = nil, digressIn: String? = nil, digressOut: String? = nil, digressOutSlots: String? = nil) {
         self.dialogNode = dialogNode
         self.description = description
         self.conditions = conditions
@@ -117,6 +151,9 @@ public struct UpdateDialogNode {
         self.eventName = eventName
         self.variable = variable
         self.actions = actions
+        self.digressIn = digressIn
+        self.digressOut = digressOut
+        self.digressOutSlots = digressOutSlots
     }
 }
 
@@ -137,12 +174,15 @@ extension UpdateDialogNode: Codable {
         case eventName = "event_name"
         case variable = "variable"
         case actions = "actions"
-        static let allValues = [dialogNode, description, conditions, parent, previousSibling, output, context, metadata, nextStep, title, nodeType, eventName, variable, actions]
+        case digressIn = "digress_in"
+        case digressOut = "digress_out"
+        case digressOutSlots = "digress_out_slots"
+        static let allValues = [dialogNode, description, conditions, parent, previousSibling, output, context, metadata, nextStep, title, nodeType, eventName, variable, actions, digressIn, digressOut, digressOutSlots]
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        dialogNode = try container.decode(String.self, forKey: .dialogNode)
+        dialogNode = try container.decodeIfPresent(String.self, forKey: .dialogNode)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         conditions = try container.decodeIfPresent(String.self, forKey: .conditions)
         parent = try container.decodeIfPresent(String.self, forKey: .parent)
@@ -156,11 +196,14 @@ extension UpdateDialogNode: Codable {
         eventName = try container.decodeIfPresent(String.self, forKey: .eventName)
         variable = try container.decodeIfPresent(String.self, forKey: .variable)
         actions = try container.decodeIfPresent([DialogNodeAction].self, forKey: .actions)
+        digressIn = try container.decodeIfPresent(String.self, forKey: .digressIn)
+        digressOut = try container.decodeIfPresent(String.self, forKey: .digressOut)
+        digressOutSlots = try container.decodeIfPresent(String.self, forKey: .digressOutSlots)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(dialogNode, forKey: .dialogNode)
+        try container.encodeIfPresent(dialogNode, forKey: .dialogNode)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(conditions, forKey: .conditions)
         try container.encodeIfPresent(parent, forKey: .parent)
@@ -174,6 +217,9 @@ extension UpdateDialogNode: Codable {
         try container.encodeIfPresent(eventName, forKey: .eventName)
         try container.encodeIfPresent(variable, forKey: .variable)
         try container.encodeIfPresent(actions, forKey: .actions)
+        try container.encodeIfPresent(digressIn, forKey: .digressIn)
+        try container.encodeIfPresent(digressOut, forKey: .digressOut)
+        try container.encodeIfPresent(digressOutSlots, forKey: .digressOutSlots)
     }
 
 }

--- a/Source/ConversationV1/Models/UpdateEntity.swift
+++ b/Source/ConversationV1/Models/UpdateEntity.swift
@@ -19,10 +19,10 @@ import Foundation
 /** UpdateEntity. */
 public struct UpdateEntity {
 
-    /// The name of the entity.
+    /// The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
     public var entity: String?
 
-    /// The description of the entity.
+    /// The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
     public var description: String?
 
     /// Any metadata related to the entity.
@@ -37,8 +37,8 @@ public struct UpdateEntity {
     /**
      Initialize a `UpdateEntity` with member variables.
 
-     - parameter entity: The name of the entity.
-     - parameter description: The description of the entity.
+     - parameter entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
+     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
      - parameter metadata: Any metadata related to the entity.
      - parameter fuzzyMatch: Whether to use fuzzy matching for the entity.
      - parameter values: An array of entity values.

--- a/Source/ConversationV1/Models/UpdateExample.swift
+++ b/Source/ConversationV1/Models/UpdateExample.swift
@@ -19,13 +19,13 @@ import Foundation
 /** UpdateExample. */
 public struct UpdateExample {
 
-    /// The text of the user input example.
+    /// The text of the user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
     public var text: String?
 
     /**
      Initialize a `UpdateExample` with member variables.
 
-     - parameter text: The text of the user input example.
+     - parameter text: The text of the user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
 
      - returns: An initialized `UpdateExample`.
     */

--- a/Source/ConversationV1/Models/UpdateIntent.swift
+++ b/Source/ConversationV1/Models/UpdateIntent.swift
@@ -19,7 +19,7 @@ import Foundation
 /** UpdateIntent. */
 public struct UpdateIntent {
 
-    /// The name of the intent.
+    /// The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
     public var intent: String?
 
     /// The description of the intent.
@@ -31,7 +31,7 @@ public struct UpdateIntent {
     /**
      Initialize a `UpdateIntent` with member variables.
 
-     - parameter intent: The name of the intent.
+     - parameter intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
      - parameter description: The description of the intent.
      - parameter examples: An array of user input examples for the intent.
 

--- a/Source/ConversationV1/Models/UpdateSynonym.swift
+++ b/Source/ConversationV1/Models/UpdateSynonym.swift
@@ -19,13 +19,13 @@ import Foundation
 /** UpdateSynonym. */
 public struct UpdateSynonym {
 
-    /// The text of the synonym.
+    /// The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
     public var synonym: String?
 
     /**
      Initialize a `UpdateSynonym` with member variables.
 
-     - parameter synonym: The text of the synonym.
+     - parameter synonym: The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
 
      - returns: An initialized `UpdateSynonym`.
     */

--- a/Source/ConversationV1/Models/UpdateValue.swift
+++ b/Source/ConversationV1/Models/UpdateValue.swift
@@ -19,35 +19,35 @@ import Foundation
 /** UpdateValue. */
 public struct UpdateValue {
 
-    /// Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
+    /// Specifies the type of value.
     public enum ValueType: String {
         case synonyms = "synonyms"
         case patterns = "patterns"
     }
 
-    /// The text of the entity value.
+    /// The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
     public var value: String?
 
     /// Any metadata related to the entity value.
     public var metadata: [String: JSON]?
 
-    /// Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
+    /// Specifies the type of value.
     public var valueType: String?
 
-    /// An array of synonyms for the entity value.
+    /// An array of synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following resrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
     public var synonyms: [String]?
 
-    /// An array of patterns for the entity value. A pattern is specified as a regular expression.
+    /// An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
     public var patterns: [String]?
 
     /**
      Initialize a `UpdateValue` with member variables.
 
-     - parameter value: The text of the entity value.
+     - parameter value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
      - parameter metadata: Any metadata related to the entity value.
-     - parameter valueType: Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
-     - parameter synonyms: An array of synonyms for the entity value.
-     - parameter patterns: An array of patterns for the entity value. A pattern is specified as a regular expression.
+     - parameter valueType: Specifies the type of value.
+     - parameter synonyms: An array of synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following resrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
 
      - returns: An initialized `UpdateValue`.
     */

--- a/Source/ConversationV1/Models/UpdateWorkspace.swift
+++ b/Source/ConversationV1/Models/UpdateWorkspace.swift
@@ -19,10 +19,10 @@ import Foundation
 /** UpdateWorkspace. */
 public struct UpdateWorkspace {
 
-    /// The name of the workspace.
+    /// The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 64 characters.
     public var name: String?
 
-    /// The description of the workspace.
+    /// The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
     public var description: String?
 
     /// The language of the workspace.
@@ -49,8 +49,8 @@ public struct UpdateWorkspace {
     /**
      Initialize a `UpdateWorkspace` with member variables.
 
-     - parameter name: The name of the workspace.
-     - parameter description: The description of the workspace.
+     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 64 characters.
+     - parameter description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
      - parameter language: The language of the workspace.
      - parameter intents: An array of objects defining the intents for the workspace.
      - parameter entities: An array of objects defining the entities for the workspace.

--- a/Source/ConversationV1/Models/Value.swift
+++ b/Source/ConversationV1/Models/Value.swift
@@ -19,7 +19,7 @@ import Foundation
 /** Value. */
 public struct Value {
 
-    /// Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
+    /// Specifies the type of value.
     public enum ValueType: String {
         case synonyms = "synonyms"
         case patterns = "patterns"
@@ -32,39 +32,39 @@ public struct Value {
     public var metadata: [String: JSON]?
 
     /// The timestamp for creation of the entity value.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the entity value.
-    public var updated: String
+    public var updated: String?
 
-    /// An array of synonyms for the entity value.
+    /// An array containing any synonyms for the entity value.
     public var synonyms: [String]?
 
-    /// An array of patterns for the entity value. A pattern is specified as a regular expression.
+    /// An array containing any patterns for the entity value.
     public var patterns: [String]?
 
-    /// Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
+    /// Specifies the type of value.
     public var valueType: String
 
     /**
      Initialize a `Value` with member variables.
 
      - parameter valueText: The text of the entity value.
+     - parameter valueType: Specifies the type of value.
+     - parameter metadata: Any metadata related to the entity value.
      - parameter created: The timestamp for creation of the entity value.
      - parameter updated: The timestamp for the last update to the entity value.
-     - parameter valueType: Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
-     - parameter metadata: Any metadata related to the entity value.
-     - parameter synonyms: An array of synonyms for the entity value.
-     - parameter patterns: An array of patterns for the entity value. A pattern is specified as a regular expression.
+     - parameter synonyms: An array containing any synonyms for the entity value.
+     - parameter patterns: An array containing any patterns for the entity value.
 
      - returns: An initialized `Value`.
     */
-    public init(valueText: String, created: String, updated: String, valueType: String, metadata: [String: JSON]? = nil, synonyms: [String]? = nil, patterns: [String]? = nil) {
+    public init(valueText: String, valueType: String, metadata: [String: JSON]? = nil, created: String? = nil, updated: String? = nil, synonyms: [String]? = nil, patterns: [String]? = nil) {
         self.valueText = valueText
-        self.created = created
-        self.updated = updated
         self.valueType = valueType
         self.metadata = metadata
+        self.created = created
+        self.updated = updated
         self.synonyms = synonyms
         self.patterns = patterns
     }
@@ -87,8 +87,8 @@ extension Value: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         valueText = try container.decode(String.self, forKey: .valueText)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         synonyms = try container.decodeIfPresent([String].self, forKey: .synonyms)
         patterns = try container.decodeIfPresent([String].self, forKey: .patterns)
         valueType = try container.decode(String.self, forKey: .valueType)
@@ -98,8 +98,8 @@ extension Value: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(valueText, forKey: .valueText)
         try container.encodeIfPresent(metadata, forKey: .metadata)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(synonyms, forKey: .synonyms)
         try container.encodeIfPresent(patterns, forKey: .patterns)
         try container.encode(valueType, forKey: .valueType)

--- a/Source/ConversationV1/Models/ValueExport.swift
+++ b/Source/ConversationV1/Models/ValueExport.swift
@@ -19,7 +19,7 @@ import Foundation
 /** ValueExport. */
 public struct ValueExport {
 
-    /// Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
+    /// Specifies the type of value.
     public enum ValueType: String {
         case synonyms = "synonyms"
         case patterns = "patterns"
@@ -32,39 +32,39 @@ public struct ValueExport {
     public var metadata: [String: JSON]?
 
     /// The timestamp for creation of the entity value.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the entity value.
-    public var updated: String
+    public var updated: String?
 
-    /// An array of synonyms for the entity value.
+    /// An array containing any synonyms for the entity value.
     public var synonyms: [String]?
 
-    /// An array of patterns for the entity value. A pattern is specified as a regular expression.
+    /// An array containing any patterns for the entity value.
     public var patterns: [String]?
 
-    /// Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
+    /// Specifies the type of value.
     public var valueType: String
 
     /**
      Initialize a `ValueExport` with member variables.
 
      - parameter valueText: The text of the entity value.
+     - parameter valueType: Specifies the type of value.
+     - parameter metadata: Any metadata related to the entity value.
      - parameter created: The timestamp for creation of the entity value.
      - parameter updated: The timestamp for the last update to the entity value.
-     - parameter valueType: Specifies the type of value (`synonyms` or `patterns`). The default value is `synonyms`.
-     - parameter metadata: Any metadata related to the entity value.
-     - parameter synonyms: An array of synonyms for the entity value.
-     - parameter patterns: An array of patterns for the entity value. A pattern is specified as a regular expression.
+     - parameter synonyms: An array containing any synonyms for the entity value.
+     - parameter patterns: An array containing any patterns for the entity value.
 
      - returns: An initialized `ValueExport`.
     */
-    public init(valueText: String, created: String, updated: String, valueType: String, metadata: [String: JSON]? = nil, synonyms: [String]? = nil, patterns: [String]? = nil) {
+    public init(valueText: String, valueType: String, metadata: [String: JSON]? = nil, created: String? = nil, updated: String? = nil, synonyms: [String]? = nil, patterns: [String]? = nil) {
         self.valueText = valueText
-        self.created = created
-        self.updated = updated
         self.valueType = valueType
         self.metadata = metadata
+        self.created = created
+        self.updated = updated
         self.synonyms = synonyms
         self.patterns = patterns
     }
@@ -87,8 +87,8 @@ extension ValueExport: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         valueText = try container.decode(String.self, forKey: .valueText)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         synonyms = try container.decodeIfPresent([String].self, forKey: .synonyms)
         patterns = try container.decodeIfPresent([String].self, forKey: .patterns)
         valueType = try container.decode(String.self, forKey: .valueType)
@@ -98,8 +98,8 @@ extension ValueExport: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(valueText, forKey: .valueText)
         try container.encodeIfPresent(metadata, forKey: .metadata)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encodeIfPresent(synonyms, forKey: .synonyms)
         try container.encodeIfPresent(patterns, forKey: .patterns)
         try container.encode(valueType, forKey: .valueType)

--- a/Source/ConversationV1/Models/Workspace.swift
+++ b/Source/ConversationV1/Models/Workspace.swift
@@ -26,10 +26,10 @@ public struct Workspace {
     public var language: String
 
     /// The timestamp for creation of the workspace.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the workspace.
-    public var updated: String
+    public var updated: String?
 
     /// The workspace ID.
     public var workspaceID: String
@@ -37,10 +37,10 @@ public struct Workspace {
     /// The description of the workspace.
     public var description: String?
 
-    /// Any metadata that is required by the workspace.
+    /// Any metadata related to the workspace.
     public var metadata: [String: JSON]?
 
-    /// Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+    /// Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
     public var learningOptOut: Bool?
 
     /**
@@ -48,21 +48,21 @@ public struct Workspace {
 
      - parameter name: The name of the workspace.
      - parameter language: The language of the workspace.
+     - parameter workspaceID: The workspace ID.
      - parameter created: The timestamp for creation of the workspace.
      - parameter updated: The timestamp for the last update to the workspace.
-     - parameter workspaceID: The workspace ID.
      - parameter description: The description of the workspace.
-     - parameter metadata: Any metadata that is required by the workspace.
-     - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+     - parameter metadata: Any metadata related to the workspace.
+     - parameter learningOptOut: Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
 
      - returns: An initialized `Workspace`.
     */
-    public init(name: String, language: String, created: String, updated: String, workspaceID: String, description: String? = nil, metadata: [String: JSON]? = nil, learningOptOut: Bool? = nil) {
+    public init(name: String, language: String, workspaceID: String, created: String? = nil, updated: String? = nil, description: String? = nil, metadata: [String: JSON]? = nil, learningOptOut: Bool? = nil) {
         self.name = name
         self.language = language
+        self.workspaceID = workspaceID
         self.created = created
         self.updated = updated
-        self.workspaceID = workspaceID
         self.description = description
         self.metadata = metadata
         self.learningOptOut = learningOptOut
@@ -87,8 +87,8 @@ extension Workspace: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
         language = try container.decode(String.self, forKey: .language)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         workspaceID = try container.decode(String.self, forKey: .workspaceID)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         metadata = try container.decodeIfPresent([String: JSON].self, forKey: .metadata)
@@ -99,8 +99,8 @@ extension Workspace: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
         try container.encode(language, forKey: .language)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encode(workspaceID, forKey: .workspaceID)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(metadata, forKey: .metadata)

--- a/Source/ConversationV1/Models/WorkspaceCollection.swift
+++ b/Source/ConversationV1/Models/WorkspaceCollection.swift
@@ -19,7 +19,7 @@ import Foundation
 /** WorkspaceCollection. */
 public struct WorkspaceCollection {
 
-    /// An array of workspaces.
+    /// An array of objects describing the workspaces associated with the service instance.
     public var workspaces: [Workspace]
 
     /// An object defining the pagination data for the returned objects.
@@ -28,7 +28,7 @@ public struct WorkspaceCollection {
     /**
      Initialize a `WorkspaceCollection` with member variables.
 
-     - parameter workspaces: An array of workspaces.
+     - parameter workspaces: An array of objects describing the workspaces associated with the service instance.
      - parameter pagination: An object defining the pagination data for the returned objects.
 
      - returns: An initialized `WorkspaceCollection`.

--- a/Source/ConversationV1/Models/WorkspaceExport.swift
+++ b/Source/ConversationV1/Models/WorkspaceExport.swift
@@ -41,10 +41,10 @@ public struct WorkspaceExport {
     public var metadata: [String: JSON]
 
     /// The timestamp for creation of the workspace.
-    public var created: String
+    public var created: String?
 
     /// The timestamp for the last update to the workspace.
-    public var updated: String
+    public var updated: String?
 
     /// The workspace ID.
     public var workspaceID: String
@@ -74,11 +74,11 @@ public struct WorkspaceExport {
      - parameter description: The description of the workspace.
      - parameter language: The language of the workspace.
      - parameter metadata: Any metadata that is required by the workspace.
-     - parameter created: The timestamp for creation of the workspace.
-     - parameter updated: The timestamp for the last update to the workspace.
      - parameter workspaceID: The workspace ID.
      - parameter status: The current status of the workspace.
      - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+     - parameter created: The timestamp for creation of the workspace.
+     - parameter updated: The timestamp for the last update to the workspace.
      - parameter intents: An array of intents.
      - parameter entities: An array of entities.
      - parameter counterexamples: An array of counterexamples.
@@ -86,16 +86,16 @@ public struct WorkspaceExport {
 
      - returns: An initialized `WorkspaceExport`.
     */
-    public init(name: String, description: String, language: String, metadata: [String: JSON], created: String, updated: String, workspaceID: String, status: String, learningOptOut: Bool, intents: [IntentExport]? = nil, entities: [EntityExport]? = nil, counterexamples: [Counterexample]? = nil, dialogNodes: [DialogNode]? = nil) {
+    public init(name: String, description: String, language: String, metadata: [String: JSON], workspaceID: String, status: String, learningOptOut: Bool, created: String? = nil, updated: String? = nil, intents: [IntentExport]? = nil, entities: [EntityExport]? = nil, counterexamples: [Counterexample]? = nil, dialogNodes: [DialogNode]? = nil) {
         self.name = name
         self.description = description
         self.language = language
         self.metadata = metadata
-        self.created = created
-        self.updated = updated
         self.workspaceID = workspaceID
         self.status = status
         self.learningOptOut = learningOptOut
+        self.created = created
+        self.updated = updated
         self.intents = intents
         self.entities = entities
         self.counterexamples = counterexamples
@@ -128,8 +128,8 @@ extension WorkspaceExport: Codable {
         description = try container.decode(String.self, forKey: .description)
         language = try container.decode(String.self, forKey: .language)
         metadata = try container.decode([String: JSON].self, forKey: .metadata)
-        created = try container.decode(String.self, forKey: .created)
-        updated = try container.decode(String.self, forKey: .updated)
+        created = try container.decodeIfPresent(String.self, forKey: .created)
+        updated = try container.decodeIfPresent(String.self, forKey: .updated)
         workspaceID = try container.decode(String.self, forKey: .workspaceID)
         status = try container.decode(String.self, forKey: .status)
         learningOptOut = try container.decode(Bool.self, forKey: .learningOptOut)
@@ -145,8 +145,8 @@ extension WorkspaceExport: Codable {
         try container.encode(description, forKey: .description)
         try container.encode(language, forKey: .language)
         try container.encode(metadata, forKey: .metadata)
-        try container.encode(created, forKey: .created)
-        try container.encode(updated, forKey: .updated)
+        try container.encodeIfPresent(created, forKey: .created)
+        try container.encodeIfPresent(updated, forKey: .updated)
         try container.encode(workspaceID, forKey: .workspaceID)
         try container.encode(status, forKey: .status)
         try container.encode(learningOptOut, forKey: .learningOptOut)

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -144,8 +144,8 @@ class ConversationTests: XCTestCase {
             XCTAssertNotNil(response.context.conversationID)
             XCTAssertNotEqual(response.context.conversationID, "")
             XCTAssertNotNil(response.context.system)
-            XCTAssertNotNil(response.context.system.additionalProperties)
-            XCTAssertFalse(response.context.system.additionalProperties.isEmpty)
+            XCTAssertNotNil(response.context.system!.additionalProperties)
+            XCTAssertFalse(response.context.system!.additionalProperties.isEmpty)
 
             // verify entities
             XCTAssertTrue(response.entities.isEmpty)
@@ -185,8 +185,8 @@ class ConversationTests: XCTestCase {
             // verify context
             XCTAssertEqual(response.context.conversationID, context!.conversationID)
             XCTAssertNotNil(response.context.system)
-            XCTAssertNotNil(response.context.system.additionalProperties)
-            XCTAssertFalse(response.context.system.additionalProperties.isEmpty)
+            XCTAssertNotNil(response.context.system!.additionalProperties)
+            XCTAssertFalse(response.context.system!.additionalProperties.isEmpty)
 
             // verify entities
             XCTAssertEqual(response.entities.count, 1)

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -1458,7 +1458,7 @@ class ConversationTests: XCTestCase {
 
         let description3 = "Delete a dialog node."
         let expectation3 = self.expectation(description: description3)
-        conversation.deleteDialogNode(workspaceID: workspaceID, dialogNode: updatedNode.dialogNode, failure: failWithError) {
+        conversation.deleteDialogNode(workspaceID: workspaceID, dialogNode: updatedNode.dialogNode!, failure: failWithError) {
             expectation3.fulfill()
         }
         waitForExpectations()

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -96,7 +96,7 @@ class ConversationTests: XCTestCase {
     func instantiateConversation() {
         let username = Credentials.ConversationUsername
         let password = Credentials.ConversationPassword
-        let version = "2017-05-26"
+        let version = "2018-02-16"
         conversation = Conversation(username: username, password: password, version: version)
         conversation.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         conversation.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -375,7 +375,7 @@ class ConversationTests: XCTestCase {
         let description = "List all workspaces."
         let expectation = self.expectation(description: description)
 
-        conversation.listWorkspaces(failure: failWithError) { workspaceResponse in
+        conversation.listWorkspaces(includeAudit: true, failure: failWithError) { workspaceResponse in
             for workspace in workspaceResponse.workspaces {
                 XCTAssertNotNil(workspace.name)
                 XCTAssertNotNil(workspace.created)
@@ -393,7 +393,7 @@ class ConversationTests: XCTestCase {
         let description = "List all workspaces with page limit specified as 1."
         let expectation = self.expectation(description: description)
 
-        conversation.listWorkspaces(pageLimit: 1, failure: failWithError) { workspaceResponse in
+        conversation.listWorkspaces(pageLimit: 1, includeAudit: true, failure: failWithError) { workspaceResponse in
             XCTAssertEqual(workspaceResponse.workspaces.count, 1)
             for workspace in workspaceResponse.workspaces {
                 XCTAssertNotNil(workspace.name)
@@ -413,7 +413,7 @@ class ConversationTests: XCTestCase {
         let description = "List all workspaces with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        conversation.listWorkspaces(includeCount: true, failure: failWithError) { workspaceResponse in
+        conversation.listWorkspaces(includeCount: true, includeAudit: true, failure: failWithError) { workspaceResponse in
             for workspace in workspaceResponse.workspaces {
                 XCTAssertNotNil(workspace.name)
                 XCTAssertNotNil(workspace.created)
@@ -452,8 +452,6 @@ class ConversationTests: XCTestCase {
             XCTAssertEqual(workspace.name, workspaceName)
             XCTAssertEqual(workspace.description, workspaceDescription)
             XCTAssertEqual(workspace.language, workspaceLanguage)
-            XCTAssertNotNil(workspace.created)
-            XCTAssertNotNil(workspace.updated)
             XCTAssertNotNil(workspace.workspaceID)
 
             newWorkspace = workspace.workspaceID
@@ -469,7 +467,7 @@ class ConversationTests: XCTestCase {
         let description2 = "Get the newly created workspace."
         let expectation2 = expectation(description: description2)
 
-        conversation.getWorkspace(workspaceID: newWorkspaceID, export: true, failure: failWithError) { workspace in
+        conversation.getWorkspace(workspaceID: newWorkspaceID, export: true, includeAudit: true, failure: failWithError) { workspace in
             XCTAssertEqual(workspace.name, workspaceName)
             XCTAssertEqual(workspace.description, workspaceDescription)
             XCTAssertEqual(workspace.language, workspaceLanguage)
@@ -517,7 +515,7 @@ class ConversationTests: XCTestCase {
         let description = "List details of a single workspace."
         let expectation = self.expectation(description: description)
 
-        conversation.getWorkspace(workspaceID: workspaceID, export: false, failure: failWithError) { workspace in
+        conversation.getWorkspace(workspaceID: workspaceID, export: false, includeAudit: true, failure: failWithError) { workspace in
             XCTAssertNotNil(workspace.name)
             XCTAssertNotNil(workspace.created)
             XCTAssertNotNil(workspace.updated)
@@ -548,8 +546,6 @@ class ConversationTests: XCTestCase {
             XCTAssertEqual(workspace.name, workspaceName)
             XCTAssertEqual(workspace.description, workspaceDescription)
             XCTAssertEqual(workspace.language, workspaceLanguage)
-            XCTAssertNotNil(workspace.created)
-            XCTAssertNotNil(workspace.updated)
             XCTAssertNotNil(workspace.workspaceID)
 
             newWorkspace = workspace.workspaceID
@@ -572,8 +568,6 @@ class ConversationTests: XCTestCase {
             XCTAssertEqual(workspace.name, newWorkspaceName)
             XCTAssertEqual(workspace.description, newWorkspaceDescription)
             XCTAssertEqual(workspace.language, workspaceLanguage)
-            XCTAssertNotNil(workspace.created)
-            XCTAssertNotNil(workspace.updated)
             XCTAssertNotNil(workspace.workspaceID)
             expectation2.fulfill()
         }
@@ -594,7 +588,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the intents in a workspace."
         let expectation = self.expectation(description: description)
 
-        conversation.listIntents(workspaceID: workspaceID, failure: failWithError) { intents in
+        conversation.listIntents(workspaceID: workspaceID, includeAudit: true, failure: failWithError) { intents in
             for intent in intents.intents {
                 XCTAssertNotNil(intent.intentName)
                 XCTAssertNotNil(intent.created)
@@ -614,7 +608,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the intents in a workspace with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        conversation.listIntents(workspaceID: workspaceID, includeCount: true, failure: failWithError) { intents in
+        conversation.listIntents(workspaceID: workspaceID, includeCount: true, includeAudit: true, failure: failWithError) { intents in
             for intent in intents.intents {
                 XCTAssertNotNil(intent.intentName)
                 XCTAssertNotNil(intent.created)
@@ -635,7 +629,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the intents in a workspace with pageLimit specified as 1."
         let expectation = self.expectation(description: description)
 
-        conversation.listIntents(workspaceID: workspaceID, pageLimit: 1, failure: failWithError) { intents in
+        conversation.listIntents(workspaceID: workspaceID, pageLimit: 1, includeAudit: true, failure: failWithError) { intents in
             XCTAssertEqual(intents.intents.count, 1)
             for intent in intents.intents {
                 XCTAssertNotNil(intent.intentName)
@@ -656,7 +650,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the intents in a workspace with export as true."
         let expectation = self.expectation(description: description)
 
-        conversation.listIntents(workspaceID: workspaceID, export: true, failure: failWithError) { intents in
+        conversation.listIntents(workspaceID: workspaceID, export: true, includeAudit: true, failure: failWithError) { intents in
             for intent in intents.intents {
                 XCTAssertNotNil(intent.intentName)
                 XCTAssertNotNil(intent.created)
@@ -688,8 +682,6 @@ class ConversationTests: XCTestCase {
         conversation.createIntent(workspaceID: workspaceID, intent: newIntentName, description: newIntentDescription, examples: [example1, example2], failure: failWithError) { intent in
             XCTAssertEqual(intent.intentName, newIntentName)
             XCTAssertEqual(intent.description, newIntentDescription)
-            XCTAssertNotNil(intent.created)
-            XCTAssertNotNil(intent.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -707,7 +699,7 @@ class ConversationTests: XCTestCase {
         let description = "Get details of a specific intent."
         let expectation = self.expectation(description: description)
 
-        conversation.getIntent(workspaceID: workspaceID, intent: "weather", export: true, failure: failWithError) { intent in
+        conversation.getIntent(workspaceID: workspaceID, intent: "weather", export: true, includeAudit: true, failure: failWithError) { intent in
             XCTAssertNotNil(intent.intentName)
             XCTAssertNotNil(intent.created)
             XCTAssertNotNil(intent.updated)
@@ -733,8 +725,6 @@ class ConversationTests: XCTestCase {
         conversation.createIntent(workspaceID: workspaceID, intent: newIntentName, description: newIntentDescription, examples: [example1, example2], failure: failWithError) { intent in
             XCTAssertEqual(intent.intentName, newIntentName)
             XCTAssertEqual(intent.description, newIntentDescription)
-            XCTAssertNotNil(intent.created)
-            XCTAssertNotNil(intent.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -748,8 +738,6 @@ class ConversationTests: XCTestCase {
         conversation.updateIntent(workspaceID: workspaceID, intent: newIntentName, newIntent: updatedIntentName, newDescription: updatedIntentDescription, newExamples: [updatedExample1], failure: failWithError) { intent in
             XCTAssertEqual(intent.intentName, updatedIntentName)
             XCTAssertEqual(intent.description, updatedIntentDescription)
-            XCTAssertNotNil(intent.created)
-            XCTAssertNotNil(intent.updated)
             expectation2.fulfill()
         }
         waitForExpectations()
@@ -769,7 +757,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the examples of an intent."
         let expectation = self.expectation(description: description)
 
-        conversation.listExamples(workspaceID: workspaceID, intent: "weather", failure: failWithError) { examples in
+        conversation.listExamples(workspaceID: workspaceID, intent: "weather", includeAudit: true, failure: failWithError) { examples in
             for example in examples.examples {
                 XCTAssertNotNil(example.created)
                 XCTAssertNotNil(example.updated)
@@ -787,7 +775,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the examples for an intent with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        conversation.listExamples(workspaceID: workspaceID, intent: "weather", includeCount: true, failure: failWithError) { examples in
+        conversation.listExamples(workspaceID: workspaceID, intent: "weather", includeCount: true, includeAudit: true, failure: failWithError) { examples in
             for example in examples.examples {
                 XCTAssertNotNil(example.created)
                 XCTAssertNotNil(example.updated)
@@ -806,7 +794,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the examples for an intent with pageLimit specified as 1."
         let expectation = self.expectation(description: description)
 
-        conversation.listExamples(workspaceID: workspaceID, intent: "weather", pageLimit: 1, failure: failWithError) { examples in
+        conversation.listExamples(workspaceID: workspaceID, intent: "weather", pageLimit: 1, includeAudit: true, failure: failWithError) { examples in
             XCTAssertEqual(examples.examples.count, 1)
             for example in examples.examples {
                 XCTAssertNotNil(example.created)
@@ -828,8 +816,6 @@ class ConversationTests: XCTestCase {
 
         let newExample = "swift-sdk-test-example" + UUID().uuidString
         conversation.createExample(workspaceID: workspaceID, intent: "weather", text: newExample, failure: failWithError) { example in
-            XCTAssertNotNil(example.created)
-            XCTAssertNotNil(example.updated)
             XCTAssertEqual(example.exampleText, newExample)
             expectation.fulfill()
         }
@@ -849,7 +835,7 @@ class ConversationTests: XCTestCase {
         let expectation = self.expectation(description: description)
 
         let exampleText = "tell me the weather"
-        conversation.getExample(workspaceID: workspaceID, intent: "weather", text: exampleText, failure: failWithError) { example in
+        conversation.getExample(workspaceID: workspaceID, intent: "weather", text: exampleText, includeAudit: true, failure: failWithError) { example in
             XCTAssertNotNil(example.created)
             XCTAssertNotNil(example.updated)
             XCTAssertEqual(example.exampleText, exampleText)
@@ -864,8 +850,6 @@ class ConversationTests: XCTestCase {
 
         let newExample = "swift-sdk-test-example" + UUID().uuidString
         conversation.createExample(workspaceID: workspaceID, intent: "weather", text: newExample, failure: failWithError) { example in
-            XCTAssertNotNil(example.created)
-            XCTAssertNotNil(example.updated)
             XCTAssertEqual(example.exampleText, newExample)
             expectation.fulfill()
         }
@@ -876,8 +860,6 @@ class ConversationTests: XCTestCase {
 
         let updatedText = "updated-" + newExample
         conversation.updateExample(workspaceID: workspaceID, intent: "weather", text: newExample, newText: updatedText, failure: failWithError) { example in
-            XCTAssertNotNil(example.created)
-            XCTAssertNotNil(example.updated)
             XCTAssertEqual(example.exampleText, updatedText)
             expectation2.fulfill()
         }
@@ -898,7 +880,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the counterexamples of a workspace."
         let expectation = self.expectation(description: description)
 
-        conversation.listCounterexamples(workspaceID: workspaceID, failure: failWithError) { counterexamples in
+        conversation.listCounterexamples(workspaceID: workspaceID, includeAudit: true, failure: failWithError) { counterexamples in
             for counterexample in counterexamples.counterexamples {
                 XCTAssertNotNil(counterexample.created)
                 XCTAssertNotNil(counterexample.updated)
@@ -917,7 +899,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the counterexamples of a workspace with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        conversation.listCounterexamples(workspaceID: workspaceID, includeCount: true, failure: failWithError) { counterexamples in
+        conversation.listCounterexamples(workspaceID: workspaceID, includeCount: true, includeAudit: true, failure: failWithError) { counterexamples in
             for counterexample in counterexamples.counterexamples {
                 XCTAssertNotNil(counterexample.created)
                 XCTAssertNotNil(counterexample.updated)
@@ -937,7 +919,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the counterexamples of a workspace with pageLimit specified as 1."
         let expectation = self.expectation(description: description)
 
-        conversation.listCounterexamples(workspaceID: workspaceID, pageLimit: 1, failure: failWithError) { counterexamples in
+        conversation.listCounterexamples(workspaceID: workspaceID, pageLimit: 1, includeAudit: true, failure: failWithError) { counterexamples in
             for counterexample in counterexamples.counterexamples {
                 XCTAssertNotNil(counterexample.created)
                 XCTAssertNotNil(counterexample.updated)
@@ -958,8 +940,6 @@ class ConversationTests: XCTestCase {
 
         let newExample = "swift-sdk-test-counterexample" + UUID().uuidString
         conversation.createCounterexample(workspaceID: workspaceID, text: newExample, failure: failWithError) { counterexample in
-            XCTAssertNotNil(counterexample.created)
-            XCTAssertNotNil(counterexample.updated)
             XCTAssertNotNil(counterexample.text)
             expectation.fulfill()
         }
@@ -979,7 +959,7 @@ class ConversationTests: XCTestCase {
         let expectation = self.expectation(description: description)
 
         let exampleText = "I want financial advice today."
-        conversation.getCounterexample(workspaceID: workspaceID, text: exampleText, failure: failWithError) { counterexample in
+        conversation.getCounterexample(workspaceID: workspaceID, text: exampleText, includeAudit: true, failure: failWithError) { counterexample in
             XCTAssertNotNil(counterexample.created)
             XCTAssertNotNil(counterexample.updated)
             XCTAssertEqual(counterexample.text, exampleText)
@@ -994,8 +974,6 @@ class ConversationTests: XCTestCase {
 
         let newExample = "swift-sdk-test-counterexample" + UUID().uuidString
         conversation.createCounterexample(workspaceID: workspaceID, text: newExample, failure: failWithError) { counterexample in
-            XCTAssertNotNil(counterexample.created)
-            XCTAssertNotNil(counterexample.updated)
             XCTAssertEqual(counterexample.text, newExample)
             expectation.fulfill()
         }
@@ -1006,8 +984,6 @@ class ConversationTests: XCTestCase {
 
         let updatedText = "updated-"+newExample
         conversation.updateCounterexample(workspaceID: workspaceID, text: newExample, newText: updatedText, failure: failWithError) { counterexample in
-            XCTAssertNotNil(counterexample.created)
-            XCTAssertNotNil(counterexample.updated)
             XCTAssertEqual(counterexample.text, updatedText)
             expectation2.fulfill()
         }
@@ -1028,7 +1004,7 @@ class ConversationTests: XCTestCase {
         let description = "List all entities"
         let expectation = self.expectation(description: description)
 
-        conversation.listEntities(workspaceID: workspaceID, failure: failWithError){entities in
+        conversation.listEntities(workspaceID: workspaceID, includeAudit: true, failure: failWithError){entities in
             for entity in entities.entities {
                 XCTAssertNotNil(entity.entityName)
                 XCTAssertNotNil(entity.created)
@@ -1048,7 +1024,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the entities in a workspace with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        conversation.listEntities(workspaceID: workspaceID, includeCount: true, failure: failWithError) { entities in
+        conversation.listEntities(workspaceID: workspaceID, includeCount: true, includeAudit: true, failure: failWithError) { entities in
             for entity in entities.entities {
                 XCTAssertNotNil(entity.entityName)
                 XCTAssertNotNil(entity.created)
@@ -1068,7 +1044,7 @@ class ConversationTests: XCTestCase {
         let description = "List all entities with page limit 1"
         let expectation = self.expectation(description: description)
 
-        conversation.listEntities(workspaceID: workspaceID, pageLimit: 1, failure: failWithError){entities in
+        conversation.listEntities(workspaceID: workspaceID, pageLimit: 1, includeAudit: true, failure: failWithError){entities in
             for entity in entities.entities {
                 XCTAssertNotNil(entity.entityName)
                 XCTAssertNotNil(entity.created)
@@ -1089,7 +1065,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the entities in a workspace with export as true."
         let expectation = self.expectation(description: description)
 
-        conversation.listEntities(workspaceID: workspaceID, export: true, failure: failWithError) { entities in
+        conversation.listEntities(workspaceID: workspaceID, export: true, includeAudit: true, failure: failWithError) { entities in
             for entity in entities.entities {
                 XCTAssertNotNil(entity.entityName)
                 XCTAssertNotNil(entity.created)
@@ -1115,8 +1091,6 @@ class ConversationTests: XCTestCase {
         conversation.createEntity(workspaceID: workspaceID, properties: entity, failure: failWithError){ entityResponse in
             XCTAssertEqual(entityResponse.entityName, entityName)
             XCTAssertEqual(entityResponse.description, entityDescription)
-            XCTAssertNotNil(entityResponse.created)
-            XCTAssertNotNil(entityResponse.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -1141,8 +1115,6 @@ class ConversationTests: XCTestCase {
         conversation.createEntity(workspaceID: workspaceID, properties: entity, failure: failWithError){ entityResponse in
             XCTAssertEqual(entityResponse.entityName, entityName)
             XCTAssertEqual(entityResponse.description, entityDescription)
-            XCTAssertNotNil(entityResponse.created)
-            XCTAssertNotNil(entityResponse.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -1156,8 +1128,6 @@ class ConversationTests: XCTestCase {
         conversation.updateEntity(workspaceID: workspaceID, entity: entityName, properties: updatedEntity, failure: failWithError){ entityResponse in
             XCTAssertEqual(entityResponse.entityName, updatedEntityName)
             XCTAssertEqual(entityResponse.description, updatedEntityDescription)
-            XCTAssertNotNil(entityResponse.created)
-            XCTAssertNotNil(entityResponse.updated)
             expectationTwo.fulfill()
         }
         waitForExpectations()
@@ -1178,7 +1148,7 @@ class ConversationTests: XCTestCase {
         conversation.listEntities(workspaceID: workspaceID, failure: failWithError) {entityCollection in
             XCTAssert(entityCollection.entities.count > 0)
             let entity = entityCollection.entities[0]
-            self.conversation.getEntity(workspaceID: self.workspaceID, entity: entity.entityName, export: true, failure: self.failWithError) { entityExport in
+            self.conversation.getEntity(workspaceID: self.workspaceID, entity: entity.entityName, export: true, includeAudit: true, failure: self.failWithError) { entityExport in
                 XCTAssertEqual(entityExport.entityName, entity.entityName)
                 XCTAssertEqual(entityExport.description, entity.description)
                 XCTAssertNotNil(entityExport.created)
@@ -1200,6 +1170,7 @@ class ConversationTests: XCTestCase {
             entity: entityName,
             export: true,
             includeCount: true,
+            includeAudit: true,
             failure: failWithError) {
                 valueCollection in
                 for value in valueCollection.values {
@@ -1224,8 +1195,6 @@ class ConversationTests: XCTestCase {
         let value = CreateValue(value: valueName)
         conversation.createValue(workspaceID: workspaceID, entity: entityName, properties: value, failure: failWithError) { value in
             XCTAssertEqual(value.valueText, valueName)
-            XCTAssertNotNil(value.created)
-            XCTAssertNotNil(value.updated)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -1237,8 +1206,6 @@ class ConversationTests: XCTestCase {
         let updatedValue = UpdateValue(value: updatedValueName, metadata: ["oldname": .string(valueName)])
         conversation.updateValue(workspaceID: workspaceID, entity: entityName, value: valueName, properties: updatedValue, failure: failWithError) { value in
             XCTAssertEqual(value.valueText, updatedValueName)
-            XCTAssertNotNil(value.created)
-            XCTAssertNotNil(value.updated)
             XCTAssertNotNil(value.metadata)
             expectationTwo.fulfill()
         }
@@ -1262,7 +1229,7 @@ class ConversationTests: XCTestCase {
         conversation.listValues(workspaceID: workspaceID, entity: entityName, failure: failWithError) { valueCollection in
             XCTAssert(valueCollection.values.count > 0)
             let value = valueCollection.values[0]
-            self.conversation.getValue(workspaceID: self.workspaceID, entity: entityName, value: value.valueText, export: true, failure: self.failWithError) { valueExport in
+            self.conversation.getValue(workspaceID: self.workspaceID, entity: entityName, value: value.valueText, export: true, includeAudit: true, failure: self.failWithError) { valueExport in
                 XCTAssertEqual(valueExport.valueText, value.valueText)
                 XCTAssertNotNil(valueExport.created)
                 XCTAssertNotNil(valueExport.updated)
@@ -1278,7 +1245,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the synonyms for an entity and value."
         let expectation = self.expectation(description: description)
 
-        conversation.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", failure: failWithError) { synonyms in
+        conversation.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", includeAudit: true, failure: failWithError) { synonyms in
             for synonym in synonyms.synonyms {
                 XCTAssertNotNil(synonym.created)
                 XCTAssertNotNil(synonym.updated)
@@ -1296,7 +1263,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the synonyms for an entity and value with includeCount as true."
         let expectation = self.expectation(description: description)
 
-        conversation.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", includeCount: true, failure: failWithError) { synonyms in
+        conversation.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", includeCount: true, includeAudit: true, failure: failWithError) { synonyms in
             for synonym in synonyms.synonyms {
                 XCTAssertNotNil(synonym.created)
                 XCTAssertNotNil(synonym.updated)
@@ -1315,7 +1282,7 @@ class ConversationTests: XCTestCase {
         let description = "List all the synonyms for an entity and value with pageLimit specified as 1."
         let expectation = self.expectation(description: description)
 
-        conversation.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", pageLimit: 1, failure: failWithError) { synonyms in
+        conversation.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", pageLimit: 1, includeAudit: true, failure: failWithError) { synonyms in
             XCTAssertEqual(synonyms.synonyms.count, 1)
             for synonym in synonyms.synonyms {
                 XCTAssertNotNil(synonym.created)
@@ -1337,8 +1304,6 @@ class ConversationTests: XCTestCase {
 
         let newSynonym = "swift-sdk-test-synonym" + UUID().uuidString
         conversation.createSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym, failure: failWithError) { synonym in
-            XCTAssertNotNil(synonym.created)
-            XCTAssertNotNil(synonym.updated)
             XCTAssertEqual(synonym.synonymText, newSynonym)
             expectation.fulfill()
         }
@@ -1358,7 +1323,7 @@ class ConversationTests: XCTestCase {
         let expectation = self.expectation(description: description)
 
         let synonymName = "headlight"
-        conversation.getSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: synonymName, failure: failWithError) { synonym in
+        conversation.getSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: synonymName, includeAudit: true, failure: failWithError) { synonym in
             XCTAssertEqual(synonym.synonymText, synonymName)
             XCTAssertNotNil(synonym.created)
             XCTAssertNotNil(synonym.updated)
@@ -1373,8 +1338,6 @@ class ConversationTests: XCTestCase {
 
         let newSynonym = "swift-sdk-test-synonym" + UUID().uuidString
         conversation.createSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym, failure: failWithError) { synonym in
-            XCTAssertNotNil(synonym.created)
-            XCTAssertNotNil(synonym.updated)
             XCTAssertEqual(synonym.synonymText, newSynonym)
             expectation.fulfill()
         }
@@ -1385,8 +1348,6 @@ class ConversationTests: XCTestCase {
 
         let updatedSynonym = "new-" + newSynonym
         conversation.updateSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym, newSynonym: updatedSynonym, failure: failWithError){ synonym in
-            XCTAssertNotNil(synonym.created)
-            XCTAssertNotNil(synonym.updated)
             XCTAssertEqual(synonym.synonymText, updatedSynonym)
             expectation2.fulfill()
         }


### PR DESCRIPTION
This pull request defines the `created` and `updated` properties to be optional. This is consistent with the `2018-02-16` release of the Conversation service.

The tests also pass when the service date is set to `2017-05-26`.

### Notes

The first commit reorders the methods in Conversation according to the Swagger specification. This will be the source of a large diff, but shouldn't introduce any subtle bugs from the generator—since neither order produced by the generator was consistent with the existing order of methods in `Conversation.swift`, I decided to manually copy/paste the methods to reorder them.

These tests should also be consistent with those in the Assistant pull request (#768). I copied/pasted `AssistantTests.swift` to `ConversationTests.swift` then backed out any changes where `conversation` had been renamed to `assistant`.