### PR TITLE
Update Starscream dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" "31f522155a4d6323cd1aaefb8dbc140ced7be1ca"
+github "daltoniam/Starscream" ~> 3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" "31f522155a4d6323cd1aaefb8dbc140ced7be1ca"
+github "daltoniam/Starscream" "3.0.5"


### PR DESCRIPTION
Hot on the heels of #781, this pull request reverts the `Cartfile` to use Starscream v3.0.5.

Starscream v3.0.5 includes the Carthage fix along with updates for Swift 4.1 / Xcode 9.3.