### PR TITLE
Remove deprecated services from .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,22 +1,6 @@
-
-# Exclude deprecated/legacy services
-excluded: # paths to ignore during linting. Takes precedence over `included`.
+excluded: # paths to ignore during linting (takes precedence over `included`)
   - Carthage
-  - Source/AlchemyDataNewsV1
-  - Source/AlchemyLanguageV1
-  - Source/AlchemyVisionV1
-  - Source/DialogV1
-  - Source/PersonalityInsightsV2
-  - Source/RelationshipExtractionV1Beta
-  - Source/TradeoffAnalyticsV1
   - Source/SupportingFiles/Dependencies
-  - Tests/AlchemyDataNewsV1Tests
-  - Tests/AlchemyLanguageV1Tests
-  - Tests/AlchemyVisionV1Tests
-  - Tests/DialogV1Tests
-  - Tests/PersonalityInsightsV2Tests
-  - Tests/RelationshipExtractionV1BetaTests
-  - Tests/TradeoffAnalyticsV1Tests
 
 disabled_rules: # rule identifiers to exclude from running
   - closure_parameter_position


### PR DESCRIPTION
Cleaning up `swiftlint.yml`, which I missed in #760.