### PR TITLE
Regenerate Tone Analyzer

### DIFF
--- a/Source/ToneAnalyzerV3/Models/DocumentAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/DocumentAnalysis.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DocumentAnalysis. */
-public struct DocumentAnalysis {
+public struct DocumentAnalysis: Decodable {
 
     /// **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the document. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
     public var tones: [ToneScore]?
@@ -28,43 +28,11 @@ public struct DocumentAnalysis {
     /// **`2017-09-21`:** A warning message if the overall content exceeds 128 KB or contains more than 1000 sentences. The service analyzes only the first 1000 sentences for document-level analysis and the first 100 sentences for sentence-level analysis. **`2016-05-19`:** Not returned.
     public var warning: String?
 
-    /**
-     Initialize a `DocumentAnalysis` with member variables.
-
-     - parameter tones: **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the document. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
-     - parameter toneCategories: **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the full document of the input content. The service returns results only for the tones specified with the `tones` parameter of the request.
-     - parameter warning: **`2017-09-21`:** A warning message if the overall content exceeds 128 KB or contains more than 1000 sentences. The service analyzes only the first 1000 sentences for document-level analysis and the first 100 sentences for sentence-level analysis. **`2016-05-19`:** Not returned.
-
-     - returns: An initialized `DocumentAnalysis`.
-    */
-    public init(tones: [ToneScore]? = nil, toneCategories: [ToneCategory]? = nil, warning: String? = nil) {
-        self.tones = tones
-        self.toneCategories = toneCategories
-        self.warning = warning
-    }
-}
-
-extension DocumentAnalysis: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case tones = "tones"
         case toneCategories = "tone_categories"
         case warning = "warning"
-        static let allValues = [tones, toneCategories, warning]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        tones = try container.decodeIfPresent([ToneScore].self, forKey: .tones)
-        toneCategories = try container.decodeIfPresent([ToneCategory].self, forKey: .toneCategories)
-        warning = try container.decodeIfPresent(String.self, forKey: .warning)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encodeIfPresent(tones, forKey: .tones)
-        try container.encodeIfPresent(toneCategories, forKey: .toneCategories)
-        try container.encodeIfPresent(warning, forKey: .warning)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/SentenceAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/SentenceAnalysis.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SentenceAnalysis. */
-public struct SentenceAnalysis {
+public struct SentenceAnalysis: Decodable {
 
     /// The unique identifier of a sentence of the input content. The first sentence has ID 0, and the ID of each subsequent sentence is incremented by one.
     public var sentenceID: Int
@@ -37,30 +37,7 @@ public struct SentenceAnalysis {
     /// **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the last character of the sentence in the overall input content.
     public var inputTo: Int?
 
-    /**
-     Initialize a `SentenceAnalysis` with member variables.
-
-     - parameter sentenceID: The unique identifier of a sentence of the input content. The first sentence has ID 0, and the ID of each subsequent sentence is incremented by one.
-     - parameter text: The text of the input sentence.
-     - parameter tones: **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the sentence. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
-     - parameter toneCategories: **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the sentence. The service returns results only for the tones specified with the `tones` parameter of the request.
-     - parameter inputFrom: **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the first character of the sentence in the overall input content.
-     - parameter inputTo: **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the last character of the sentence in the overall input content.
-
-     - returns: An initialized `SentenceAnalysis`.
-    */
-    public init(sentenceID: Int, text: String, tones: [ToneScore]? = nil, toneCategories: [ToneCategory]? = nil, inputFrom: Int? = nil, inputTo: Int? = nil) {
-        self.sentenceID = sentenceID
-        self.text = text
-        self.tones = tones
-        self.toneCategories = toneCategories
-        self.inputFrom = inputFrom
-        self.inputTo = inputTo
-    }
-}
-
-extension SentenceAnalysis: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case sentenceID = "sentence_id"
         case text = "text"
@@ -68,27 +45,6 @@ extension SentenceAnalysis: Codable {
         case toneCategories = "tone_categories"
         case inputFrom = "input_from"
         case inputTo = "input_to"
-        static let allValues = [sentenceID, text, tones, toneCategories, inputFrom, inputTo]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        sentenceID = try container.decode(Int.self, forKey: .sentenceID)
-        text = try container.decode(String.self, forKey: .text)
-        tones = try container.decodeIfPresent([ToneScore].self, forKey: .tones)
-        toneCategories = try container.decodeIfPresent([ToneCategory].self, forKey: .toneCategories)
-        inputFrom = try container.decodeIfPresent(Int.self, forKey: .inputFrom)
-        inputTo = try container.decodeIfPresent(Int.self, forKey: .inputTo)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(sentenceID, forKey: .sentenceID)
-        try container.encode(text, forKey: .text)
-        try container.encodeIfPresent(tones, forKey: .tones)
-        try container.encodeIfPresent(toneCategories, forKey: .toneCategories)
-        try container.encodeIfPresent(inputFrom, forKey: .inputFrom)
-        try container.encodeIfPresent(inputTo, forKey: .inputTo)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/ToneAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneAnalysis.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneAnalysis. */
-public struct ToneAnalysis {
+public struct ToneAnalysis: Decodable {
 
     /// An object of type `DocumentAnalysis` that provides the results of the analysis for the full input document.
     public var documentTone: DocumentAnalysis
@@ -25,38 +25,10 @@ public struct ToneAnalysis {
     /// An array of `SentenceAnalysis` objects that provides the results of the analysis for the individual sentences of the input content. The service returns results only for the first 100 sentences of the input. The field is omitted if the `sentences` parameter of the request is set to `false`.
     public var sentencesTone: [SentenceAnalysis]?
 
-    /**
-     Initialize a `ToneAnalysis` with member variables.
-
-     - parameter documentTone: An object of type `DocumentAnalysis` that provides the results of the analysis for the full input document.
-     - parameter sentencesTone: An array of `SentenceAnalysis` objects that provides the results of the analysis for the individual sentences of the input content. The service returns results only for the first 100 sentences of the input. The field is omitted if the `sentences` parameter of the request is set to `false`.
-
-     - returns: An initialized `ToneAnalysis`.
-    */
-    public init(documentTone: DocumentAnalysis, sentencesTone: [SentenceAnalysis]? = nil) {
-        self.documentTone = documentTone
-        self.sentencesTone = sentencesTone
-    }
-}
-
-extension ToneAnalysis: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case documentTone = "document_tone"
         case sentencesTone = "sentences_tone"
-        static let allValues = [documentTone, sentencesTone]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        documentTone = try container.decode(DocumentAnalysis.self, forKey: .documentTone)
-        sentencesTone = try container.decodeIfPresent([SentenceAnalysis].self, forKey: .sentencesTone)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(documentTone, forKey: .documentTone)
-        try container.encodeIfPresent(sentencesTone, forKey: .sentencesTone)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/ToneCategory.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneCategory.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneCategory. */
-public struct ToneCategory {
+public struct ToneCategory: Decodable {
 
     /// An array of `ToneScore` objects that provides the results for the tones of the category.
     public var tones: [ToneScore]
@@ -28,43 +28,11 @@ public struct ToneCategory {
     /// The user-visible, localized name of the category.
     public var categoryName: String
 
-    /**
-     Initialize a `ToneCategory` with member variables.
-
-     - parameter tones: An array of `ToneScore` objects that provides the results for the tones of the category.
-     - parameter categoryID: The unique, non-localized identifier of the category for the results. The service can return results for the following category IDs: `emotion_tone`, `language_tone`, and `social_tone`.
-     - parameter categoryName: The user-visible, localized name of the category.
-
-     - returns: An initialized `ToneCategory`.
-    */
-    public init(tones: [ToneScore], categoryID: String, categoryName: String) {
-        self.tones = tones
-        self.categoryID = categoryID
-        self.categoryName = categoryName
-    }
-}
-
-extension ToneCategory: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case tones = "tones"
         case categoryID = "category_id"
         case categoryName = "category_name"
-        static let allValues = [tones, categoryID, categoryName]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        tones = try container.decode([ToneScore].self, forKey: .tones)
-        categoryID = try container.decode(String.self, forKey: .categoryID)
-        categoryName = try container.decode(String.self, forKey: .categoryName)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(tones, forKey: .tones)
-        try container.encode(categoryID, forKey: .categoryID)
-        try container.encode(categoryName, forKey: .categoryName)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/ToneChatInput.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneChatInput.swift
@@ -17,10 +17,15 @@
 import Foundation
 
 /** ToneChatInput. */
-public struct ToneChatInput {
+public struct ToneChatInput: Encodable {
 
     /// An array of `Utterance` objects that provides the input content that the service is to analyze.
     public var utterances: [Utterance]
+
+    // Map each property name to the key that shall be used for encoding/decoding.
+    private enum CodingKeys: String, CodingKey {
+        case utterances = "utterances"
+    }
 
     /**
      Initialize a `ToneChatInput` with member variables.
@@ -31,24 +36,6 @@ public struct ToneChatInput {
     */
     public init(utterances: [Utterance]) {
         self.utterances = utterances
-    }
-}
-
-extension ToneChatInput: Codable {
-
-    private enum CodingKeys: String, CodingKey {
-        case utterances = "utterances"
-        static let allValues = [utterances]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        utterances = try container.decode([Utterance].self, forKey: .utterances)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(utterances, forKey: .utterances)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneChatScore. */
-public struct ToneChatScore {
+public struct ToneChatScore: Decodable {
 
     /// The score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the utterance.
     public var score: Double
@@ -28,43 +28,11 @@ public struct ToneChatScore {
     /// The user-visible, localized name of the tone.
     public var toneName: String
 
-    /**
-     Initialize a `ToneChatScore` with member variables.
-
-     - parameter score: The score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the utterance.
-     - parameter toneID: The unique, non-localized identifier of the tone for the results. The service can return results for the following tone IDs: `sad`, `frustrated`, `satisfied`, `excited`, `polite`, `impolite`, and `sympathetic`. The service returns results only for tones whose scores meet a minimum threshold of 0.5.
-     - parameter toneName: The user-visible, localized name of the tone.
-
-     - returns: An initialized `ToneChatScore`.
-    */
-    public init(score: Double, toneID: String, toneName: String) {
-        self.score = score
-        self.toneID = toneID
-        self.toneName = toneName
-    }
-}
-
-extension ToneChatScore: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case score = "score"
         case toneID = "tone_id"
         case toneName = "tone_name"
-        static let allValues = [score, toneID, toneName]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        score = try container.decode(Double.self, forKey: .score)
-        toneID = try container.decode(String.self, forKey: .toneID)
-        toneName = try container.decode(String.self, forKey: .toneName)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(score, forKey: .score)
-        try container.encode(toneID, forKey: .toneID)
-        try container.encode(toneName, forKey: .toneName)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/ToneInput.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneInput.swift
@@ -17,10 +17,15 @@
 import Foundation
 
 /** ToneInput. */
-public struct ToneInput {
+public struct ToneInput: Encodable {
 
     /// The input content that the service is to analyze.
     public var text: String
+
+    // Map each property name to the key that shall be used for encoding/decoding.
+    private enum CodingKeys: String, CodingKey {
+        case text = "text"
+    }
 
     /**
      Initialize a `ToneInput` with member variables.
@@ -31,24 +36,6 @@ public struct ToneInput {
     */
     public init(text: String) {
         self.text = text
-    }
-}
-
-extension ToneInput: Codable {
-
-    private enum CodingKeys: String, CodingKey {
-        case text = "text"
-        static let allValues = [text]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        text = try container.decode(String.self, forKey: .text)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(text, forKey: .text)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/ToneScore.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneScore.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneScore. */
-public struct ToneScore {
+public struct ToneScore: Decodable {
 
     /// The score for the tone. * **`2017-09-21`:** The score that is returned lies in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the content. * **`2016-05-19`:** The score that is returned lies in the range of 0 to 1. A score less than 0.5 indicates that the tone is unlikely to be perceived in the content; a score greater than 0.75 indicates a high likelihood that the tone is perceived.
     public var score: Double
@@ -28,43 +28,11 @@ public struct ToneScore {
     /// The user-visible, localized name of the tone.
     public var toneName: String
 
-    /**
-     Initialize a `ToneScore` with member variables.
-
-     - parameter score: The score for the tone. * **`2017-09-21`:** The score that is returned lies in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the content. * **`2016-05-19`:** The score that is returned lies in the range of 0 to 1. A score less than 0.5 indicates that the tone is unlikely to be perceived in the content; a score greater than 0.75 indicates a high likelihood that the tone is perceived.
-     - parameter toneID: The unique, non-localized identifier of the tone. * **`2017-09-21`:** The service can return results for the following tone IDs: `anger`, `fear`, `joy`, and `sadness` (emotional tones); `analytical`, `confident`, and `tentative` (language tones). The service returns results only for tones whose scores meet a minimum threshold of 0.5. * **`2016-05-19`:** The service can return results for the following tone IDs of the different categories: for the `emotion` category: `anger`, `disgust`, `fear`, `joy`, and `sadness`; for the `language` category: `analytical`, `confident`, and `tentative`; for the `social` category: `openness_big5`, `conscientiousness_big5`, `extraversion_big5`, `agreeableness_big5`, and `emotional_range_big5`. The service returns scores for all tones of a category, regardless of their values.
-     - parameter toneName: The user-visible, localized name of the tone.
-
-     - returns: An initialized `ToneScore`.
-    */
-    public init(score: Double, toneID: String, toneName: String) {
-        self.score = score
-        self.toneID = toneID
-        self.toneName = toneName
-    }
-}
-
-extension ToneScore: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case score = "score"
         case toneID = "tone_id"
         case toneName = "tone_name"
-        static let allValues = [score, toneID, toneName]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        score = try container.decode(Double.self, forKey: .score)
-        toneID = try container.decode(String.self, forKey: .toneID)
-        toneName = try container.decode(String.self, forKey: .toneName)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(score, forKey: .score)
-        try container.encode(toneID, forKey: .toneID)
-        try container.encode(toneName, forKey: .toneName)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/Utterance.swift
+++ b/Source/ToneAnalyzerV3/Models/Utterance.swift
@@ -17,13 +17,19 @@
 import Foundation
 
 /** Utterance. */
-public struct Utterance {
+public struct Utterance: Encodable {
 
     /// An utterance contributed by a user in the conversation that is to be analyzed. The utterance can contain multiple sentences.
     public var text: String
 
     /// A string that identifies the user who contributed the utterance specified by the `text` parameter.
     public var user: String?
+
+    // Map each property name to the key that shall be used for encoding/decoding.
+    private enum CodingKeys: String, CodingKey {
+        case text = "text"
+        case user = "user"
+    }
 
     /**
      Initialize a `Utterance` with member variables.
@@ -36,27 +42,6 @@ public struct Utterance {
     public init(text: String, user: String? = nil) {
         self.text = text
         self.user = user
-    }
-}
-
-extension Utterance: Codable {
-
-    private enum CodingKeys: String, CodingKey {
-        case text = "text"
-        case user = "user"
-        static let allValues = [text, user]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        text = try container.decode(String.self, forKey: .text)
-        user = try container.decodeIfPresent(String.self, forKey: .user)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(text, forKey: .text)
-        try container.encodeIfPresent(user, forKey: .user)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/UtteranceAnalyses.swift
+++ b/Source/ToneAnalyzerV3/Models/UtteranceAnalyses.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UtteranceAnalyses. */
-public struct UtteranceAnalyses {
+public struct UtteranceAnalyses: Decodable {
 
     /// An array of `UtteranceAnalysis` objects that provides the results for each utterance of the input.
     public var utterancesTone: [UtteranceAnalysis]
@@ -25,38 +25,10 @@ public struct UtteranceAnalyses {
     /// **`2017-09-21`:** A warning message if the content contains more than 50 utterances. The service analyzes only the first 50 utterances. **`2016-05-19`:** Not returned.
     public var warning: String?
 
-    /**
-     Initialize a `UtteranceAnalyses` with member variables.
-
-     - parameter utterancesTone: An array of `UtteranceAnalysis` objects that provides the results for each utterance of the input.
-     - parameter warning: **`2017-09-21`:** A warning message if the content contains more than 50 utterances. The service analyzes only the first 50 utterances. **`2016-05-19`:** Not returned.
-
-     - returns: An initialized `UtteranceAnalyses`.
-    */
-    public init(utterancesTone: [UtteranceAnalysis], warning: String? = nil) {
-        self.utterancesTone = utterancesTone
-        self.warning = warning
-    }
-}
-
-extension UtteranceAnalyses: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case utterancesTone = "utterances_tone"
         case warning = "warning"
-        static let allValues = [utterancesTone, warning]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        utterancesTone = try container.decode([UtteranceAnalysis].self, forKey: .utterancesTone)
-        warning = try container.decodeIfPresent(String.self, forKey: .warning)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(utterancesTone, forKey: .utterancesTone)
-        try container.encodeIfPresent(warning, forKey: .warning)
     }
 
 }

--- a/Source/ToneAnalyzerV3/Models/UtteranceAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/UtteranceAnalysis.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UtteranceAnalysis. */
-public struct UtteranceAnalysis {
+public struct UtteranceAnalysis: Decodable {
 
     /// The unique identifier of the utterance. The first utterance has ID 0, and the ID of each subsequent utterance is incremented by one.
     public var utteranceID: Int
@@ -31,48 +31,12 @@ public struct UtteranceAnalysis {
     /// **`2017-09-21`:** An error message if the utterance contains more than 500 characters. The service does not analyze the utterance. **`2016-05-19`:** Not returned.
     public var error: String?
 
-    /**
-     Initialize a `UtteranceAnalysis` with member variables.
-
-     - parameter utteranceID: The unique identifier of the utterance. The first utterance has ID 0, and the ID of each subsequent utterance is incremented by one.
-     - parameter utteranceText: The text of the utterance.
-     - parameter tones: An array of `ToneChatScore` objects that provides results for the most prevalent tones of the utterance. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold.
-     - parameter error: **`2017-09-21`:** An error message if the utterance contains more than 500 characters. The service does not analyze the utterance. **`2016-05-19`:** Not returned.
-
-     - returns: An initialized `UtteranceAnalysis`.
-    */
-    public init(utteranceID: Int, utteranceText: String, tones: [ToneChatScore], error: String? = nil) {
-        self.utteranceID = utteranceID
-        self.utteranceText = utteranceText
-        self.tones = tones
-        self.error = error
-    }
-}
-
-extension UtteranceAnalysis: Codable {
-
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case utteranceID = "utterance_id"
         case utteranceText = "utterance_text"
         case tones = "tones"
         case error = "error"
-        static let allValues = [utteranceID, utteranceText, tones, error]
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        utteranceID = try container.decode(Int.self, forKey: .utteranceID)
-        utteranceText = try container.decode(String.self, forKey: .utteranceText)
-        tones = try container.decode([ToneChatScore].self, forKey: .tones)
-        error = try container.decodeIfPresent(String.self, forKey: .error)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(utteranceID, forKey: .utteranceID)
-        try container.encode(utteranceText, forKey: .utteranceText)
-        try container.encode(tones, forKey: .tones)
-        try container.encodeIfPresent(error, forKey: .error)
     }
 
 }

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -99,8 +99,6 @@ public class ToneAnalyzer {
 
      - parameter toneInput: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type
      `ToneInput`.
-     - parameter contentType: The type of the input: application/json, text/plain, or text/html. A character encoding can be specified by
-     including a `charset` parameter. For example, 'text/plain;charset=utf-8'.
      - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of
      the full document. If `true` (the default), the service returns results for each sentence.
      - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the
@@ -120,7 +118,6 @@ public class ToneAnalyzer {
      */
     public func tone(
         toneInput: ToneInput,
-        contentType: String,
         sentences: Bool? = nil,
         tones: [String]? = nil,
         contentLanguage: String? = nil,

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -201,6 +201,7 @@ public class ToneAnalyzer {
      */
     public func toneChat(
         utterances: [Utterance],
+        contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (UtteranceAnalyses) -> Void)
@@ -216,6 +217,9 @@ public class ToneAnalyzer {
         var headers = defaultHeaders
         headers["Accept"] = "application/json"
         headers["Content-Type"] = "application/json"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
         if let acceptLanguage = acceptLanguage {
             headers["Accept-Language"] = acceptLanguage
         }

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -17,34 +17,11 @@
 import Foundation
 
 /**
-  ### Service Overview
  The IBM Watson Tone Analyzer service uses linguistic analysis to detect emotional and language tones in written text.
  The service can analyze tone at both the document and sentence levels. You can use the service to understand how your
  written communications are perceived and then to improve the tone of your communications. Businesses can use the
  service to learn the tone of their customers' communications and to respond to each customer appropriately, or to
  understand and improve their customer conversations.
- ### API Usage
- The following information provides details about using the service to analyze tone:
- * **The tone method:** The service offers `GET` and `POST /v3/tone` methods that use the general purpose endpoint to
- analyze the tone of input content. The methods accept content in JSON, plain text, or HTML format.
- * **The tone_chat method:** The service offers a `POST /v3/tone_chat` method that uses the customer engagement endpoint
- to analyze the tone of customer service and customer support conversations. The method accepts content in JSON format.
- * **Authentication:** You authenticate to the service by using your service credentials. You can use your credentials
- to authenticate via a proxy server that resides in IBM Cloud, or you can use your credentials to obtain a token and
- contact the service directly. See [Service credentials for Watson
- services](https://console.bluemix.net/docs/services/watson/getting-started-credentials.html) and [Tokens for
- authentication](https://console.bluemix.net/docs/services/watson/getting-started-tokens.html).
- * **Request Logging:** By default, all Watson services log requests and their results. Data is collected only to
- improve the Watson services. If you do not want to share your data, set the header parameter
- `X-Watson-Learning-Opt-Out` to `true` for each request. Data is collected for any request that omits this header. See
- [Controlling request logging for Watson
- services](https://console.bluemix.net/docs/services/watson/getting-started-logging.html).
-
- For more information about the service, see [About Tone
- Analyzer](https://console.bluemix.net/docs/services/tone-analyzer/index.html).
-
- **Note:** Method descriptions apply to the latest version of the interface, `2017-09-21`. Where necessary, parameters
- and models describe differences between versions `2017-09-21` and `2016-05-19`.
  */
 public class ToneAnalyzer {
 
@@ -64,7 +41,7 @@ public class ToneAnalyzer {
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date
-       in "YYYY-MM-DD" format.
+     in "YYYY-MM-DD" format.
      */
     public init(username: String, password: String, version: String) {
         self.credentials = .basicAuthentication(username: username, password: password)
@@ -107,30 +84,40 @@ public class ToneAnalyzer {
     }
 
     /**
-     Analyze general purpose tone.
+     Analyze general tone.
 
-          Uses the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for
+     Use the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for
      emotional and language tones. The method always analyzes the tone of the full document; by default, it also
      analyzes the tone of each individual sentence of the content.   You can submit no more than 128 KB of total input
      content and no more than 1000 individual sentences in JSON, plain text, or HTML format. The service analyzes the
      first 1000 sentences for document-level analysis and only the first 100 sentences for sentence-level analysis.
-     Use the `POST` request method to analyze larger amounts of content in any of the available formats. Use the `GET`
-     request method to analyze smaller quantities of plain text content.   Per the JSON specification, the default
-     character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default encoding
-     for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content type of
-     plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text; for
-     example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the service removes HTML tags and analyzes only
-     the textual content.
+     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the
+     HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
+     set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
+     character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the
+     service removes HTML tags and analyzes only the textual content.
 
-     - parameter toneInput: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type `ToneInput`.
-     - parameter contentType: The type of the input: application/json, text/plain, or text/html. A character encoding can be specified by including a `charset` parameter. For example, 'text/plain;charset=utf-8'.
-     - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of the full document. If `true` (the default), the service returns results for each sentence.
-     - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the parameter no longer affects the response.   **`2016-05-19`:** A comma-separated list of tones for which the service is to return its analysis of the input; the indicated tones apply both to the full document and to individual sentences of the document. You can specify one or more of the valid values. Omit the parameter to request results for all three tones.
-     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not submit content that contains both languages. You can specify any combination of languages for `contentLanguage` and `Accept-Language`. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for `Content-Language` and `acceptLanguage`.
+     - parameter toneInput: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type
+     `ToneInput`.
+     - parameter contentType: The type of the input: application/json, text/plain, or text/html. A character encoding can be specified by
+     including a `charset` parameter. For example, 'text/plain;charset=utf-8'.
+     - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of
+     the full document. If `true` (the default), the service returns results for each sentence.
+     - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the
+     parameter no longer affects the response.   **`2016-05-19`:** A comma-separated list of tones for which the service
+     is to return its analysis of the input; the indicated tones apply both to the full document and to individual
+     sentences of the document. You can specify one or more of the valid values. Omit the parameter to request results
+     for all three tones.
+     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not
+     submit content that contains both languages. You can use different languages for **Content-Language** and
+     **Accept-Language**. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language** and
+     **Accept-Language**.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
-    */
+     */
     public func tone(
         toneInput: ToneInput,
         contentType: String,
@@ -184,7 +171,7 @@ public class ToneAnalyzer {
     /**
      Analyze customer engagement tone.
 
-          Use the customer engagement endpoint to analyze the tone of customer service and customer support conversations.
+     Use the customer engagement endpoint to analyze the tone of customer service and customer support conversations.
      For each utterance of a conversation, the method reports the most prevalent subset of the following seven tones:
      sad, frustrated, satisfied, excited, polite, impolite, and sympathetic.   If you submit more than 50 utterances,
      the service returns a warning for the overall content and analyzes only the first 50 utterances. If you submit a
@@ -193,10 +180,16 @@ public class ToneAnalyzer {
      specification, the default character encoding for JSON content is effectively always UTF-8.
 
      - parameter utterances: An array of `Utterance` objects that provides the input content that the service is to analyze.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`.
+     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not
+     submit content that contains both languages. You can use different languages for **Content-Language** and
+     **Accept-Language**. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language** and
+     **Accept-Language**.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
-    */
+     */
     public func toneChat(
         utterances: [Utterance],
         acceptLanguage: String? = nil,

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -134,6 +134,17 @@ public class ToneAnalyzer {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -151,9 +162,7 @@ public class ToneAnalyzer {
             method: "POST",
             url: serviceURL + "/v3/tone",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )
@@ -203,6 +212,14 @@ public class ToneAnalyzer {
             return
         }
 
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
         // construct query parameters
         var queryParameters = [URLQueryItem]()
         queryParameters.append(URLQueryItem(name: "version", value: version))
@@ -212,9 +229,7 @@ public class ToneAnalyzer {
             method: "POST",
             url: serviceURL + "/v3/tone_chat",
             credentials: credentials,
-            headerParameters: defaultHeaders,
-            acceptType: "application/json",
-            contentType: "application/json",
+            headerParameters: headers,
             queryItems: queryParameters,
             messageBody: body
         )

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -153,7 +153,7 @@ public class ToneAnalyzer {
             queryParameters.append(queryParameter)
         }
         if let tones = tones {
-            let queryParameter = URLQueryItem(name: "tones", value: "\(tones)")
+            let queryParameter = URLQueryItem(name: "tones", value: tones.joined(separator: ","))
             queryParameters.append(queryParameter)
         }
 

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -175,6 +175,188 @@ public class ToneAnalyzer {
     }
 
     /**
+     Analyze general tone.
+
+     Use the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for
+     emotional and language tones. The method always analyzes the tone of the full document; by default, it also
+     analyzes the tone of each individual sentence of the content.   You can submit no more than 128 KB of total input
+     content and no more than 1000 individual sentences in JSON, plain text, or HTML format. The service analyzes the
+     first 1000 sentences for document-level analysis and only the first 100 sentences for sentence-level analysis.
+     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the
+     HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
+     set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
+     character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the
+     service removes HTML tags and analyzes only the textual content.
+
+     - parameter text: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type
+     `ToneInput`.
+     - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of
+     the full document. If `true` (the default), the service returns results for each sentence.
+     - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the
+     parameter no longer affects the response.   **`2016-05-19`:** A comma-separated list of tones for which the service
+     is to return its analysis of the input; the indicated tones apply both to the full document and to individual
+     sentences of the document. You can specify one or more of the valid values. Omit the parameter to request results
+     for all three tones.
+     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not
+     submit content that contains both languages. You can use different languages for **Content-Language** and
+     **Accept-Language**. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language** and
+     **Accept-Language**.
+     - parameter failure: A function executed if an error occurs.
+     - parameter success: A function executed with the successful result.
+     */
+    public func tone(
+        text: String,
+        sentences: Bool? = nil,
+        tones: [String]? = nil,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (ToneAnalysis) -> Void)
+    {
+        // construct body
+        guard let body = text.data(using: .utf8) else {
+            failure?(RestError.serializationError)
+            return
+        }
+
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "text/plain"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
+        // construct query parameters
+        var queryParameters = [URLQueryItem]()
+        queryParameters.append(URLQueryItem(name: "version", value: version))
+        if let sentences = sentences {
+            let queryParameter = URLQueryItem(name: "sentences", value: "\(sentences)")
+            queryParameters.append(queryParameter)
+        }
+        if let tones = tones {
+            let queryParameter = URLQueryItem(name: "tones", value: tones.joined(separator: ","))
+            queryParameters.append(queryParameter)
+        }
+
+        // construct REST request
+        let request = RestRequest(
+            method: "POST",
+            url: serviceURL + "/v3/tone",
+            credentials: credentials,
+            headerParameters: headers,
+            queryItems: queryParameters,
+            messageBody: body
+        )
+
+        // execute REST request
+        request.responseObject(responseToError: responseToError) {
+            (response: RestResponse<ToneAnalysis>) in
+            switch response.result {
+            case .success(let retval): success(retval)
+            case .failure(let error): failure?(error)
+            }
+        }
+    }
+
+    /**
+     Analyze general tone.
+
+     Use the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for
+     emotional and language tones. The method always analyzes the tone of the full document; by default, it also
+     analyzes the tone of each individual sentence of the content.   You can submit no more than 128 KB of total input
+     content and no more than 1000 individual sentences in JSON, plain text, or HTML format. The service analyzes the
+     first 1000 sentences for document-level analysis and only the first 100 sentences for sentence-level analysis.
+     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the
+     HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
+     set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
+     character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the
+     service removes HTML tags and analyzes only the textual content.
+
+     - parameter html: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type
+     `ToneInput`.
+     - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of
+     the full document. If `true` (the default), the service returns results for each sentence.
+     - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the
+     parameter no longer affects the response.   **`2016-05-19`:** A comma-separated list of tones for which the service
+     is to return its analysis of the input; the indicated tones apply both to the full document and to individual
+     sentences of the document. You can specify one or more of the valid values. Omit the parameter to request results
+     for all three tones.
+     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not
+     submit content that contains both languages. You can use different languages for **Content-Language** and
+     **Accept-Language**. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
+     language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language** and
+     **Accept-Language**.
+     - parameter failure: A function executed if an error occurs.
+     - parameter success: A function executed with the successful result.
+     */
+    public func tone(
+        html: String,
+        sentences: Bool? = nil,
+        tones: [String]? = nil,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (ToneAnalysis) -> Void)
+    {
+        // construct body
+        guard let body = html.data(using: .utf8) else {
+            failure?(RestError.serializationError)
+            return
+        }
+
+        // construct header parameters
+        var headers = defaultHeaders
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "text/plain"
+        if let contentLanguage = contentLanguage {
+            headers["Content-Language"] = contentLanguage
+        }
+        if let acceptLanguage = acceptLanguage {
+            headers["Accept-Language"] = acceptLanguage
+        }
+
+        // construct query parameters
+        var queryParameters = [URLQueryItem]()
+        queryParameters.append(URLQueryItem(name: "version", value: version))
+        if let sentences = sentences {
+            let queryParameter = URLQueryItem(name: "sentences", value: "\(sentences)")
+            queryParameters.append(queryParameter)
+        }
+        if let tones = tones {
+            let queryParameter = URLQueryItem(name: "tones", value: tones.joined(separator: ","))
+            queryParameters.append(queryParameter)
+        }
+
+        // construct REST request
+        let request = RestRequest(
+            method: "POST",
+            url: serviceURL + "/v3/tone",
+            credentials: credentials,
+            headerParameters: headers,
+            queryItems: queryParameters,
+            messageBody: body
+        )
+
+        // execute REST request
+        request.responseObject(responseToError: responseToError) {
+            (response: RestResponse<ToneAnalysis>) in
+            switch response.result {
+            case .success(let retval): success(retval)
+            case .failure(let error): failure?(error)
+            }
+        }
+    }
+
+    /**
      Analyze customer engagement tone.
 
      Use the customer engagement endpoint to analyze the tone of customer service and customer support conversations.

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -173,6 +173,7 @@ class ToneAnalyzerTests: XCTestCase {
     func testToneChat() {
         let expectation = self.expectation(description: "Tone chat.")
         toneAnalyzer.toneChat(utterances: utterances, acceptLanguage: "en", failure: failWithError) { analyses in
+            XCTAssert(!analyses.utterancesTone.isEmpty)
             expectation.fulfill()
         }
         waitForExpectations()

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -26,7 +26,9 @@ class ToneAnalyzerTests: XCTestCase {
 
     static var allTests: [(String, (ToneAnalyzerTests) -> () throws -> Void)] {
         return [
-            ("testGetTone", testGetTone),
+            ("testGetToneJSON", testGetToneJSON),
+            ("testGetTonePlainText", testGetTonePlainText),
+            ("testGetToneHTML", testGetToneHTML),
             ("testGetToneCustom", testGetToneCustom),
             ("testToneChat", testToneChat),
             ("testGetToneEmptyString", testGetToneEmptyString),
@@ -90,9 +92,9 @@ class ToneAnalyzerTests: XCTestCase {
 
     // MARK: - Positive Tests
 
-    func testGetTone() {
+    func testGetToneJSON() {
         let expectation = self.expectation(description: "Get tone.")
-        toneAnalyzer.tone(toneInput: ToneInput(text: text), contentType: "plain/text", failure: failWithError) {
+        toneAnalyzer.tone(toneInput: ToneInput(text: text), failure: failWithError) {
             toneAnalysis in
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
             XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
@@ -110,11 +112,50 @@ class ToneAnalyzerTests: XCTestCase {
         waitForExpectations()
     }
 
+    func testGetTonePlainText() {
+        let expectation = self.expectation(description: "Get tone.")
+        toneAnalyzer.tone(text: text, failure: failWithError) {
+            toneAnalysis in
+            XCTAssertNotNil(toneAnalysis.documentTone.tones)
+            XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
+            XCTAssertNotNil(toneAnalysis.sentencesTone)
+            XCTAssertGreaterThan(toneAnalysis.sentencesTone!.count, 0)
+            for sentenceAnalysis in toneAnalysis.sentencesTone! {
+                XCTAssertNotNil(sentenceAnalysis.tones)
+                XCTAssertGreaterThan(sentenceAnalysis.tones!.count, 0)
+                XCTAssertNil(sentenceAnalysis.toneCategories)
+                XCTAssertNil(sentenceAnalysis.inputFrom)
+                XCTAssertNil(sentenceAnalysis.inputTo)
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+
+    func testGetToneHTML() {
+        let expectation = self.expectation(description: "Get tone.")
+        let html = "<!DOCTYPE html><html><body><p>\(text)</p></body></html>"
+        toneAnalyzer.tone(html: html, failure: failWithError) {
+            toneAnalysis in
+            XCTAssertNotNil(toneAnalysis.documentTone.tones)
+            XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
+            XCTAssertNotNil(toneAnalysis.sentencesTone)
+            XCTAssertGreaterThan(toneAnalysis.sentencesTone!.count, 0)
+            for sentenceAnalysis in toneAnalysis.sentencesTone! {
+                XCTAssertNotNil(sentenceAnalysis.tones)
+                XCTAssertNil(sentenceAnalysis.toneCategories)
+                XCTAssertNil(sentenceAnalysis.inputFrom)
+                XCTAssertNil(sentenceAnalysis.inputTo)
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+
     func testGetToneCustom() {
         let expectation = self.expectation(description: "Get tone with custom parameters.")
         toneAnalyzer.tone(
             toneInput: ToneInput(text: text),
-            contentType: "plain/text",
             sentences: false,
             contentLanguage: "en",
             acceptLanguage: "en",
@@ -142,12 +183,7 @@ class ToneAnalyzerTests: XCTestCase {
     func testGetToneEmptyString() {
         let expectation = self.expectation(description: "Get tone with an empty string.")
         let failure = { (error: Error) in expectation.fulfill() }
-        toneAnalyzer.tone(
-            toneInput: ToneInput(text: ""),
-            contentType: "plain/text",
-            failure: failure,
-            success: failWithResult
-        )
+        toneAnalyzer.tone(toneInput: ToneInput(text: ""), failure: failure, success: failWithResult)
         waitForExpectations()
     }
 


### PR DESCRIPTION
In addition to updating Tone Analyzer to use the latest style produced by the generator, this pull request makes the following changes:

- Fix a bug with the `tones` array by joining the list elements into a CSV list
- Add `contentLanguage` as a parameter to `toneChat`. Unfortunately, this parameter was added _before_ `acceptLanguage`, which would technically be a breaking change.
- Remove unused `content-type` parameter from the JSON variant of the `tone` function.
- Manually support "multiple consumers" by copying `tone(toneInput: ToneInput, ...)` to `tone(text: String, ...)` and `tone(html: String, ...)`
- Add tests for the new multiple consumers functions
- Add an assert statement in the `toneChat` function avoid an Xcode warning about an unused closure parameter.