### PR TITLE
Disable cyclomatic complexity style check

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ disabled_rules: # rule identifiers to exclude from running
   - closure_parameter_position
   - opening_brace
   - redundant_string_enum_value
+  - cyclomatic_complexity
 
 opt_in_rules:
  - force_unwrapping

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -1470,8 +1470,6 @@ public class Discovery {
         }
     }
 
-    // swiftlint:disable cyclomatic_complexity
-
     /**
      Query documents.
 
@@ -1628,8 +1626,6 @@ public class Discovery {
             }
         }
     }
-
-    // swiftlint:enable cyclomatic_complexity
 
     /**
      Query system notices.

--- a/Source/DiscoveryV1/Models/QueryAggregation.swift
+++ b/Source/DiscoveryV1/Models/QueryAggregation.swift
@@ -38,7 +38,6 @@ public enum QueryAggregation: Decodable {
         case type = "type"
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         guard let type = try container.decodeIfPresent(String.self, forKey: .type) else {

--- a/Source/SpeechToTextV1/Models/RecognitionSettings.swift
+++ b/Source/SpeechToTextV1/Models/RecognitionSettings.swift
@@ -99,7 +99,6 @@ public struct RecognitionSettings: JSONEncodable {
     }
 
     /** Used internally to serialize a `RecognitionSettings` model to JSON. */
-    // swiftlint:disable:next cyclomatic_complexity
     public func toJSONObject() -> Any {
         var json = [String: Any]()
         json["action"] = action

--- a/Source/TextToSpeechV1/TextToSpeechDecoder.swift
+++ b/Source/TextToSpeechV1/TextToSpeechDecoder.swift
@@ -125,7 +125,6 @@ internal class TextToSpeechDecoder {
     }
 
     // Extract a packet from the ogg stream and store the extracted data within the packet object.
-    // swiftlint:disable:next cyclomatic_complexity
     private func extractPacket(_ streamState: inout ogg_stream_state, _ packet: inout ogg_packet) throws {
         // attempt to extract a packet from the ogg stream
         while ogg_stream_packetout(&streamState, &packet) == 1 {


### PR DESCRIPTION
## Summary

Disable the SwiftLint style rule for `cyclomatic_complexity`.

## Context

The `cyclomatic_complexity` rule checks for the number of paths through any given code block. In particular it is triggered by lots of `if` statements or `switch` statements, since lots of branches can make code difficult to understand.

However, this rule is commonly triggered by generated operations with many optional query parameters. There is an `if` statement for each optional query parameter, resulting in a large number of possible branches through the code.

Since `cyclomatic_complexity` is configured as an error, generated code may be blocked from building until we manually add `swiftlint:disable` comments to selectively turn it off.

I have yet to see a situation in our code where the `cyclomatic_complexity` error is helpful. So I'm inclined to disable the rule so we can avoid manually editing generated source code.

## Alternatives

Instead of disabling `cyclomatic_complexity`, we could reduce the severity to a warning. But we would still need to manually add `swiftline:disable` comments to resolve the warnings in generated code.