### PR TITLE
Update Starscream dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" ~> 3.0
+github "daltoniam/Starscream" "31f522155a4d6323cd1aaefb8dbc140ced7be1ca"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,1 @@
-github "daltoniam/Starscream" "3.0.4"
-github "daltoniam/common-crypto-spm" "1.1.0"
-github "daltoniam/zlib-spm" "1.1.0"
+github "daltoniam/Starscream" "31f522155a4d6323cd1aaefb8dbc140ced7be1ca"


### PR DESCRIPTION
### Summary

This pull request updates the `Cartfile` to point to a newer version of Starscream. The newer version resolves some build warnings that appear when running `carthage update --platform iOS`.

### Context

The latest [Starscream release][0] (as of this comment) is 3.0.4. Unfortunately, the 3.0.4 release causes build warnings with Xcode 9.3 (see [this issue][1] for more details).

So I temporarily changed the `Cartfile` to explicitly reference commit `31f522155a4d6323cd1aaefb8dbc140ced7be1ca`. It removes the recursive dependencies `common-crypto-spm` and `zlib-spm`, which were causing the build warnings but weren't actually required.

Once a >3.0.5 release has been published with those changes, we can revert the `Cartfile` back to `~> 3.0` to make sure that new releases will be used by the Swift SDK. But in the meantime, explicitly referencing the commit ensures that users do not experience build warnings when running Carthage.

[0]: https://github.com/daltoniam/Starscream/releases
[1]: https://github.com/daltoniam/Starscream/issues/491