### PR TITLE
Update to Swift 4.1 / Xcode 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
       dist: trusty
       sudo: required
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.3beta
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,21 @@ matrix:
       dist: trusty
       sudo: required
     - os: osx
-      osx_image: xcode9.2
+      osx_image: xcode9.3
 branches:
   only:
     - master
 env:
   global:
     - IOS_SDK="iphonesimulator"
-    - IOS_DESTINATION="OS=11.2,name=iPhone 7"
+    - IOS_DESTINATION="OS=11.3,name=iPhone 7"
 before_install:
   - openssl aes-256-cbc -K $encrypted_0a18e1be1a16_key -iv $encrypted_0a18e1be1a16_iv -in Source/SupportingFiles/Credentials.swift.enc -out Source/SupportingFiles/Credentials.swift -d
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./Scripts/run-tests.sh ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -y ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://swift.org/builds/swift-4.0.2-release/ubuntu1404/swift-4.0.2-RELEASE/swift-4.0.2-RELEASE-ubuntu14.04.tar.gz ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xzvf swift-4.0.2-RELEASE-ubuntu14.04.tar.gz ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=swift-4.0.2-RELEASE-ubuntu14.04/usr/bin:$PATH ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://swift.org/builds/swift-4.1-release/ubuntu1404/swift-4.1-RELEASE/swift-4.1-RELEASE-ubuntu14.04.tar.gz ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xzvf swift-4.1-RELEASE-ubuntu14.04.tar.gz ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=swift-4.1-RELEASE-ubuntu14.04.tar.gz/usr/bin:$PATH ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then rm Source/SupportingFiles/Credentials.swift ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then swift build ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -y ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://swift.org/builds/swift-4.1-release/ubuntu1404/swift-4.1-RELEASE/swift-4.1-RELEASE-ubuntu14.04.tar.gz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xzvf swift-4.1-RELEASE-ubuntu14.04.tar.gz ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=swift-4.1-RELEASE-ubuntu14.04.tar.gz/usr/bin:$PATH ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=swift-4.1-RELEASE-ubuntu14.04/usr/bin:$PATH ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then rm Source/SupportingFiles/Credentials.swift ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then swift build ; fi

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -8,7 +8,7 @@
 ####################
 
 # the device to build for
-DESTINATION="OS=11.2,name=iPhone 7"
+DESTINATION="OS=11.3,name=iPhone 7"
 
 # the exit code of each build command
 EXIT_CODES=()

--- a/Source/RestKit/JSON.swift
+++ b/Source/RestKit/JSON.swift
@@ -152,12 +152,12 @@ public enum JSON: Equatable, Codable {
     public static func == (lhs: JSON, rhs: JSON) -> Bool {
         switch (lhs, rhs) {
         case (.null, null): return true
-        case (.boolean(let x), .boolean(let y)): return x == y
-        case (.string(let x), .string(let y)): return x == y
-        case (.int(let x), .int(let y)): return x == y
-        case (.double(let x), .double(let y)): return x == y
-        case (.array(let x), .array(let y)): return x == y
-        case (.object(let x), .object(let y)): return x == y
+        case (.boolean(let x), .boolean(let y)): return x == y //swiftlint:disable:this identifier_name
+        case (.string(let x), .string(let y)): return x == y   //swiftlint:disable:this identifier_name
+        case (.int(let x), .int(let y)): return x == y         //swiftlint:disable:this identifier_name
+        case (.double(let x), .double(let y)): return x == y   //swiftlint:disable:this identifier_name
+        case (.array(let x), .array(let y)): return x == y     //swiftlint:disable:this identifier_name
+        case (.object(let x), .object(let y)): return x == y   //swiftlint:disable:this identifier_name
         default: return false
         }
     }

--- a/Source/RestKit/RestUtilities.swift
+++ b/Source/RestKit/RestUtilities.swift
@@ -20,8 +20,8 @@ internal extension Dictionary {
 
     internal func map<OutValue>(transform: (Value) throws -> OutValue) rethrows -> [Key: OutValue] {
         var dictionary = [Key: OutValue]()
-        for (k, v) in self {
-            dictionary[k] = try transform(v)
+        for (key, value) in self {
+            dictionary[key] = try transform(value)
         }
         return dictionary
     }

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -244,17 +244,17 @@ class AssistantTests: XCTestCase {
             XCTAssertNotNil(output)
 
             // verify intents are equal
-            for i in 0..<response.intents.count {
-                let intent1 = intents![i]
-                let intent2 = response.intents[i]
+            for index in 0..<response.intents.count {
+                let intent1 = intents![index]
+                let intent2 = response.intents[index]
                 XCTAssertEqual(intent1.intent, intent2.intent)
                 XCTAssertEqual(intent1.confidence, intent2.confidence, accuracy: 10E-5)
             }
 
             // verify entities are equal
-            for i in 0..<response.entities.count {
-                let entity1 = entities![i]
-                let entity2 = response.entities[i]
+            for index in 0..<response.entities.count {
+                let entity1 = entities![index]
+                let entity2 = response.entities[index]
                 XCTAssertEqual(entity1.entity, entity2.entity)
                 XCTAssertEqual(entity1.location[0], entity2.location[0])
                 XCTAssertEqual(entity1.location[1], entity2.location[1])
@@ -311,17 +311,17 @@ class AssistantTests: XCTestCase {
             XCTAssertNotNil(output)
 
             // verify intents are equal
-            for i in 0..<response.intents.count {
-                let intent1 = intents![i]
-                let intent2 = response.intents[i]
+            for index in 0..<response.intents.count {
+                let intent1 = intents![index]
+                let intent2 = response.intents[index]
                 XCTAssertEqual(intent1.intent, intent2.intent)
                 XCTAssertEqual(intent1.confidence, intent2.confidence, accuracy: 10E-5)
             }
 
             // verify entities are equal
-            for i in 0..<response.entities.count {
-                let entity1 = entities![i]
-                let entity2 = response.entities[i]
+            for index in 0..<response.entities.count {
+                let entity1 = entities![index]
+                let entity2 = response.entities[index]
                 XCTAssertEqual(entity1.entity, entity2.entity)
                 XCTAssertEqual(entity1.location[0], entity2.location[0])
                 XCTAssertEqual(entity1.location[1], entity2.location[1])

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -244,17 +244,17 @@ class ConversationTests: XCTestCase {
             XCTAssertNotNil(output)
 
             // verify intents are equal
-            for i in 0..<response.intents.count {
-                let intent1 = intents![i]
-                let intent2 = response.intents[i]
+            for index in 0..<response.intents.count {
+                let intent1 = intents![index]
+                let intent2 = response.intents[index]
                 XCTAssertEqual(intent1.intent, intent2.intent)
                 XCTAssertEqual(intent1.confidence, intent2.confidence, accuracy: 10E-5)
             }
 
             // verify entities are equal
-            for i in 0..<response.entities.count {
-                let entity1 = entities![i]
-                let entity2 = response.entities[i]
+            for index in 0..<response.entities.count {
+                let entity1 = entities![index]
+                let entity2 = response.entities[index]
                 XCTAssertEqual(entity1.entity, entity2.entity)
                 XCTAssertEqual(entity1.location[0], entity2.location[0])
                 XCTAssertEqual(entity1.location[1], entity2.location[1])
@@ -311,17 +311,17 @@ class ConversationTests: XCTestCase {
             XCTAssertNotNil(output)
 
             // verify intents are equal
-            for i in 0..<response.intents.count {
-                let intent1 = intents![i]
-                let intent2 = response.intents[i]
+            for index in 0..<response.intents.count {
+                let intent1 = intents![index]
+                let intent2 = response.intents[index]
                 XCTAssertEqual(intent1.intent, intent2.intent)
                 XCTAssertEqual(intent1.confidence, intent2.confidence, accuracy: 10E-5)
             }
 
             // verify entities are equal
-            for i in 0..<response.entities.count {
-                let entity1 = entities![i]
-                let entity2 = response.entities[i]
+            for index in 0..<response.entities.count {
+                let entity1 = entities![index]
+                let entity2 = response.entities[index]
                 XCTAssertEqual(entity1.entity, entity2.entity)
                 XCTAssertEqual(entity1.location[0], entity2.location[0])
                 XCTAssertEqual(entity1.location[1], entity2.location[1])

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -1123,11 +1123,11 @@ class DiscoveryTests: XCTestCase {
                         XCTAssertNotNil(result.enrichedTitle)
                         if let enrichedTitle = result.enrichedTitle {
                             XCTAssertNotNil(enrichedTitle.json["semantic_roles"])
-                            if let semantic_roles = enrichedTitle.json["semantic_roles"] as? [[String: Any]] {
-                                for semantic_role in semantic_roles {
-                                    XCTAssertNotNil(semantic_role["sentence"])
-                                    XCTAssertNotNil(semantic_role["action"])
-                                    XCTAssertNotNil(semantic_role["subject"])
+                            if let semanticRoles = enrichedTitle.json["semantic_roles"] as? [[String: Any]] {
+                                for semanticRole in semanticRoles {
+                                    XCTAssertNotNil(semanticRole["sentence"])
+                                    XCTAssertNotNil(semanticRole["action"])
+                                    XCTAssertNotNil(semanticRole["subject"])
                                     //XCTAssertNotNil(semantic_role["object"])
                                 }
                             }

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
@@ -89,9 +89,9 @@ class VisualRecognitionUIImageTests: XCTestCase {
                 return
             }
             XCTAssertGreaterThan(classes.count, 0)
-            for c in classes where c.className == "car" {
+            for cls in classes where cls.className == "car" {
                 containsPersonClass = true
-                classifierScore = c.score
+                classifierScore = cls.score
                 break
             }
             XCTAssertEqual(true, containsPersonClass)

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -568,9 +568,9 @@ class VisualRecognitionTests: XCTestCase {
                 return
             }
             XCTAssertGreaterThan(classes.count, 0)
-            for c in classes where c.className == "person" {
+            for cls in classes where cls.className == "person" {
                 containsPersonClass = true
-                classifierScore = c.score
+                classifierScore = cls.score
                 break
             }
             XCTAssertEqual(true, containsPersonClass)
@@ -620,9 +620,9 @@ class VisualRecognitionTests: XCTestCase {
                 return
             }
             XCTAssertGreaterThan(classes.count, 0)
-            for c in classes where c.className == "person" {
+            for cls in classes where cls.className == "person" {
                 containsPersonClass = true
-                classifierScore = c.score
+                classifierScore = cls.score
                 break
             }
             XCTAssertEqual(containsPersonClass, true)
@@ -740,9 +740,9 @@ class VisualRecognitionTests: XCTestCase {
                     XCTAssertEqual(classifier.name, "default")
 
                     XCTAssertGreaterThan(classifier.classes.count, 0)
-                    for c in classifier.classes where c.className == "car" {
+                    for cls in classifier.classes where cls.className == "car" {
                         containsCarClass = true
-                        classifierScore = c.score
+                        classifierScore = cls.score
                     }
                     XCTAssertEqual(containsCarClass, true)
                     if let score = classifierScore {
@@ -792,9 +792,9 @@ class VisualRecognitionTests: XCTestCase {
                 return
             }
             XCTAssertGreaterThan(classes.count, 0)
-            for c in classes where c.className == "car" {
+            for cls in classes where cls.className == "car" {
                 containsPersonClass = true
-                classifierScore = c.score
+                classifierScore = cls.score
                 break
             }
             XCTAssertEqual(true, containsPersonClass)
@@ -844,9 +844,9 @@ class VisualRecognitionTests: XCTestCase {
                 return
             }
             XCTAssertGreaterThan(classes.count, 0)
-            for c in classes where c.className == "car" {
+            for cls in classes where cls.className == "car" {
                 containsPersonClass = true
-                classifierScore = c.score
+                classifierScore = cls.score
                 break
             }
             XCTAssertEqual(containsPersonClass, true)
@@ -968,9 +968,9 @@ class VisualRecognitionTests: XCTestCase {
                     XCTAssertEqual(classifier.name, "default")
 
                     XCTAssertGreaterThan(classifier.classes.count, 0)
-                    for c in classifier.classes where c.className == "car" {
+                    for cls in classifier.classes where cls.className == "car" {
                         containsCarClass = true
-                        classifierScore = c.score
+                        classifierScore = cls.score
                     }
                     XCTAssertEqual(containsCarClass, true)
                     if let score = classifierScore {
@@ -1022,11 +1022,11 @@ class VisualRecognitionTests: XCTestCase {
                         XCTAssertEqual(classifier.classifierID, "default")
                         XCTAssertEqual(classifier.name, "default")
                         XCTAssertGreaterThan(classifier.classes.count, 0)
-                        for c in classifier.classes {
+                        for cls in classifier.classes {
                             let classes = ["car", "vehicle", "sedan", "Parking Garage (Indoor)"]
-                            if classes.contains(c.className) {
+                            if classes.contains(cls.className) {
                                 containsCarClass = true
-                                classifierScore = c.score
+                                classifierScore = cls.score
                             }
                         }
                         XCTAssertEqual(containsCarClass, true)

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -369,6 +369,7 @@
 		68D09C25200D61870087ADE5 /* DocumentAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C1E200D61870087ADE5 /* DocumentAnalysis.swift */; };
 		68D8A8862009CF5B0090B84B /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68A0EEE72006D22700E58658 /* Starscream.framework */; };
 		68D8A8872009CF680090B84B /* Starscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 68A0EEE72006D22700E58658 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		68DA5E872071E41700817741 /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68DA5E862071E41700817741 /* CoreML.framework */; };
 		68FBD8221FE0873900878788 /* VisualRecognition+CoreMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FBD8211FE0873900878788 /* VisualRecognition+CoreMLTests.swift */; };
 		7A1B0F291D82645100783EA3 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B0F281D82645100783EA3 /* Model.swift */; };
 		7A1F486B1D47AF7E00971377 /* ConversationV1.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A1F486A1D47AF7E00971377 /* ConversationV1.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -910,6 +911,7 @@
 		68D09C1C200D61870087ADE5 /* ToneInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneInput.swift; sourceTree = "<group>"; };
 		68D09C1D200D61870087ADE5 /* Utterance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utterance.swift; sourceTree = "<group>"; };
 		68D09C1E200D61870087ADE5 /* DocumentAnalysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentAnalysis.swift; sourceTree = "<group>"; };
+		68DA5E862071E41700817741 /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = System/Library/Frameworks/CoreML.framework; sourceTree = SDKROOT; };
 		68FBD8211FE0873900878788 /* VisualRecognition+CoreMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "VisualRecognition+CoreMLTests.swift"; path = "Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift"; sourceTree = SOURCE_ROOT; };
 		7A0F95B81C23288E004C01C0 /* Info-Release.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-Release.plist"; path = "Source/SupportingFiles/Info-Release.plist"; sourceTree = "<group>"; };
 		7A0F95C41C23288E004C01C0 /* Info-Tests.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-Tests.plist"; path = "Source/SupportingFiles/Info-Tests.plist"; sourceTree = "<group>"; };
@@ -1127,6 +1129,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				68DA5E872071E41700817741 /* CoreML.framework in Frameworks */,
 				7AAAF3CD1CEE9A3700B74848 /* VisualRecognitionV3.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1561,6 +1564,7 @@
 		7A0F97301C232CB5004C01C0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				68DA5E862071E41700817741 /* CoreML.framework */,
 				68A0EEE72006D22700E58658 /* Starscream.framework */,
 			);
 			name = Frameworks;

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -358,7 +358,6 @@
 		68BC29031F8C38700042810E /* RestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A61174F1CB5988B009A4DA1 /* RestRequest.swift */; };
 		68BC29041F8C38700042810E /* RestToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAA9A3D1CEE3059002C9564 /* RestToken.swift */; };
 		68BC29051F8C38700042810E /* RestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAA9A3C1CEE3059002C9564 /* RestUtilities.swift */; };
-		68FBD8221FE0873900878788 /* VisualRecognition+CoreMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FBD8211FE0873900878788 /* VisualRecognition+CoreMLTests.swift */; };
 		68C441502017B19000B251C6 /* DialogNodeVisitedDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C4414E2017B17B00B251C6 /* DialogNodeVisitedDetails.swift */; };
 		68C974AC200D52F6002DCFA3 /* CaptureGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C974AA200D52E4002DCFA3 /* CaptureGroup.swift */; };
 		68D09C1F200D61870087ADE5 /* ToneChatInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C18200D61870087ADE5 /* ToneChatInput.swift */; };
@@ -370,6 +369,7 @@
 		68D09C25200D61870087ADE5 /* DocumentAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D09C1E200D61870087ADE5 /* DocumentAnalysis.swift */; };
 		68D8A8862009CF5B0090B84B /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68A0EEE72006D22700E58658 /* Starscream.framework */; };
 		68D8A8872009CF680090B84B /* Starscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 68A0EEE72006D22700E58658 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		68FBD8221FE0873900878788 /* VisualRecognition+CoreMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FBD8211FE0873900878788 /* VisualRecognition+CoreMLTests.swift */; };
 		7A1B0F291D82645100783EA3 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B0F281D82645100783EA3 /* Model.swift */; };
 		7A1F486B1D47AF7E00971377 /* ConversationV1.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A1F486A1D47AF7E00971377 /* ConversationV1.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7A31CA8E1DD3A31C0001D469 /* StockAnnouncement.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7A31CA8D1DD3A31C0001D469 /* StockAnnouncement.wav */; };
@@ -901,7 +901,6 @@
 		68B213E81F84296D0052DC00 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		68B213ED1F8429880052DC00 /* CodableExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableExtensionsTests.swift; sourceTree = "<group>"; };
 		68B213EE1F8429890052DC00 /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
-		68FBD8211FE0873900878788 /* VisualRecognition+CoreMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "VisualRecognition+CoreMLTests.swift"; path = "Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift"; sourceTree = SOURCE_ROOT; };
 		68C4414E2017B17B00B251C6 /* DialogNodeVisitedDetails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DialogNodeVisitedDetails.swift; sourceTree = "<group>"; };
 		68C974AA200D52E4002DCFA3 /* CaptureGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaptureGroup.swift; sourceTree = "<group>"; };
 		68D09C18200D61870087ADE5 /* ToneChatInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneChatInput.swift; sourceTree = "<group>"; };
@@ -911,6 +910,7 @@
 		68D09C1C200D61870087ADE5 /* ToneInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneInput.swift; sourceTree = "<group>"; };
 		68D09C1D200D61870087ADE5 /* Utterance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utterance.swift; sourceTree = "<group>"; };
 		68D09C1E200D61870087ADE5 /* DocumentAnalysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentAnalysis.swift; sourceTree = "<group>"; };
+		68FBD8211FE0873900878788 /* VisualRecognition+CoreMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "VisualRecognition+CoreMLTests.swift"; path = "Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift"; sourceTree = SOURCE_ROOT; };
 		7A0F95B81C23288E004C01C0 /* Info-Release.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-Release.plist"; path = "Source/SupportingFiles/Info-Release.plist"; sourceTree = "<group>"; };
 		7A0F95C41C23288E004C01C0 /* Info-Tests.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-Tests.plist"; path = "Source/SupportingFiles/Info-Tests.plist"; sourceTree = "<group>"; };
 		7A1B0F281D82645100783EA3 /* Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
@@ -2545,7 +2545,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "Glenn R. Fisher";
 				TargetAttributes = {
 					1241DFAD1E380F0A00B8B33E = {
@@ -4145,12 +4145,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -4201,12 +4203,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;

--- a/WatsonDeveloperCloud.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/WatsonDeveloperCloud.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/AssistantV1.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/AssistantV1.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -78,7 +77,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/ConversationV1.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/ConversationV1.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -64,7 +63,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/DiscoveryV1.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/DiscoveryV1.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +69,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/LanguageTranslatorV2.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/LanguageTranslatorV2.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/NaturalLanguageClassifierV1.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/NaturalLanguageClassifierV1.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/NaturalLanguageUnderstandingV1.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/NaturalLanguageUnderstandingV1.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +69,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/PersonalityInsightsV3.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/PersonalityInsightsV3.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/RestKit.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/RestKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/SpeechToTextV1.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/SpeechToTextV1.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/TextToSpeechV1.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/TextToSpeechV1.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -84,7 +83,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/ToneAnalyzerV3.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/ToneAnalyzerV3.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/VisualRecognitionV3.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/VisualRecognitionV3.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Fixes build errors and warnings introduced by Swift 4.1 and Xcode 9.3.

- There were a number of new `identifier_name` errors with SwiftLint. I don't understand why these only popped up with Xcode 9.3, but I fixed them or added a comment to ignore them.

- Xcode 9.3 has a couple new recommended project settings, which I applied to `WatsonDeveloperCloud.xcodeproj`.

- Previously, the `CoreML` library was implicitly linked with the `VisualRecognitionV3Tests` target. Now, Xcode 9.3 requires the `CoreML` library to be explicitly linked in the build phases tab.