### PR TITLE
Update description of RestError.serializationError

### DIFF
--- a/Source/RestKit/RestError.swift
+++ b/Source/RestKit/RestError.swift
@@ -25,7 +25,7 @@ public enum RestError: Error {
     /// No data was returned from the server.
     case noData
 
-    /// Failed to serialize JSON to data.
+    /// Failed to serialize value(s) to data.
     case serializationError
 
     /// Failed to replace special characters in the


### PR DESCRIPTION
This pull request changes the description of a `RestError.serializationError`. This change has two benefits:

1. It hides the underlying representation of value(s) as JSON, rather than leaking that representation to users.
2. It allows us to use this error whenever we are serializing a value, even if that value is not actually JSON, e.g. `guard let foo.data(using: .utf8) else { throw RestError.serializationError }`