### PR TITLE
Decrease severity of superfluous_disable_command

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -35,3 +35,6 @@ trailing_comma:
 
 trailing_whitespace:
   severity: error
+
+superfluous_disable_command:
+  severity: warning


### PR DESCRIPTION
## Summary

A `superfluous_disable_command` should not cause the build to fail. Instead, it should only be a warning.

## Context

Since SwiftLint interprets identifier names differently between Xcode 9.2 and Xcode 9.3, we added `swiftlint:disable` comments to resolve `identifier_name` errors.

However, SwiftLint does not identify those same errors when using Xcode 9.2. Instead, SwiftLint fails the build with a `superfluous_disable_command` error. The build shouldn't fail because of a comment!

<img width="1575" alt="screen shot 2018-04-09 at 9 46 37 am" src="https://user-images.githubusercontent.com/1957636/38505328-852f5620-3bdc-11e8-8b98-dea522ba916b.png">

## Related

This may resolve issue #791, where the build failed without a reasonable explanation. The user was on Xcode 9.2 and may have had SwiftLint installed, resulting in a failed `run script` that blocked the build.
