### PR TITLE
Reorder Natural Language Classifier According to API Definition

### DIFF
--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -239,39 +239,34 @@ public class NaturalLanguageClassifier {
     }
 
     /**
-     Delete classifier.
+     List classifiers.
 
-     - parameter classifierID: Classifier ID to delete.
+     Returns an empty array if no classifiers are available.
+
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
-    public func deleteClassifier(
-        classifierID: String,
+    public func listClassifiers(
         failure: ((Error) -> Void)? = nil,
-        success: @escaping () -> Void)
+        success: @escaping (ClassifierList) -> Void)
     {
         // construct header parameters
         var headers = defaultHeaders
         headers["Accept"] = "application/json"
 
         // construct REST request
-        let path = "/v1/classifiers/\(classifierID)"
-        guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            failure?(RestError.encodingError)
-            return
-        }
         let request = RestRequest(
-            method: "DELETE",
-            url: serviceURL + encodedPath,
+            method: "GET",
+            url: serviceURL + "/v1/classifiers",
             credentials: credentials,
             headerParameters: headers
         )
 
         // execute REST request
-        request.responseVoid(responseToError: responseToError) {
-            (response: RestResponse) in
+        request.responseObject(responseToError: responseToError) {
+            (response: RestResponse<ClassifierList>) in
             switch response.result {
-            case .success: success()
+            case .success(let retval): success(retval)
             case .failure(let error): failure?(error)
             }
         }
@@ -319,34 +314,39 @@ public class NaturalLanguageClassifier {
     }
 
     /**
-     List classifiers.
+     Delete classifier.
 
-     Returns an empty array if no classifiers are available.
-
+     - parameter classifierID: Classifier ID to delete.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
-    public func listClassifiers(
+    public func deleteClassifier(
+        classifierID: String,
         failure: ((Error) -> Void)? = nil,
-        success: @escaping (ClassifierList) -> Void)
+        success: @escaping () -> Void)
     {
         // construct header parameters
         var headers = defaultHeaders
         headers["Accept"] = "application/json"
 
         // construct REST request
+        let path = "/v1/classifiers/\(classifierID)"
+        guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            failure?(RestError.encodingError)
+            return
+        }
         let request = RestRequest(
-            method: "GET",
-            url: serviceURL + "/v1/classifiers",
+            method: "DELETE",
+            url: serviceURL + encodedPath,
             credentials: credentials,
             headerParameters: headers
         )
 
         // execute REST request
-        request.responseObject(responseToError: responseToError) {
-            (response: RestResponse<ClassifierList>) in
+        request.responseVoid(responseToError: responseToError) {
+            (response: RestResponse) in
             switch response.result {
-            case .success(let retval): success(retval)
+            case .success: success()
             case .failure(let error): failure?(error)
             }
         }


### PR DESCRIPTION
This pull request reorders the Natural Language Classifier service according to the API definition.

The following command is a handy way to verify that this is only a reordering of the methods:
`bash -c 'diff <(sort Service-Before.swift) <(sort Service-After.swift)'`