### PR TITLE
Regenerate Personality Insights

### DIFF
--- a/Source/PersonalityInsightsV3/Models/Behavior.swift
+++ b/Source/PersonalityInsightsV3/Models/Behavior.swift
@@ -17,12 +17,12 @@
 import Foundation
 
 /** Behavior. */
-public struct Behavior {
+public struct Behavior: Decodable {
 
-    /// The unique identifier of the characteristic to which the results pertain. IDs have the form `behavior_{value}`.
+    /// The unique, non-localized identifier of the characteristic to which the results pertain. IDs have the form `behavior_{value}`.
     public var traitID: String
 
-    /// The user-visible name of the characteristic.
+    /// The user-visible, localized name of the characteristic.
     public var name: String
 
     /// The category of the characteristic: `behavior` for temporal data.
@@ -31,48 +31,12 @@ public struct Behavior {
     /// For JSON content that is timestamped, the percentage of timestamped input data that occurred during that day of the week or hour of the day. The range is 0 to 1.
     public var percentage: Double
 
-    /**
-     Initialize a `Behavior` with member variables.
-
-     - parameter traitID: The unique identifier of the characteristic to which the results pertain. IDs have the form `behavior_{value}`.
-     - parameter name: The user-visible name of the characteristic.
-     - parameter category: The category of the characteristic: `behavior` for temporal data.
-     - parameter percentage: For JSON content that is timestamped, the percentage of timestamped input data that occurred during that day of the week or hour of the day. The range is 0 to 1.
-
-     - returns: An initialized `Behavior`.
-    */
-    public init(traitID: String, name: String, category: String, percentage: Double) {
-        self.traitID = traitID
-        self.name = name
-        self.category = category
-        self.percentage = percentage
-    }
-}
-
-extension Behavior: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case traitID = "trait_id"
         case name = "name"
         case category = "category"
         case percentage = "percentage"
-        static let allValues = [traitID, name, category, percentage]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        traitID = try container.decode(String.self, forKey: .traitID)
-        name = try container.decode(String.self, forKey: .name)
-        category = try container.decode(String.self, forKey: .category)
-        percentage = try container.decode(Double.self, forKey: .percentage)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(traitID, forKey: .traitID)
-        try container.encode(name, forKey: .name)
-        try container.encode(category, forKey: .category)
-        try container.encode(percentage, forKey: .percentage)
     }
 
 }

--- a/Source/PersonalityInsightsV3/Models/ConsumptionPreferences.swift
+++ b/Source/PersonalityInsightsV3/Models/ConsumptionPreferences.swift
@@ -17,54 +17,22 @@
 import Foundation
 
 /** ConsumptionPreferences. */
-public struct ConsumptionPreferences {
+public struct ConsumptionPreferences: Decodable {
 
-    /// The unique identifier of the consumption preference to which the results pertain. IDs have the form `consumption_preferences_{preference}`.
+    /// The unique, non-localized identifier of the consumption preference to which the results pertain. IDs have the form `consumption_preferences_{preference}`.
     public var consumptionPreferenceID: String
 
-    /// The user-visible name of the consumption preference.
+    /// The user-visible, localized name of the consumption preference.
     public var name: String
 
     /// The score for the consumption preference: * `0.0`: Unlikely * `0.5`: Neutral * `1.0`: Likely   The scores for some preferences are binary and do not allow a neutral value. The score is an indication of preference based on the results inferred from the input text, not a normalized percentile.
     public var score: Double
 
-    /**
-     Initialize a `ConsumptionPreferences` with member variables.
-
-     - parameter consumptionPreferenceID: The unique identifier of the consumption preference to which the results pertain. IDs have the form `consumption_preferences_{preference}`.
-     - parameter name: The user-visible name of the consumption preference.
-     - parameter score: The score for the consumption preference: * `0.0`: Unlikely * `0.5`: Neutral * `1.0`: Likely   The scores for some preferences are binary and do not allow a neutral value. The score is an indication of preference based on the results inferred from the input text, not a normalized percentile.
-
-     - returns: An initialized `ConsumptionPreferences`.
-    */
-    public init(consumptionPreferenceID: String, name: String, score: Double) {
-        self.consumptionPreferenceID = consumptionPreferenceID
-        self.name = name
-        self.score = score
-    }
-}
-
-extension ConsumptionPreferences: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case consumptionPreferenceID = "consumption_preference_id"
         case name = "name"
         case score = "score"
-        static let allValues = [consumptionPreferenceID, name, score]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        consumptionPreferenceID = try container.decode(String.self, forKey: .consumptionPreferenceID)
-        name = try container.decode(String.self, forKey: .name)
-        score = try container.decode(Double.self, forKey: .score)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(consumptionPreferenceID, forKey: .consumptionPreferenceID)
-        try container.encode(name, forKey: .name)
-        try container.encode(score, forKey: .score)
     }
 
 }

--- a/Source/PersonalityInsightsV3/Models/ConsumptionPreferencesCategory.swift
+++ b/Source/PersonalityInsightsV3/Models/ConsumptionPreferencesCategory.swift
@@ -17,9 +17,9 @@
 import Foundation
 
 /** ConsumptionPreferencesCategory. */
-public struct ConsumptionPreferencesCategory {
+public struct ConsumptionPreferencesCategory: Decodable {
 
-    /// The unique identifier of the consumption preferences category to which the results pertain. IDs have the form `consumption_preferences_{category}`.
+    /// The unique, non-localized identifier of the consumption preferences category to which the results pertain. IDs have the form `consumption_preferences_{category}`.
     public var consumptionPreferenceCategoryID: String
 
     /// The user-visible name of the consumption preferences category.
@@ -28,43 +28,11 @@ public struct ConsumptionPreferencesCategory {
     /// Detailed results inferred from the input text for the individual preferences of the category.
     public var consumptionPreferences: [ConsumptionPreferences]
 
-    /**
-     Initialize a `ConsumptionPreferencesCategory` with member variables.
-
-     - parameter consumptionPreferenceCategoryID: The unique identifier of the consumption preferences category to which the results pertain. IDs have the form `consumption_preferences_{category}`.
-     - parameter name: The user-visible name of the consumption preferences category.
-     - parameter consumptionPreferences: Detailed results inferred from the input text for the individual preferences of the category.
-
-     - returns: An initialized `ConsumptionPreferencesCategory`.
-    */
-    public init(consumptionPreferenceCategoryID: String, name: String, consumptionPreferences: [ConsumptionPreferences]) {
-        self.consumptionPreferenceCategoryID = consumptionPreferenceCategoryID
-        self.name = name
-        self.consumptionPreferences = consumptionPreferences
-    }
-}
-
-extension ConsumptionPreferencesCategory: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case consumptionPreferenceCategoryID = "consumption_preference_category_id"
         case name = "name"
         case consumptionPreferences = "consumption_preferences"
-        static let allValues = [consumptionPreferenceCategoryID, name, consumptionPreferences]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        consumptionPreferenceCategoryID = try container.decode(String.self, forKey: .consumptionPreferenceCategoryID)
-        name = try container.decode(String.self, forKey: .name)
-        consumptionPreferences = try container.decode([ConsumptionPreferences].self, forKey: .consumptionPreferences)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(consumptionPreferenceCategoryID, forKey: .consumptionPreferenceCategoryID)
-        try container.encode(name, forKey: .name)
-        try container.encode(consumptionPreferences, forKey: .consumptionPreferences)
     }
 
 }

--- a/Source/PersonalityInsightsV3/Models/Content.swift
+++ b/Source/PersonalityInsightsV3/Models/Content.swift
@@ -17,10 +17,15 @@
 import Foundation
 
 /** Content. */
-public struct Content {
+public struct Content: Encodable {
 
     /// An array of `ContentItem` objects that provides the text that is to be analyzed.
     public var contentItems: [ContentItem]
+
+    // Map each property name to the key that shall be used for encoding/decoding.
+    private enum CodingKeys: String, CodingKey {
+        case contentItems = "contentItems"
+    }
 
     /**
      Initialize a `Content` with member variables.
@@ -31,24 +36,6 @@ public struct Content {
     */
     public init(contentItems: [ContentItem]) {
         self.contentItems = contentItems
-    }
-}
-
-extension Content: Codable {
-
-    private enum CodingKeys: String, CodingKey {
-        case contentItems = "contentItems"
-        static let allValues = [contentItems]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        contentItems = try container.decode([ContentItem].self, forKey: .contentItems)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(contentItems, forKey: .contentItems)
     }
 
 }

--- a/Source/PersonalityInsightsV3/Models/ContentItem.swift
+++ b/Source/PersonalityInsightsV3/Models/ContentItem.swift
@@ -17,15 +17,15 @@
 import Foundation
 
 /** ContentItem. */
-public struct ContentItem {
+public struct ContentItem: Encodable {
 
-    /// MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
+    /// The MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
     public enum Contenttype: String {
         case plain = "text/plain"
         case html = "text/html"
     }
 
-    /// Language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the `Content-Type` header overrides the value of this parameter; any content items that specify a different language are ignored. Omit the `Content-Type` header to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
+    /// The language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the **Content-Type** parameter overrides the value of this parameter; any content items that specify a different language are ignored. Omit the **Content-Type** parameter to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
     public enum Language: String {
         case ar = "ar"
         case en = "en"
@@ -34,25 +34,25 @@ public struct ContentItem {
         case ko = "ko"
     }
 
-    /// Content that is to be analyzed. The service supports up to 20 MB of content for all items combined.
+    /// The content that is to be analyzed. The service supports up to 20 MB of content for all `ContentItem` objects combined.
     public var content: String
 
-    /// Unique identifier for this content item.
+    /// A unique identifier for this content item.
     public var id: String?
 
-    /// Timestamp that identifies when this content was created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
+    /// A timestamp that identifies when this content was created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
     public var created: Int?
 
-    /// Timestamp that identifies when this content was last updated. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
+    /// A timestamp that identifies when this content was last updated. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
     public var updated: Int?
 
-    /// MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
+    /// The MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
     public var contenttype: String?
 
-    /// Language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the `Content-Type` header overrides the value of this parameter; any content items that specify a different language are ignored. Omit the `Content-Type` header to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
+    /// The language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the **Content-Type** parameter overrides the value of this parameter; any content items that specify a different language are ignored. Omit the **Content-Type** parameter to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
     public var language: String?
 
-    /// Unique ID of the parent content item for this item. Used to identify hierarchical relationships between posts/replies, messages/replies, and so on.
+    /// The unique ID of the parent content item for this item. Used to identify hierarchical relationships between posts/replies, messages/replies, and so on.
     public var parentid: String?
 
     /// Indicates whether this content item is a reply to another content item.
@@ -61,16 +61,29 @@ public struct ContentItem {
     /// Indicates whether this content item is a forwarded/copied version of another content item.
     public var forward: Bool?
 
+    // Map each property name to the key that shall be used for encoding/decoding.
+    private enum CodingKeys: String, CodingKey {
+        case content = "content"
+        case id = "id"
+        case created = "created"
+        case updated = "updated"
+        case contenttype = "contenttype"
+        case language = "language"
+        case parentid = "parentid"
+        case reply = "reply"
+        case forward = "forward"
+    }
+
     /**
      Initialize a `ContentItem` with member variables.
 
-     - parameter content: Content that is to be analyzed. The service supports up to 20 MB of content for all items combined.
-     - parameter id: Unique identifier for this content item.
-     - parameter created: Timestamp that identifies when this content was created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
-     - parameter updated: Timestamp that identifies when this content was last updated. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
-     - parameter contenttype: MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
-     - parameter language: Language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the `Content-Type` header overrides the value of this parameter; any content items that specify a different language are ignored. Omit the `Content-Type` header to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
-     - parameter parentid: Unique ID of the parent content item for this item. Used to identify hierarchical relationships between posts/replies, messages/replies, and so on.
+     - parameter content: The content that is to be analyzed. The service supports up to 20 MB of content for all `ContentItem` objects combined.
+     - parameter id: A unique identifier for this content item.
+     - parameter created: A timestamp that identifies when this content was created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
+     - parameter updated: A timestamp that identifies when this content was last updated. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
+     - parameter contenttype: The MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
+     - parameter language: The language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the **Content-Type** parameter overrides the value of this parameter; any content items that specify a different language are ignored. Omit the **Content-Type** parameter to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
+     - parameter parentid: The unique ID of the parent content item for this item. Used to identify hierarchical relationships between posts/replies, messages/replies, and so on.
      - parameter reply: Indicates whether this content item is a reply to another content item.
      - parameter forward: Indicates whether this content item is a forwarded/copied version of another content item.
 
@@ -86,48 +99,6 @@ public struct ContentItem {
         self.parentid = parentid
         self.reply = reply
         self.forward = forward
-    }
-}
-
-extension ContentItem: Codable {
-
-    private enum CodingKeys: String, CodingKey {
-        case content = "content"
-        case id = "id"
-        case created = "created"
-        case updated = "updated"
-        case contenttype = "contenttype"
-        case language = "language"
-        case parentid = "parentid"
-        case reply = "reply"
-        case forward = "forward"
-        static let allValues = [content, id, created, updated, contenttype, language, parentid, reply, forward]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        content = try container.decode(String.self, forKey: .content)
-        id = try container.decodeIfPresent(String.self, forKey: .id)
-        created = try container.decodeIfPresent(Int.self, forKey: .created)
-        updated = try container.decodeIfPresent(Int.self, forKey: .updated)
-        contenttype = try container.decodeIfPresent(String.self, forKey: .contenttype)
-        language = try container.decodeIfPresent(String.self, forKey: .language)
-        parentid = try container.decodeIfPresent(String.self, forKey: .parentid)
-        reply = try container.decodeIfPresent(Bool.self, forKey: .reply)
-        forward = try container.decodeIfPresent(Bool.self, forKey: .forward)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(content, forKey: .content)
-        try container.encodeIfPresent(id, forKey: .id)
-        try container.encodeIfPresent(created, forKey: .created)
-        try container.encodeIfPresent(updated, forKey: .updated)
-        try container.encodeIfPresent(contenttype, forKey: .contenttype)
-        try container.encodeIfPresent(language, forKey: .language)
-        try container.encodeIfPresent(parentid, forKey: .parentid)
-        try container.encodeIfPresent(reply, forKey: .reply)
-        try container.encodeIfPresent(forward, forKey: .forward)
     }
 
 }

--- a/Source/PersonalityInsightsV3/Models/Profile.swift
+++ b/Source/PersonalityInsightsV3/Models/Profile.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Profile. */
-public struct Profile {
+public struct Profile: Decodable {
 
     /// The language model that was used to process the input.
     public enum ProcessedLanguage: String {
@@ -31,97 +31,41 @@ public struct Profile {
     /// The language model that was used to process the input.
     public var processedLanguage: String
 
-    /// The number of words that were found in the input.
+    /// The number of words from the input that were used to produce the profile.
     public var wordCount: Int
 
     /// When guidance is appropriate, a string that provides a message that indicates the number of words found and where that value falls in the range of required or suggested number of words.
     public var wordCountMessage: String?
 
-    /// Detailed results for the Big Five personality characteristics (dimensions and facets) inferred from the input text.
+    /// A recursive array of `Trait` objects that provides detailed results for the Big Five personality characteristics (dimensions and facets) inferred from the input text.
     public var personality: [Trait]
 
     /// Detailed results for the Needs characteristics inferred from the input text.
-    public var values: [Trait]
+    public var needs: [Trait]
 
     /// Detailed results for the Values characteristics inferred from the input text.
-    public var needs: [Trait]
+    public var values: [Trait]
 
     /// For JSON content that is timestamped, detailed results about the social behavior disclosed by the input in terms of temporal characteristics. The results include information about the distribution of the content over the days of the week and the hours of the day.
     public var behavior: [Behavior]?
 
-    /// If the `consumption_preferences` query parameter is `true`, detailed results for each category of consumption preferences. Each element of the array provides information inferred from the input text for the individual preferences of that category.
+    /// If the **consumption_preferences** parameter is `true`, detailed results for each category of consumption preferences. Each element of the array provides information inferred from the input text for the individual preferences of that category.
     public var consumptionPreferences: [ConsumptionPreferencesCategory]?
 
     /// Warning messages associated with the input text submitted with the request. The array is empty if the input generated no warnings.
     public var warnings: [Warning]
 
-    /**
-     Initialize a `Profile` with member variables.
-
-     - parameter processedLanguage: The language model that was used to process the input.
-     - parameter wordCount: The number of words that were found in the input.
-     - parameter personality: Detailed results for the Big Five personality characteristics (dimensions and facets) inferred from the input text.
-     - parameter values: Detailed results for the Needs characteristics inferred from the input text.
-     - parameter needs: Detailed results for the Values characteristics inferred from the input text.
-     - parameter warnings: Warning messages associated with the input text submitted with the request. The array is empty if the input generated no warnings.
-     - parameter wordCountMessage: When guidance is appropriate, a string that provides a message that indicates the number of words found and where that value falls in the range of required or suggested number of words.
-     - parameter behavior: For JSON content that is timestamped, detailed results about the social behavior disclosed by the input in terms of temporal characteristics. The results include information about the distribution of the content over the days of the week and the hours of the day.
-     - parameter consumptionPreferences: If the `consumption_preferences` query parameter is `true`, detailed results for each category of consumption preferences. Each element of the array provides information inferred from the input text for the individual preferences of that category.
-
-     - returns: An initialized `Profile`.
-    */
-    public init(processedLanguage: String, wordCount: Int, personality: [Trait], values: [Trait], needs: [Trait], warnings: [Warning], wordCountMessage: String? = nil, behavior: [Behavior]? = nil, consumptionPreferences: [ConsumptionPreferencesCategory]? = nil) {
-        self.processedLanguage = processedLanguage
-        self.wordCount = wordCount
-        self.personality = personality
-        self.values = values
-        self.needs = needs
-        self.warnings = warnings
-        self.wordCountMessage = wordCountMessage
-        self.behavior = behavior
-        self.consumptionPreferences = consumptionPreferences
-    }
-}
-
-extension Profile: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case processedLanguage = "processed_language"
         case wordCount = "word_count"
         case wordCountMessage = "word_count_message"
         case personality = "personality"
-        case values = "values"
         case needs = "needs"
+        case values = "values"
         case behavior = "behavior"
         case consumptionPreferences = "consumption_preferences"
         case warnings = "warnings"
-        static let allValues = [processedLanguage, wordCount, wordCountMessage, personality, values, needs, behavior, consumptionPreferences, warnings]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        processedLanguage = try container.decode(String.self, forKey: .processedLanguage)
-        wordCount = try container.decode(Int.self, forKey: .wordCount)
-        wordCountMessage = try container.decodeIfPresent(String.self, forKey: .wordCountMessage)
-        personality = try container.decode([Trait].self, forKey: .personality)
-        values = try container.decode([Trait].self, forKey: .values)
-        needs = try container.decode([Trait].self, forKey: .needs)
-        behavior = try container.decodeIfPresent([Behavior].self, forKey: .behavior)
-        consumptionPreferences = try container.decodeIfPresent([ConsumptionPreferencesCategory].self, forKey: .consumptionPreferences)
-        warnings = try container.decode([Warning].self, forKey: .warnings)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(processedLanguage, forKey: .processedLanguage)
-        try container.encode(wordCount, forKey: .wordCount)
-        try container.encodeIfPresent(wordCountMessage, forKey: .wordCountMessage)
-        try container.encode(personality, forKey: .personality)
-        try container.encode(values, forKey: .values)
-        try container.encode(needs, forKey: .needs)
-        try container.encodeIfPresent(behavior, forKey: .behavior)
-        try container.encodeIfPresent(consumptionPreferences, forKey: .consumptionPreferences)
-        try container.encode(warnings, forKey: .warnings)
     }
 
 }

--- a/Source/PersonalityInsightsV3/Models/Trait.swift
+++ b/Source/PersonalityInsightsV3/Models/Trait.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Trait. */
-public struct Trait {
+public struct Trait: Decodable {
 
     /// The category of the characteristic: * `personality` for Big Five personality characteristics * `needs` for Needs * `values` for Values.
     public enum Category: String {
@@ -26,10 +26,10 @@ public struct Trait {
         case values = "values"
     }
 
-    /// The unique identifier of the characteristic to which the results pertain. IDs have the form `big5_{characteristic}` for Big Five personality characteristics, `need_{characteristic}` for Needs, or `value_{characteristic}` for Values.
+    /// The unique, non-localized identifier of the characteristic to which the results pertain. IDs have the form * `big5_{characteristic}` for Big Five personality dimensions * `facet_{characteristic}` for Big Five personality facets * `need_{characteristic}` for Needs  *`value_{characteristic}` for Values.
     public var traitID: String
 
-    /// The user-visible name of the characteristic.
+    /// The user-visible, localized name of the characteristic.
     public var name: String
 
     /// The category of the characteristic: * `personality` for Big Five personality characteristics * `needs` for Needs * `values` for Values.
@@ -38,7 +38,7 @@ public struct Trait {
     /// The normalized percentile score for the characteristic. The range is 0 to 1. For example, if the percentage for Openness is 0.60, the author scored in the 60th percentile; the author is more open than 59 percent of the population and less open than 39 percent of the population.
     public var percentile: Double
 
-    /// The raw score for the characteristic. The range is 0 to 1. A higher score generally indicates a greater likelihood that the author has that characteristic, but raw scores must be considered in aggregate: The range of values in practice might be much smaller than 0 to 1, so an individual score must be considered in the context of the overall scores and their range. The raw score is computed based on the input and the service model; it is not normalized or compared with a sample population. The raw score enables comparison of the results against a different sampling population and with a custom normalization approach.
+    /// The raw score for the characteristic. The range is 0 to 1. A higher score generally indicates a greater likelihood that the author has that characteristic, but raw scores must be considered in aggregate: The range of values in practice might be much smaller than 0 to 1, so an individual score must be considered in the context of the overall scores and their range.   The raw score is computed based on the input and the service model; it is not normalized or compared with a sample population. The raw score enables comparison of the results against a different sampling population and with a custom normalization approach.
     public var rawScore: Double?
 
     /// **`2017-10-13`**: Indicates whether the characteristic is meaningful for the input language. The field is always `true` for all characteristics of English, Spanish, and Japanese input. The field is `false` for the subset of characteristics of Arabic and Korean input for which the service's models are unable to generate meaningful results. **`2016-10-19`**: Not returned.
@@ -47,32 +47,7 @@ public struct Trait {
     /// For `personality` (Big Five) dimensions, more detailed results for the facets of each dimension as inferred from the input text.
     public var children: [Trait]?
 
-    /**
-     Initialize a `Trait` with member variables.
-
-     - parameter traitID: The unique identifier of the characteristic to which the results pertain. IDs have the form `big5_{characteristic}` for Big Five personality characteristics, `need_{characteristic}` for Needs, or `value_{characteristic}` for Values.
-     - parameter name: The user-visible name of the characteristic.
-     - parameter category: The category of the characteristic: * `personality` for Big Five personality characteristics * `needs` for Needs * `values` for Values.
-     - parameter percentile: The normalized percentile score for the characteristic. The range is 0 to 1. For example, if the percentage for Openness is 0.60, the author scored in the 60th percentile; the author is more open than 59 percent of the population and less open than 39 percent of the population.
-     - parameter rawScore: The raw score for the characteristic. The range is 0 to 1. A higher score generally indicates a greater likelihood that the author has that characteristic, but raw scores must be considered in aggregate: The range of values in practice might be much smaller than 0 to 1, so an individual score must be considered in the context of the overall scores and their range. The raw score is computed based on the input and the service model; it is not normalized or compared with a sample population. The raw score enables comparison of the results against a different sampling population and with a custom normalization approach.
-     - parameter significant: **`2017-10-13`**: Indicates whether the characteristic is meaningful for the input language. The field is always `true` for all characteristics of English, Spanish, and Japanese input. The field is `false` for the subset of characteristics of Arabic and Korean input for which the service's models are unable to generate meaningful results. **`2016-10-19`**: Not returned.
-     - parameter children: For `personality` (Big Five) dimensions, more detailed results for the facets of each dimension as inferred from the input text.
-
-     - returns: An initialized `Trait`.
-    */
-    public init(traitID: String, name: String, category: String, percentile: Double, rawScore: Double? = nil, significant: Bool? = nil, children: [Trait]? = nil) {
-        self.traitID = traitID
-        self.name = name
-        self.category = category
-        self.percentile = percentile
-        self.rawScore = rawScore
-        self.significant = significant
-        self.children = children
-    }
-}
-
-extension Trait: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case traitID = "trait_id"
         case name = "name"
@@ -81,29 +56,6 @@ extension Trait: Codable {
         case rawScore = "raw_score"
         case significant = "significant"
         case children = "children"
-        static let allValues = [traitID, name, category, percentile, rawScore, significant, children]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        traitID = try container.decode(String.self, forKey: .traitID)
-        name = try container.decode(String.self, forKey: .name)
-        category = try container.decode(String.self, forKey: .category)
-        percentile = try container.decode(Double.self, forKey: .percentile)
-        rawScore = try container.decodeIfPresent(Double.self, forKey: .rawScore)
-        significant = try container.decodeIfPresent(Bool.self, forKey: .significant)
-        children = try container.decodeIfPresent([Trait].self, forKey: .children)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(traitID, forKey: .traitID)
-        try container.encode(name, forKey: .name)
-        try container.encode(category, forKey: .category)
-        try container.encode(percentile, forKey: .percentile)
-        try container.encodeIfPresent(rawScore, forKey: .rawScore)
-        try container.encodeIfPresent(significant, forKey: .significant)
-        try container.encodeIfPresent(children, forKey: .children)
     }
 
 }

--- a/Source/PersonalityInsightsV3/Models/Warning.swift
+++ b/Source/PersonalityInsightsV3/Models/Warning.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Warning. */
-public struct Warning {
+public struct Warning: Decodable {
 
     /// The identifier of the warning message.
     public enum WarningID: String {
@@ -33,38 +33,10 @@ public struct Warning {
     /// The message associated with the `warning_id`: * `WORD_COUNT_MESSAGE`: "There were {number} words in the input. We need a minimum of 600, preferably 1,200 or more, to compute statistically significant estimates." * `JSON_AS_TEXT`: "Request input was processed as text/plain as indicated, however detected a JSON input. Did you mean application/json?" * `CONTENT_TRUNCATED`: "For maximum accuracy while also optimizing processing time, only the first 250KB of input text (excluding markup) was analyzed. Accuracy levels off at approximately 3,000 words so this did not affect the accuracy of the profile." * `PARTIAL_TEXT_USED`, "The text provided to compute the profile was trimmed for performance reasons. This action does not affect the accuracy of the output, as not all of the input text was required." Applies only when Arabic input text exceeds a threshold at which additional words do not contribute to the accuracy of the profile.
     public var message: String
 
-    /**
-     Initialize a `Warning` with member variables.
-
-     - parameter warningID: The identifier of the warning message.
-     - parameter message: The message associated with the `warning_id`: * `WORD_COUNT_MESSAGE`: "There were {number} words in the input. We need a minimum of 600, preferably 1,200 or more, to compute statistically significant estimates." * `JSON_AS_TEXT`: "Request input was processed as text/plain as indicated, however detected a JSON input. Did you mean application/json?" * `CONTENT_TRUNCATED`: "For maximum accuracy while also optimizing processing time, only the first 250KB of input text (excluding markup) was analyzed. Accuracy levels off at approximately 3,000 words so this did not affect the accuracy of the profile." * `PARTIAL_TEXT_USED`, "The text provided to compute the profile was trimmed for performance reasons. This action does not affect the accuracy of the output, as not all of the input text was required." Applies only when Arabic input text exceeds a threshold at which additional words do not contribute to the accuracy of the profile.
-
-     - returns: An initialized `Warning`.
-    */
-    public init(warningID: String, message: String) {
-        self.warningID = warningID
-        self.message = message
-    }
-}
-
-extension Warning: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case warningID = "warning_id"
         case message = "message"
-        static let allValues = [warningID, message]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        warningID = try container.decode(String.self, forKey: .warningID)
-        message = try container.decode(String.self, forKey: .message)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(warningID, forKey: .warningID)
-        try container.encode(message, forKey: .message)
     }
 
 }

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -145,6 +145,17 @@ public class PersonalityInsights {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -162,9 +173,7 @@ public class PersonalityInsights {
             method: "POST",
             url: serviceURL + "/v3/profile",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -234,6 +243,17 @@ public class PersonalityInsights {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "text/plain"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -251,9 +271,7 @@ public class PersonalityInsights {
             method: "POST",
             url: serviceURL + "/v3/profile",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "text/plain",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -323,6 +341,17 @@ public class PersonalityInsights {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "text/html"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -340,9 +369,7 @@ public class PersonalityInsights {
             method: "POST",
             url: serviceURL + "/v3/profile",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "text/html",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -415,6 +442,17 @@ public class PersonalityInsights {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "text/csv"
+        headers["Content-Type"] = "application/json"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -436,9 +474,7 @@ public class PersonalityInsights {
             method: "POST",
             url: serviceURL + "/v3/profile",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "text/csv",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -511,6 +547,17 @@ public class PersonalityInsights {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "text/csv"
+        headers["Content-Type"] = "text/plain"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -532,9 +579,7 @@ public class PersonalityInsights {
             method: "POST",
             url: serviceURL + "/v3/profile",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "text/csv",
-            contentType: "text/plain",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -607,6 +652,17 @@ public class PersonalityInsights {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "text/csv"
+        headers["Content-Type"] = "text/html"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -628,9 +684,7 @@ public class PersonalityInsights {
             method: "POST",
             url: serviceURL + "/v3/profile",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "text/csv",
-            contentType: "text/html",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -17,36 +17,17 @@
 import Foundation
 
 /**
- ### Service Overview
- The IBM Watson Personality Insights service provides a Representational State Transfer (REST) Application Programming
- Interface (API) that enables applications to derive insights from social media, enterprise data, or other digital
- communications. The service uses linguistic analytics to infer individuals' intrinsic personality characteristics,
- including Big Five, Needs, and Values, from digital communications such as email, text messages, tweets, and forum
- posts. The service can automatically infer, from potentially noisy social media, portraits of individuals that reflect
- their personality characteristics. The service can report consumption preferences based on the results of its analysis,
- and for JSON content that is timestamped, it can report temporal behavior.
- ### API Usage
- The following information provides details about using the service to obtain a personality profile:
- * **The profile method:** The service offers a single `/v3/profile` method that accepts up to 20 MB of input data and
- produces results in JSON or CSV format. The service accepts input in Arabic, English, Japanese, Korean, or Spanish and
- can produce output in a variety of languages.
- * **Authentication:** You authenticate to the service by using your service credentials. You can use your credentials
- to authenticate via a proxy server that resides in IBM Cloud, or you can use your credentials to obtain a token and
- contact the service directly. See [Service credentials for Watson
- services](https://console.bluemix.net/docs/services/watson/getting-started-credentials.html) and [Tokens for
- authentication](https://console.bluemix.net/docs/services/watson/getting-started-tokens.html).
- * **Request Logging:** By default, all Watson services log requests and their results. Data is collected only to
- improve the Watson services. If you do not want to share your data, set the header parameter
- `X-Watson-Learning-Opt-Out` to `true` for each request. Data is collected for any request that omits this header. See
- [Controlling request logging for Watson
- services](https://console.bluemix.net/docs/services/watson/getting-started-logging.html).
-
- For more information about the service, see [About Personality
- Insights](https://console.bluemix.net/docs/services/personality-insights/index.html). For information about calling the
- service and the responses it can generate, see [Requesting a
- profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON
- profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
- profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
+ The IBM Watson Personality Insights service enables applications to derive insights from social media, enterprise data,
+ or other digital communications. The service uses linguistic analytics to infer individuals' intrinsic personality
+ characteristics, including Big Five, Needs, and Values, from digital communications such as email, text messages,
+ tweets, and forum posts.
+ The service can automatically infer, from potentially noisy social media, portraits of individuals that reflect their
+ personality characteristics. The service can infer consumption preferences based on the results of its analysis and,
+ for JSON content that is timestamped, can report temporal behavior.
+ For information about the meaning of the models that the service uses to describe personality characteristics, see
+ [Personality models](https://console.bluemix.net/docs/services/personality-insights/models.html). For information about
+ the meaning of the consumption preferences, see [Consumption
+ preferences](https://console.bluemix.net/docs/services/personality-insights/preferences.html).
  */
 public class PersonalityInsights {
 
@@ -66,7 +47,7 @@ public class PersonalityInsights {
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date
-       in "YYYY-MM-DD" format.
+     in "YYYY-MM-DD" format.
      */
     public init(username: String, password: String, version: String) {
         self.credentials = .basicAuthentication(username: username, password: password)
@@ -110,22 +91,45 @@ public class PersonalityInsights {
     }
 
     /**
-     Generates a personality profile based on input text.
+     Get profile.
 
-     Derives personality insights for up to 20 MB of input content written by an author, though the service requires
-     much less text to produce an accurate profile; for more information, see [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). Accepts input in
-     Arabic, English, Japanese, Korean, or Spanish and produces output in one of eleven languages. Provide plain text,
-     HTML, or JSON content, and receive results in JSON or CSV format.
+     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
+     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
+     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
+     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
+     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
+     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
+     parameter; CSV output includes a fixed number of columns and optional headers.   Per the JSON specification, the
+     default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default
+     encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content
+     type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text;
+     for example: `Content-Type: text/plain;charset=utf-8`.   For detailed information about calling the service and the
+     responses it can generate, see (Requesting a
+     profile)[https://console.bluemix.net/docs/services/personality-insights/input.html], (Understanding a JSON
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output.html], and (Understanding a CSV
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output-csv.html].
 
-     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). A JSON request must conform to the `Content` model.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The effect of the `contentLanguage` header depends on the `Content-Type` header. When `Content-Type` is `text/plain` or `text/html`, `contentLanguage` is the only way to specify the language. When `Content-Type` is `application/json`, `contentLanguage` overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this header to base the language on the specification of the content items. You can specify any combination of languages for `contentLanguage` and `Accept-Language`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input and response content.
-     - parameter rawScores: If `true`, a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. If `false` (the default), only normalized percentiles are returned.
-     - parameter consumptionPreferences: If `true`, information about consumption preferences is returned with the results; if `false` (the default), the response does not include the information.
+     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
+     [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient).
+     For JSON input, provide an object of type `Content`.
+     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
+     are treated as their parent language; for example, `en-US` is interpreted as `en`.   The effect of the
+     **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type** is `text/plain` or
+     `text/html`, **Content-Language** is the only way to specify the language. When **Content-Type** is
+     `application/json`, **Content-Language** overrides a language specified with the `language` parameter of a
+     `ContentItem` object, and content items that specify a different language are ignored; omit this parameter to base
+     the language on the specification of the content items. You can specify any combination of languages for
+     **Content-Language** and **Accept-Language**.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
+     and response content.
+     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
+     scores are not compared with a sample population. By default, only normalized percentiles are returned.
+     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences are
+     returned.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
-    */
+     */
     public func profile(
         content: Content,
         contentLanguage: String? = nil,
@@ -176,19 +180,42 @@ public class PersonalityInsights {
     }
 
     /**
-     Generates a personality profile based on input text.
+     Get profile.
 
-     Derives personality insights for up to 20 MB of input content written by an author, though the service requires
-     much less text to produce an accurate profile; for more information, see [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). Accepts input in
-     Arabic, English, Japanese, Korean, or Spanish and produces output in one of eleven languages. Provide plain text,
-     HTML, or JSON content, and receive results in JSON or CSV format.
+     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
+     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
+     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
+     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
+     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
+     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
+     parameter; CSV output includes a fixed number of columns and optional headers.   Per the JSON specification, the
+     default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default
+     encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content
+     type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text;
+     for example: `Content-Type: text/plain;charset=utf-8`.   For detailed information about calling the service and the
+     responses it can generate, see (Requesting a
+     profile)[https://console.bluemix.net/docs/services/personality-insights/input.html], (Understanding a JSON
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output.html], and (Understanding a CSV
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output-csv.html].
 
-     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). A JSON request must conform to the `Content` model.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The effect of the `contentLanguage` header depends on the `Content-Type` header. When `Content-Type` is `text/plain` or `text/html`, `contentLanguage` is the only way to specify the language. When `Content-Type` is `application/json`, `contentLanguage` overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this header to base the language on the specification of the content items. You can specify any combination of languages for `contentLanguage` and `Accept-Language`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input and response content.
-     - parameter rawScores: If `true`, a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. If `false` (the default), only normalized percentiles are returned.
-     - parameter consumptionPreferences: If `true`, information about consumption preferences is returned with the results; if `false` (the default), the response does not include the information.
+     - parameter text: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
+     [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient).
+     For JSON input, provide an object of type `Content`.
+     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
+     are treated as their parent language; for example, `en-US` is interpreted as `en`.   The effect of the
+     **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type** is `text/plain` or
+     `text/html`, **Content-Language** is the only way to specify the language. When **Content-Type** is
+     `application/json`, **Content-Language** overrides a language specified with the `language` parameter of a
+     `ContentItem` object, and content items that specify a different language are ignored; omit this parameter to base
+     the language on the specification of the content items. You can specify any combination of languages for
+     **Content-Language** and **Accept-Language**.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
+     and response content.
+     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
+     scores are not compared with a sample population. By default, only normalized percentiles are returned.
+     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences are
+     returned.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -242,19 +269,42 @@ public class PersonalityInsights {
     }
 
     /**
-     Generates a personality profile based on input text.
+     Get profile.
 
-     Derives personality insights for up to 20 MB of input content written by an author, though the service requires
-     much less text to produce an accurate profile; for more information, see [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). Accepts input in
-     Arabic, English, Japanese, Korean, or Spanish and produces output in one of eleven languages. Provide plain text,
-     HTML, or JSON content, and receive results in JSON or CSV format.
+     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
+     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
+     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
+     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
+     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
+     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
+     parameter; CSV output includes a fixed number of columns and optional headers.   Per the JSON specification, the
+     default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default
+     encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content
+     type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text;
+     for example: `Content-Type: text/plain;charset=utf-8`.   For detailed information about calling the service and the
+     responses it can generate, see (Requesting a
+     profile)[https://console.bluemix.net/docs/services/personality-insights/input.html], (Understanding a JSON
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output.html], and (Understanding a CSV
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output-csv.html].
 
-     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). A JSON request must conform to the `Content` model.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The effect of the `contentLanguage` header depends on the `Content-Type` header. When `Content-Type` is `text/plain` or `text/html`, `contentLanguage` is the only way to specify the language. When `Content-Type` is `application/json`, `contentLanguage` overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this header to base the language on the specification of the content items. You can specify any combination of languages for `contentLanguage` and `Accept-Language`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input and response content.
-     - parameter rawScores: If `true`, a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. If `false` (the default), only normalized percentiles are returned.
-     - parameter consumptionPreferences: If `true`, information about consumption preferences is returned with the results; if `false` (the default), the response does not include the information.
+     - parameter html: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
+     [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient).
+     For JSON input, provide an object of type `Content`.
+     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
+     are treated as their parent language; for example, `en-US` is interpreted as `en`.   The effect of the
+     **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type** is `text/plain` or
+     `text/html`, **Content-Language** is the only way to specify the language. When **Content-Type** is
+     `application/json`, **Content-Language** overrides a language specified with the `language` parameter of a
+     `ContentItem` object, and content items that specify a different language are ignored; omit this parameter to base
+     the language on the specification of the content items. You can specify any combination of languages for
+     **Content-Language** and **Accept-Language**.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
+     and response content.
+     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
+     scores are not compared with a sample population. By default, only normalized percentiles are returned.
+     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences are
+     returned.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -308,23 +358,47 @@ public class PersonalityInsights {
     }
 
     /**
-     Generates a personality profile based on input text.
+     Get profile. as csv
 
-     Derives personality insights for up to 20 MB of input content written by an author, though the service requires
-     much less text to produce an accurate profile; for more information, see [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). Accepts input in
-     Arabic, English, Japanese, Korean, or Spanish and produces output in one of eleven languages. Provide plain text,
-     HTML, or JSON content, and receive results in JSON or CSV format.
+     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
+     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
+     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
+     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
+     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
+     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
+     parameter; CSV output includes a fixed number of columns and optional headers.   Per the JSON specification, the
+     default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default
+     encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content
+     type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text;
+     for example: `Content-Type: text/plain;charset=utf-8`.   For detailed information about calling the service and the
+     responses it can generate, see (Requesting a
+     profile)[https://console.bluemix.net/docs/services/personality-insights/input.html], (Understanding a JSON
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output.html], and (Understanding a CSV
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output-csv.html].
 
-     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). A JSON request must conform to the `Content` model.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The effect of the `Content-Language` header depends on the `Content-Type` header. When `Content-Type` is `text/plain` or `text/html`, `Content-Language` is the only way to specify the language. When `Content-Type` is `application/json`, `Content-Language` overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this header to base the language on the specification of the content items. You can specify any combination of languages for `Content-Language` and `Accept-Language`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input and response content.
-     - parameter rawScores: If `true`, a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. If `false` (the default), only normalized percentiles are returned.
-     - parameter csvHeaders: If `true`, column labels are returned with a CSV response; if `false` (the default), they are not. Applies only when the `Accept` header is set to `text/csv`.
-     - parameter consumptionPreferences: If `true`, information about consumption preferences is returned with the results; if `false` (the default), the response does not include the information.
+     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
+     [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient).
+     For JSON input, provide an object of type `Content`.
+     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
+     are treated as their parent language; for example, `en-US` is interpreted as `en`.   The effect of the
+     **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type** is `text/plain` or
+     `text/html`, **Content-Language** is the only way to specify the language. When **Content-Type** is
+     `application/json`, **Content-Language** overrides a language specified with the `language` parameter of a
+     `ContentItem` object, and content items that specify a different language are ignored; omit this parameter to base
+     the language on the specification of the content items. You can specify any combination of languages for
+     **Content-Language** and **Accept-Language**.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
+     and response content.
+     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
+     scores are not compared with a sample population. By default, only normalized percentiles are returned.
+     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences are
+     returned.
+     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column labels are returned.
+     Applies only when the **Accept** parameter is set to `text/csv`.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
-    */
+     */
     public func profileAsCsv(
         content: Content,
         contentLanguage: String? = nil,
@@ -380,20 +454,44 @@ public class PersonalityInsights {
     }
 
     /**
-     Generates a personality profile based on input text.
+     Get profile. as csv
 
-     Derives personality insights for up to 20 MB of input content written by an author, though the service requires
-     much less text to produce an accurate profile; for more information, see [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). Accepts input in
-     Arabic, English, Japanese, Korean, or Spanish and produces output in one of eleven languages. Provide plain text,
-     HTML, or JSON content, and receive results in JSON or CSV format.
+     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
+     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
+     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
+     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
+     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
+     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
+     parameter; CSV output includes a fixed number of columns and optional headers.   Per the JSON specification, the
+     default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default
+     encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content
+     type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text;
+     for example: `Content-Type: text/plain;charset=utf-8`.   For detailed information about calling the service and the
+     responses it can generate, see (Requesting a
+     profile)[https://console.bluemix.net/docs/services/personality-insights/input.html], (Understanding a JSON
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output.html], and (Understanding a CSV
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output-csv.html].
 
-     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). A JSON request must conform to the `Content` model.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The effect of the `Content-Language` header depends on the `Content-Type` header. When `Content-Type` is `text/plain` or `text/html`, `Content-Language` is the only way to specify the language. When `Content-Type` is `application/json`, `Content-Language` overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this header to base the language on the specification of the content items. You can specify any combination of languages for `Content-Language` and `Accept-Language`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input and response content.
-     - parameter rawScores: If `true`, a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. If `false` (the default), only normalized percentiles are returned.
-     - parameter csvHeaders: If `true`, column labels are returned with a CSV response; if `false` (the default), they are not. Applies only when the `Accept` header is set to `text/csv`.
-     - parameter consumptionPreferences: If `true`, information about consumption preferences is returned with the results; if `false` (the default), the response does not include the information.
+     - parameter text: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
+     [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient).
+     For JSON input, provide an object of type `Content`.
+     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
+     are treated as their parent language; for example, `en-US` is interpreted as `en`.   The effect of the
+     **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type** is `text/plain` or
+     `text/html`, **Content-Language** is the only way to specify the language. When **Content-Type** is
+     `application/json`, **Content-Language** overrides a language specified with the `language` parameter of a
+     `ContentItem` object, and content items that specify a different language are ignored; omit this parameter to base
+     the language on the specification of the content items. You can specify any combination of languages for
+     **Content-Language** and **Accept-Language**.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
+     and response content.
+     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
+     scores are not compared with a sample population. By default, only normalized percentiles are returned.
+     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences are
+     returned.
+     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column labels are returned.
+     Applies only when the **Accept** parameter is set to `text/csv`.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
@@ -452,20 +550,44 @@ public class PersonalityInsights {
     }
 
     /**
-     Generates a personality profile based on input text.
+     Get profile. as csv
 
-     Derives personality insights for up to 20 MB of input content written by an author, though the service requires
-     much less text to produce an accurate profile; for more information, see [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). Accepts input in
-     Arabic, English, Japanese, Korean, or Spanish and produces output in one of eleven languages. Provide plain text,
-     HTML, or JSON content, and receive results in JSON or CSV format.
+     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
+     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
+     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
+     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
+     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
+     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
+     parameter; CSV output includes a fixed number of columns and optional headers.   Per the JSON specification, the
+     default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default
+     encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content
+     type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text;
+     for example: `Content-Type: text/plain;charset=utf-8`.   For detailed information about calling the service and the
+     responses it can generate, see (Requesting a
+     profile)[https://console.bluemix.net/docs/services/personality-insights/input.html], (Understanding a JSON
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output.html], and (Understanding a CSV
+     profile)[https://console.bluemix.net/docs/services/personality-insights/output-csv.html].
 
-     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). A JSON request must conform to the `Content` model.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The effect of the `Content-Language` header depends on the `Content-Type` header. When `Content-Type` is `text/plain` or `text/html`, `Content-Language` is the only way to specify the language. When `Content-Type` is `application/json`, `Content-Language` overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this header to base the language on the specification of the content items. You can specify any combination of languages for `Content-Language` and `Accept-Language`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input and response content.
-     - parameter rawScores: If `true`, a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. If `false` (the default), only normalized percentiles are returned.
-     - parameter csvHeaders: If `true`, column labels are returned with a CSV response; if `false` (the default), they are not. Applies only when the `Accept` header is set to `text/csv`.
-     - parameter consumptionPreferences: If `true`, information about consumption preferences is returned with the results; if `false` (the default), the response does not include the information.
+     - parameter html: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
+     [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient).
+     For JSON input, provide an object of type `Content`.
+     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
+     are treated as their parent language; for example, `en-US` is interpreted as `en`.   The effect of the
+     **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type** is `text/plain` or
+     `text/html`, **Content-Language** is the only way to specify the language. When **Content-Type** is
+     `application/json`, **Content-Language** overrides a language specified with the `language` parameter of a
+     `ContentItem` object, and content items that specify a different language are ignored; omit this parameter to base
+     the language on the specification of the content items. You can specify any combination of languages for
+     **Content-Language** and **Accept-Language**.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
+     and response content.
+     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
+     scores are not compared with a sample population. By default, only normalized percentiles are returned.
+     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences are
+     returned.
+     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column labels are returned.
+     Applies only when the **Accept** parameter is set to `text/csv`.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */


### PR DESCRIPTION
In addition to updating Personality Insights to conform to the latest style produced by the generator, this pull request changes the order of the `consumptionPreferences` and `csvHeaders` parameters.

Unfortunately, those parameters were swapped with this [commit][1] to the API definition. It's a backwards-incompatible change for Swift (and possibly other languages).

[1]: https://github.ibm.com/Watson/developer-cloud--api-definitions/commit/2adb55dca35609452e3288800c7f316544d07c6c#diff-6e067731bbc6e1a453f51152d65e1823L115