### PR TITLE
[needs-testing] Update RestKit to use a single completion handler

### DIFF
--- a/Source/AssistantV1/RestKit/Authentication.swift
+++ b/Source/AssistantV1/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/ConversationV1/RestKit/Authentication.swift
+++ b/Source/ConversationV1/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/DiscoveryV1/RestKit/Authentication.swift
+++ b/Source/DiscoveryV1/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/LanguageTranslatorV2/RestKit/Authentication.swift
+++ b/Source/LanguageTranslatorV2/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/NaturalLanguageClassifierV1/RestKit/Authentication.swift
+++ b/Source/NaturalLanguageClassifierV1/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/NaturalLanguageUnderstandingV1/RestKit/Authentication.swift
+++ b/Source/NaturalLanguageUnderstandingV1/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/PersonalityInsightsV3/RestKit/Authentication.swift
+++ b/Source/PersonalityInsightsV3/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/RestKit/Authentication.swift
+++ b/Source/RestKit/Authentication.swift
@@ -158,14 +158,9 @@ internal class IAMAuthentication: AuthenticationMethod {
             headerParameters: headerParameters,
             messageBody: form.joined(separator: "&").data(using: .utf8)
         )
-        request.responseObject { (response: RestResponse<IAMToken>) in
-            switch response.result {
-            case .success(let token):
-                self.token = token
-                completionHandler(token, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
+        request.responseObject { (token: IAMToken?, response: HTTPURLResponse?, error: Error?) in
+            guard let token = token, error == nil else { completionHandler(nil, error); return }
+            completionHandler(token, nil)
         }
     }
 
@@ -180,14 +175,9 @@ internal class IAMAuthentication: AuthenticationMethod {
             headerParameters: headerParameters,
             messageBody: form.joined(separator: "&").data(using: .utf8)
         )
-        request.responseObject { (response: RestResponse<IAMToken>) in
-            switch response.result {
-            case .success(let token):
-                self.token = token
-                completionHandler(token, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
+        request.responseObject { (token: IAMToken?, response: HTTPURLResponse?, error: Error?) in
+            guard let token = token, error == nil else { completionHandler(nil, error); return }
+            completionHandler(token, nil)
         }
     }
 }

--- a/Source/RestKit/Authentication.swift
+++ b/Source/RestKit/Authentication.swift
@@ -176,7 +176,7 @@ internal class IAMAuthentication: AuthenticationMethod {
         let request = RestRequest(
             method: "POST",
             url: url,
-            credentials: BasicAuthentication(username: "iam", password: "token"),
+            credentials: BasicAuthentication(username: "bx", password: "bx"),
             headerParameters: headerParameters,
             messageBody: form.joined(separator: "&").data(using: .utf8)
         )

--- a/Source/RestKit/Authentication.swift
+++ b/Source/RestKit/Authentication.swift
@@ -1,0 +1,225 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/**
+ An `AuthenticationMethod` adds authentication to a `RestRequest`.
+
+ The authentication method adapts a `RestRequest` by adding authentication credentials to it. Authentication
+ is expressed as an adapter because the credentials may be dynamic — they may change over time. For example,
+ a `RestRequest` might use one token, fail with an authentication error, then retry using a refreshed token.
+ The `RestRequest` does not need to be rebuilt, but should be updated with a new token value.
+ */
+internal protocol AuthenticationMethod {
+
+    /**
+     Authenticate a `RestRequest`.
+
+     - parameter request: The request that should be authenticated.
+     - parameter completionHandler: The completion handler to execute when the authenticated `RestRequest`.
+     */
+    func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void)
+}
+
+/** No authentication. */
+internal class NoAuthentication: AuthenticationMethod {
+    internal func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void) {
+        completionHandler(request, nil)
+    }
+}
+
+/** Authenticate with basic authentication. */
+internal class BasicAuthentication: AuthenticationMethod {
+
+    private let username: String
+    private let password: String
+
+    init(username: String, password: String) {
+        self.username = username
+        self.password = password
+    }
+
+    internal func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void) {
+        var request = request
+        guard let data = (username + ":" + password).data(using: .utf8) else {
+            completionHandler(nil, RestError.serializationError)
+            return
+        }
+        let string = "Basic \(data.base64EncodedString())"
+        request.headerParameters["Authorization"] = string
+        completionHandler(request, nil)
+    }
+}
+
+/** Authenticate with an API key. */
+internal class APIKeyAuthentication: AuthenticationMethod {
+
+    private let name: String
+    private let key: String
+    private let location: Location
+
+    internal enum Location {
+        case header
+        case query
+    }
+
+    internal init(name: String, key: String, location: Location) {
+        self.name = name
+        self.key = key
+        self.location = location
+    }
+
+    internal func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void) {
+        var request = request
+        switch location {
+        case .header: request.headerParameters[name] = key
+        case .query: request.queryItems.append(URLQueryItem(name: name, value: key))
+        }
+        completionHandler(request, nil)
+    }
+}
+
+/** Authenticate with a static IAM access token. */
+internal class IAMAccessToken: AuthenticationMethod {
+
+    private let accessToken: String
+
+    internal init(accessToken: String) {
+        self.accessToken = accessToken
+    }
+
+    internal func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void) {
+        var request = request
+        request.headerParameters["Authorization"] = "Bearer \(accessToken)"
+        completionHandler(request, nil)
+    }
+}
+
+/** Authenticate with an IAM API key. The API key is used to automatically retrieve and refresh access tokens. */
+internal class IAMAuthentication: AuthenticationMethod {
+
+    private let apiKey: String
+    private let url: String
+    private var token: IAMToken?
+
+    internal init(apiKey: String, url: String = "https://iam.ng.bluemix.net/identity/token") {
+        self.apiKey = apiKey
+        self.url = url
+        self.token = nil
+    }
+
+    internal func authenticate(request: RestRequest, completionHandler: @escaping (RestRequest?, Error?) -> Void) {
+        var request = request
+        getToken { token, error in
+            guard error == nil else { completionHandler(nil, error); return }
+            if let token = token { request.headerParameters["Authorization"] = "Bearer \(token.accessToken)" }
+            completionHandler(request, nil)
+        }
+    }
+
+    private func getToken(completionHandler: @escaping (IAMToken?, Error?) -> Void) {
+        // request a new access token if not present
+        guard let token = token, !token.isRefreshTokenExpired else {
+            requestToken(completionHandler: completionHandler)
+            return
+        }
+
+        // refresh the access token if it expired
+        guard !token.isAccessTokenExpired else {
+            refreshToken(completionHandler: completionHandler)
+            return
+        }
+
+        // use the existing, valid access token
+        completionHandler(token, nil)
+    }
+
+    private func requestToken(completionHandler: @escaping (IAMToken?, Error?) -> Void) {
+        let headerParameters = ["Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"]
+        let form = ["grant_type=urn:ibm:params:oauth:grant-type:apikey", "apikey=\(apiKey)", "response_type=cloud_iam"]
+        let request = RestRequest(
+            method: "POST",
+            url: url,
+            credentials: BasicAuthentication(username: "bx", password: "bx"),
+            headerParameters: headerParameters,
+            messageBody: form.joined(separator: "&").data(using: .utf8)
+        )
+        request.responseObject { (response: RestResponse<IAMToken>) in
+            switch response.result {
+            case .success(let token):
+                self.token = token
+                completionHandler(token, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+
+    private func refreshToken(completionHandler: @escaping (IAMToken?, Error?) -> Void) {
+        guard let token = token else { completionHandler(nil, RestError.serializationError); return }
+        let headerParameters = ["Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"]
+        let form = ["grant_type=refresh_token", "refresh_token=\(token.refreshToken)"]
+        let request = RestRequest(
+            method: "POST",
+            url: url,
+            credentials: BasicAuthentication(username: "iam", password: "token"),
+            headerParameters: headerParameters,
+            messageBody: form.joined(separator: "&").data(using: .utf8)
+        )
+        request.responseObject { (response: RestResponse<IAMToken>) in
+            switch response.result {
+            case .success(let token):
+                self.token = token
+                completionHandler(token, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+}
+
+/** An IAM token. */
+private struct IAMToken: Decodable {
+
+    let accessToken: String
+    let refreshToken: String
+    let tokenType: String
+    let expiresIn: Int
+    let expiration: Int
+
+    var isAccessTokenExpired: Bool {
+        let buffer = 0.8
+        let expirationDate = Date(timeIntervalSince1970: Double(expiration))
+        let refreshDate = expirationDate.addingTimeInterval(-1.0 * (1.0 - buffer) * Double(expiresIn))
+        return refreshDate.timeIntervalSinceNow <= 0
+    }
+
+    var isRefreshTokenExpired: Bool {
+        let sevenDays: TimeInterval = 7 * 24 * 60 * 60
+        let expirationDate = Date(timeIntervalSince1970: Double(expiration))
+        let refreshExpirationDate = expirationDate.addingTimeInterval(sevenDays)
+        return refreshExpirationDate.timeIntervalSinceNow <= 0
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+        case expiration = "expiration"
+    }
+}

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -151,17 +151,17 @@ extension RestRequest {
     /**
      Execute this request and process the response body as a JSON object.
 
-     - responseToError: A function that can parse service-specific errors from the raw data response.
+     - parseServiceError: A function that can parse service-specific errors from the raw data response.
      - path: The path at which to decode the JSON object.
      - completionHandler: The completion handler to call when the request is complete.
      */
     internal func responseObject<T: JSONDecodable>(
-        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
+        parseServiceError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
         path: [JSONPathType]? = nil,
         completionHandler: @escaping (RestResponse<T>) -> Void)
     {
         // execute the request
-        responseData(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: parseServiceError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {
@@ -212,15 +212,15 @@ extension RestRequest {
     /**
      Execute this request and process the response body as a decodable value.
 
-     - responseToError: A function that can parse service-specific errors from the raw data response.
+     - parseServiceError: A function that can parse service-specific errors from the raw data response.
      - completionHandler: The completion handler to call when the request is complete.
      */
     internal func responseObject<T: Decodable>(
-        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
         completionHandler: @escaping (RestResponse<T>) -> Void)
+        parseServiceError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
     {
         // execute the request
-        responseData(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: parseServiceError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {
@@ -257,17 +257,17 @@ extension RestRequest {
     /**
      Execute this request and process the response body as a JSON array.
 
-     - responseToError: A function that can parse service-specific errors from the raw data response.
+     - parseServiceError: A function that can parse service-specific errors from the raw data response.
      - path: The path at which to decode the JSON array.
      - completionHandler: The completion handler to call when the request is complete.
      */
     internal func responseArray<T: JSONDecodable>(
-        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
+        parseServiceError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
         path: [JSONPathType]? = nil,
         completionHandler: @escaping (RestResponse<[T]>) -> Void)
     {
         // execute the request
-        responseData(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: parseServiceError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {
@@ -319,15 +319,15 @@ extension RestRequest {
     /**
      Execute this request and process the response body as a string.
 
-     - responseToError: A function that can parse service-specific errors from the raw data response.
+     - parseServiceError: A function that can parse service-specific errors from the raw data response.
      - completionHandler: The completion handler to call when the request is complete.
      */
     internal func responseString(
-        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
         completionHandler: @escaping (RestResponse<String>) -> Void)
+        parseServiceError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
     {
         // execute the request
-        responseData(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: parseServiceError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {
@@ -364,15 +364,15 @@ extension RestRequest {
     /**
      Execute this request and ignore any response body.
 
-     - responseToError: A function that can parse service-specific errors from the raw data response.
+     - parseServiceError: A function that can parse service-specific errors from the raw data response.
      - completionHandler: The completion handler to call when the request is complete.
      */
     internal func responseVoid(
-        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
         completionHandler: @escaping (RestResponse<Void>) -> Void)
+        parseServiceError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
     {
         // execute the request
-        responseData(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: parseServiceError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -132,18 +132,18 @@ extension RestRequest {
             guard error == nil else {
                 // swiftlint:disable:next force_unwrapping
                 let result = RestResult<Data>.failure(error!)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let dataResponse = RestResponse(response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
             }
             guard let data = data else {
                 let result = RestResult<Data>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let dataResponse = RestResponse(response: response, data: nil, result: result)
                 completionHandler(dataResponse)
                 return
             }
             let result = RestResult.success(data)
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let dataResponse = RestResponse(response: response, data: data, result: result)
             completionHandler(dataResponse)
         }
     }
@@ -158,7 +158,7 @@ extension RestRequest {
             guard error == nil else {
                 // swiftlint:disable:next force_unwrapping
                 let result = RestResult<T>.failure(error!)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let dataResponse = RestResponse(response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
             }
@@ -166,7 +166,7 @@ extension RestRequest {
             // ensure data is not nil
             guard let data = data else {
                 let result = RestResult<T>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let dataResponse = RestResponse(response: response, data: nil, result: result)
                 completionHandler(dataResponse)
                 return
             }
@@ -195,7 +195,7 @@ extension RestRequest {
             }
 
             // execute callback
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let dataResponse = RestResponse(response: response, data: data, result: result)
             completionHandler(dataResponse)
         }
     }
@@ -209,7 +209,7 @@ extension RestRequest {
             guard error == nil else {
                 // swiftlint:disable:next force_unwrapping
                 let result = RestResult<T>.failure(error!)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let dataResponse = RestResponse(response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
             }
@@ -217,7 +217,7 @@ extension RestRequest {
             // ensure data is not nil
             guard let data = data else {
                 let result = RestResult<T>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let dataResponse = RestResponse(response: response, data: nil, result: result)
                 completionHandler(dataResponse)
                 return
             }
@@ -232,7 +232,7 @@ extension RestRequest {
             }
 
             // execute callback
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let dataResponse = RestResponse(response: response, data: data, result: result)
             completionHandler(dataResponse)
         }
     }
@@ -247,7 +247,7 @@ extension RestRequest {
             guard error == nil else {
                 // swiftlint:disable:next force_unwrapping
                 let result = RestResult<[T]>.failure(error!)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let dataResponse = RestResponse(response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
             }
@@ -255,7 +255,7 @@ extension RestRequest {
             // ensure data is not nil
             guard let data = data else {
                 let result = RestResult<[T]>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let dataResponse = RestResponse(response: response, data: nil, result: result)
                 completionHandler(dataResponse)
                 return
             }
@@ -285,7 +285,7 @@ extension RestRequest {
             }
 
             // execute callback
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let dataResponse = RestResponse(response: response, data: data, result: result)
             completionHandler(dataResponse)
         }
     }
@@ -299,7 +299,7 @@ extension RestRequest {
             guard error == nil else {
                 // swiftlint:disable:next force_unwrapping
                 let result = RestResult<String>.failure(error!)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let dataResponse = RestResponse(response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
             }
@@ -307,7 +307,7 @@ extension RestRequest {
             // ensure data is not nil
             guard let data = data else {
                 let result = RestResult<String>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let dataResponse = RestResponse(response: response, data: nil, result: result)
                 completionHandler(dataResponse)
                 return
             }
@@ -315,14 +315,14 @@ extension RestRequest {
             // parse data as a string
             guard let string = String(data: data, encoding: .utf8) else {
                 let result = RestResult<String>.failure(RestError.serializationError)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let dataResponse = RestResponse(response: response, data: nil, result: result)
                 completionHandler(dataResponse)
                 return
             }
 
             // execute callback
             let result = RestResult.success(string)
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let dataResponse = RestResponse(response: response, data: data, result: result)
             completionHandler(dataResponse)
         }
     }
@@ -336,14 +336,14 @@ extension RestRequest {
             guard error == nil else {
                 // swiftlint:disable:next force_unwrapping
                 let result = RestResult<Void>.failure(error!)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let dataResponse = RestResponse(response: response, data: data, result: result)
                 completionHandler(dataResponse)
                 return
             }
 
             // execute callback
             let result = RestResult<Void>.success(())
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let dataResponse = RestResponse(response: response, data: data, result: result)
             completionHandler(dataResponse)
         }
     }
@@ -367,7 +367,6 @@ extension RestRequest {
 }
 
 internal struct RestResponse<T> {
-    internal let request: URLRequest?
     internal let response: HTTPURLResponse?
     internal let data: Data?
     internal let result: RestResult<T>

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -400,14 +400,3 @@ extension RestRequest {
         }
     }
 }
-
-internal struct RestResponse<T> {
-    internal let response: HTTPURLResponse?
-    internal let data: Data?
-    internal let result: RestResult<T>
-}
-
-internal enum RestResult<T> {
-    case success(T)
-    case failure(Error)
-}

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -93,12 +93,12 @@ internal struct RestRequest {
 extension RestRequest {
 
     /**
-     Execute this request. (This is the main response function and is called by many of the functions below.)
+     Execute this request and process the response body as raw data.
 
      - parseServiceError: A function that can parse service-specific errors from the raw data response.
      - completionHandler: The completion handler to call when the request is complete.
      */
-    internal func response(
+    internal func responseData(
         parseServiceError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
         completionHandler: @escaping (Data?, HTTPURLResponse?, Error?) -> Void)
     {
@@ -149,43 +149,6 @@ extension RestRequest {
     }
 
     /**
-     Execute this request and process the response body as raw data.
-
-     - responseToError: A function that can parse service-specific errors from the raw data response.
-     - completionHandler: The completion handler to call when the request is complete.
-     */
-    internal func responseData(
-        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
-        completionHandler: @escaping (RestResponse<Data>) -> Void)
-    {
-        // execute the request
-        response(parseServiceError: responseToError) { data, response, error in
-
-            // ensure there is no underlying error
-            guard error == nil else {
-                // swiftlint:disable:next force_unwrapping
-                let result = RestResult<Data>.failure(error!)
-                let dataResponse = RestResponse(response: response, data: data, result: result)
-                completionHandler(dataResponse)
-                return
-            }
-
-            // ensure there is data to parse
-            guard let data = data else {
-                let result = RestResult<Data>.failure(RestError.noData)
-                let dataResponse = RestResponse(response: response, data: nil, result: result)
-                completionHandler(dataResponse)
-                return
-            }
-
-            // execute completion handler
-            let result = RestResult.success(data)
-            let dataResponse = RestResponse(response: response, data: data, result: result)
-            completionHandler(dataResponse)
-        }
-    }
-
-    /**
      Execute this request and process the response body as a JSON object.
 
      - responseToError: A function that can parse service-specific errors from the raw data response.
@@ -198,7 +161,7 @@ extension RestRequest {
         completionHandler: @escaping (RestResponse<T>) -> Void)
     {
         // execute the request
-        response(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: responseToError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {
@@ -257,7 +220,7 @@ extension RestRequest {
         completionHandler: @escaping (RestResponse<T>) -> Void)
     {
         // execute the request
-        response(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: responseToError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {
@@ -304,7 +267,7 @@ extension RestRequest {
         completionHandler: @escaping (RestResponse<[T]>) -> Void)
     {
         // execute the request
-        response(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: responseToError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {
@@ -364,7 +327,7 @@ extension RestRequest {
         completionHandler: @escaping (RestResponse<String>) -> Void)
     {
         // execute the request
-        response(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: responseToError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {
@@ -409,7 +372,7 @@ extension RestRequest {
         completionHandler: @escaping (RestResponse<Void>) -> Void)
     {
         // execute the request
-        response(parseServiceError: responseToError) { data, response, error in
+        responseData(parseServiceError: responseToError) { data, response, error in
 
             // ensure there is no underlying error
             guard error == nil else {

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -135,8 +135,11 @@ extension RestRequest {
         }
     }
 
-    internal func responseData(completionHandler: @escaping (RestResponse<Data>) -> Void) {
-        response { data, response, error in
+    internal func responseData(
+        responseToError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,
+        completionHandler: @escaping (RestResponse<Data>) -> Void)
+    {
+        response(parseServiceError: responseToError) { data, response, error in
             guard error == nil else {
                 // swiftlint:disable:next force_unwrapping
                 let result = RestResult<Data>.failure(error!)

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -87,6 +87,11 @@ internal struct RestRequest {
         headerParameters.forEach { (key, value) in request.setValue(value, forHTTPHeaderField: key) }
         return request
     }
+}
+
+// MARK: - Response Functions
+
+extension RestRequest {
 
     internal func response(
         parseServiceError: ((HTTPURLResponse?, Data?) -> Error?)? = nil,

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -377,13 +377,3 @@ internal enum RestResult<T> {
     case success(T)
     case failure(Error)
 }
-
-internal enum Credentials {
-    case basicAuthentication(username: String, password: String)
-    case apiKey(name: String, key: String, in: APIKeyLocation)
-
-    internal enum APIKeyLocation {
-        case header
-        case query
-    }
-}

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -57,13 +57,13 @@ internal struct RestRequest {
         method: String,
         url: String,
         credentials: AuthenticationMethod,
-        headerParameters: [String: String],
+        headerParameters: [String: String]? = nil,
         acceptType: String? = nil,
         contentType: String? = nil,
         queryItems: [URLQueryItem]? = nil,
         messageBody: Data? = nil)
     {
-        var headerParameters = headerParameters
+        var headerParameters = headerParameters ?? [:]
         if let acceptType = acceptType { headerParameters["Accept"] = acceptType }
         if let contentType = contentType { headerParameters["Content-Type"] = contentType }
         self.method = method

--- a/Source/RestKit/RestToken.swift
+++ b/Source/RestKit/RestToken.swift
@@ -27,7 +27,7 @@ internal class RestToken {
     internal var retries = 0
 
     private var tokenURL: String
-    private var credentials: Credentials
+    private var credentials: AuthenticationMethod
     private let domain = "com.ibm.watson.developer-cloud.RestKit"
 
     /**
@@ -36,7 +36,7 @@ internal class RestToken {
      - parameter tokenURL: The URL that shall be used to obtain a token.
      - parameter credentials: The credentials that shall be used to obtain a token.
      */
-    internal init(tokenURL: String, credentials: Credentials) {
+    internal init(tokenURL: String, credentials: AuthenticationMethod) {
         self.tokenURL = tokenURL
         self.credentials = credentials
     }

--- a/Source/SpeechToTextV1/RestKit/Authentication.swift
+++ b/Source/SpeechToTextV1/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/TextToSpeechV1/RestKit/Authentication.swift
+++ b/Source/TextToSpeechV1/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/ToneAnalyzerV3/RestKit/Authentication.swift
+++ b/Source/ToneAnalyzerV3/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Source/VisualRecognitionV3/RestKit/Authentication.swift
+++ b/Source/VisualRecognitionV3/RestKit/Authentication.swift
@@ -1,0 +1,1 @@
+../../RestKit/Authentication.swift

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -221,7 +221,7 @@ class AuthenticationTests: XCTestCase {
             refreshToken: credentials.token!.refreshToken,
             tokenType: credentials.token!.tokenType,
             expiresIn: credentials.token!.expiresIn,
-            expiration: 0
+            expiration: Int(Date().timeIntervalSince1970)
         )
         credentials.token = token
 

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -215,6 +215,8 @@ class AuthenticationTests: XCTestCase {
         }
         wait(for: [expectation2], timeout: 5)
 
+        sleep(1) // sleep for 1 second to make sure the unix time stamp increments
+
         // change the token's expiration date to force a refresh
         let token = IAMToken(
             accessToken: credentials.token!.accessToken,

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -1,0 +1,240 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+
+import XCTest
+
+class AuthenticationTests: XCTestCase {
+
+    static var allTests = [
+        ("testNoAuthentication", testNoAuthentication),
+        ("testBasicAuthentication", testBasicAuthentication),
+        ("testAPIKeyAuthenticationHeader", testAPIKeyAuthenticationHeader),
+        ("testAPIKeyAuthenticationQuery", testAPIKeyAuthenticationQuery),
+        ("testIAMAccessToken", testIAMAccessToken),
+        ("testIAMToken", testIAMToken),
+        ("testIAMAuthentication", testIAMAuthentication),
+    ]
+
+    var request = RestRequest(
+        method: "GET",
+        url: "http://www.example.com",
+        credentials: NoAuthentication(),
+        headerParameters: ["x-custom-header": "value"],
+        queryItems: [URLQueryItem(name: "name", value: "value")],
+        messageBody: "hello-world".data(using: .utf8)
+    )
+
+    func testNoAuthentication() {
+        request.credentials = NoAuthentication()
+        request.credentials.authenticate(request: request) { request, error in
+            guard let request = request, error == nil else { XCTFail(error!.localizedDescription); return }
+            XCTAssertEqual(self.request.method, request.method)
+            XCTAssertEqual(self.request.url, request.url)
+            XCTAssertEqual(self.request.headerParameters, request.headerParameters)
+            XCTAssertEqual(self.request.queryItems, request.queryItems)
+            XCTAssertEqual(self.request.messageBody, request.messageBody)
+        }
+    }
+
+    func testBasicAuthentication() {
+        let authentication = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        request.credentials = BasicAuthentication(username: "username", password: "password")
+        request.credentials.authenticate(request: request) { request, error in
+            guard let request = request, error == nil else { XCTFail(error!.localizedDescription); return }
+            XCTAssertEqual(self.request.method, request.method)
+            XCTAssertEqual(self.request.url, request.url)
+            XCTAssertEqual(request.headerParameters["x-custom-header"], "value")
+            XCTAssertEqual(request.headerParameters["Authorization"], authentication)
+            XCTAssertEqual(self.request.queryItems, request.queryItems)
+            XCTAssertEqual(self.request.messageBody, request.messageBody)
+        }
+    }
+
+    func testAPIKeyAuthenticationHeader() {
+        request.credentials = APIKeyAuthentication(name: "foo", key: "bar", location: .header)
+        request.credentials.authenticate(request: request) { request, error in
+            guard let request = request, error == nil else { XCTFail(error!.localizedDescription); return }
+            XCTAssertEqual(self.request.method, request.method)
+            XCTAssertEqual(self.request.url, request.url)
+            XCTAssertEqual(request.headerParameters["x-custom-header"], "value")
+            XCTAssertEqual(request.headerParameters["foo"], "bar")
+            XCTAssertEqual(self.request.queryItems, request.queryItems)
+            XCTAssertEqual(self.request.messageBody, request.messageBody)
+        }
+    }
+
+    func testAPIKeyAuthenticationQuery() {
+        request.credentials = APIKeyAuthentication(name: "foo", key: "bar", location: .query)
+        request.credentials.authenticate(request: request) { request, error in
+            guard let request = request, error == nil else { XCTFail(error!.localizedDescription); return }
+            XCTAssertEqual(self.request.method, request.method)
+            XCTAssertEqual(self.request.url, request.url)
+            XCTAssertEqual(self.request.headerParameters, request.headerParameters)
+            XCTAssertEqual(self.request.queryItems[0], request.queryItems[0])
+            XCTAssertEqual(request.queryItems[1].name, "foo")
+            XCTAssertEqual(request.queryItems[1].value, "bar")
+            XCTAssertEqual(self.request.messageBody, request.messageBody)
+        }
+    }
+
+    func testIAMAccessToken() {
+        request.credentials = IAMAccessToken(accessToken: "access-token")
+        request.credentials.authenticate(request: request) { request, error in
+            guard let request = request, error == nil else { XCTFail(error!.localizedDescription); return }
+            XCTAssertEqual(self.request.method, request.method)
+            XCTAssertEqual(self.request.url, request.url)
+            XCTAssertEqual(request.headerParameters["x-custom-header"], "value")
+            XCTAssertEqual(request.headerParameters["Authorization"], "Bearer access-token")
+            XCTAssertEqual(self.request.queryItems, request.queryItems)
+            XCTAssertEqual(self.request.messageBody, request.messageBody)
+        }
+    }
+
+    func testIAMToken() {
+
+        // To run this test:
+        // 1. Set `IAMToken` access level to `internal`
+        // 2. Uncomment the code below
+
+        // The `private` access level of the `IAMToken` makes it difficult to test. However, it should
+        // remain `private` because it should not be used by any class outside of `Authentication.swift`.
+        // You can test the token, though, by temporarily changing its access level to `internal` and
+        // uncommenting the code below.
+
+        /**
+
+        // test JSON decoding
+        let json = """
+        {
+            "access_token": "foo",
+            "refresh_token":"bar",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "expiration": 1524754769
+        }
+        """
+        let token1 = try! JSONDecoder().decode(IAMToken.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(token1.accessToken, "foo")
+        XCTAssertEqual(token1.refreshToken, "bar")
+        XCTAssertEqual(token1.tokenType, "Bearer")
+        XCTAssertEqual(token1.expiresIn, 3600)
+        XCTAssertEqual(token1.expiration, 1524754769)
+
+        // test both access token and refresh token expired
+        let token2 = IAMToken(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            tokenType: "token-type",
+            expiresIn: 3600,
+            expiration: 0
+        )
+        XCTAssertTrue(token2.isAccessTokenExpired)
+        XCTAssertTrue(token2.isRefreshTokenExpired)
+
+        // test access token expired, but not refresh token
+        // (set expiration in the future, but before the 20% refresh buffer)
+        let token3 = IAMToken(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            tokenType: "token-type",
+            expiresIn: 3600,
+            expiration: Int(Date().addingTimeInterval(3600 * 0.19).timeIntervalSince1970)
+        )
+        XCTAssertTrue(token3.isAccessTokenExpired)
+        XCTAssertFalse(token3.isRefreshTokenExpired)
+
+        // test neither access token nor refresh token expired
+        // (set expiration in the future, but just after the 20% refresh buffer)
+        let token4 = IAMToken(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            tokenType: "token-type",
+            expiresIn: 3600,
+            expiration: Int(Date().addingTimeInterval(3600 * 0.21).timeIntervalSince1970)
+        )
+        XCTAssertFalse(token4.isAccessTokenExpired)
+        XCTAssertFalse(token4.isRefreshTokenExpired)
+
+        */
+    }
+
+    func testIAMAuthentication() {
+
+        // To run this test:
+        // 1. Set `IAMToken` access level to `internal`
+        // 2. Set `IAMAuthentication.token` access level to `internal`
+        // 3. Uncomment the code below
+
+        // The `private` access level of the properties and functions in `IAMAuthentication` prohibit us from
+        // modifying/calling them directly. As a result, this is hard to test properly (particularly token refresh).
+        // One alternative would be to make the access level `internal` instead of `private`. Or we might be able to
+        // build a `RestKit` framework and import it using `@testable RestKit` in order to access private members.
+
+        /**
+
+        let credentials = IAMAuthentication(apiKey: Credentials.IAMAPIKey, url: Credentials.IAMURL)
+        var authorizationHeader: String! // save initial authorization header (it should stay the same until refreshed)
+        request.credentials = credentials
+
+        // request initial iam token
+        let expectation1 = self.expectation(description: "request initial iam token")
+        request.credentials.authenticate(request: request) { request, error in
+            guard let request = request, error == nil else { XCTFail(error!.localizedDescription); return }
+            XCTAssertEqual(self.request.method, request.method)
+            XCTAssertEqual(self.request.url, request.url)
+            XCTAssertEqual(request.headerParameters["x-custom-header"], "value")
+            XCTAssertTrue(request.headerParameters["Authorization"]!.starts(with: "Bearer "))
+            XCTAssertEqual(self.request.queryItems, request.queryItems)
+            XCTAssertEqual(self.request.messageBody, request.messageBody)
+            authorizationHeader = request.headerParameters["Authorization"]!
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 5)
+
+        // use the same iam token
+        let expectation2 = self.expectation(description: "use the same iam token")
+        request.credentials.authenticate(request: request) { request, error in
+            guard let request = request, error == nil else { XCTFail(error!.localizedDescription); return }
+            XCTAssertEqual(request.headerParameters["Authorization"]!, authorizationHeader)
+            expectation2.fulfill()
+        }
+        wait(for: [expectation2], timeout: 5)
+
+        // change the token's expiration date to force a refresh
+        let token = IAMToken(
+            accessToken: credentials.token!.accessToken,
+            refreshToken: credentials.token!.refreshToken,
+            tokenType: credentials.token!.tokenType,
+            expiresIn: credentials.token!.expiresIn,
+            expiration: 0
+        )
+        credentials.token = token
+
+        // refresh the iam token
+        let expectation3 = self.expectation(description: "refresh the iam token")
+        request.credentials.authenticate(request: request) { request, error in
+            guard let request = request, error == nil else { XCTFail(error!.localizedDescription); return }
+            XCTAssertTrue(request.headerParameters["Authorization"]!.starts(with: "Bearer "))
+            XCTAssertNotEqual(request.headerParameters["Authorization"]!, authorizationHeader)
+            expectation3.fulfill()
+        }
+        wait(for: [expectation3], timeout: 5)
+
+        */
+    }
+}

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		6836B9072091D23D006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
 		6836B9082091D23E006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
 		6836B9092091D240006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B90B2091D6DB006DF944 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B90A2091D6DB006DF944 /* AuthenticationTests.swift */; };
+		6836B90C20924DE4006DF944 /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6C7B3C1D8C960300CD97FA /* Credentials.swift */; };
 		683947D5202CF4F7007E3CF3 /* RelationArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683947AA202CF4F3007E3CF3 /* RelationArgument.swift */; };
 		683947D6202CF4F7007E3CF3 /* RelationsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683947AB202CF4F3007E3CF3 /* RelationsResult.swift */; };
 		683947D7202CF4F7007E3CF3 /* SemanticRolesObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683947AC202CF4F3007E3CF3 /* SemanticRolesObject.swift */; };
@@ -886,6 +888,7 @@
 		6823CEBE1F8EA0B300A388EC /* CreateDialogNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDialogNode.swift; sourceTree = "<group>"; };
 		682ED52E204F348100B17B06 /* WAVRepair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WAVRepair.swift; sourceTree = "<group>"; };
 		6836B8FD2091D1AF006DF944 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
+		6836B90A2091D6DB006DF944 /* AuthenticationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTests.swift; sourceTree = "<group>"; };
 		683947AA202CF4F3007E3CF3 /* RelationArgument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelationArgument.swift; sourceTree = "<group>"; };
 		683947AB202CF4F3007E3CF3 /* RelationsResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelationsResult.swift; sourceTree = "<group>"; };
 		683947AC202CF4F3007E3CF3 /* SemanticRolesObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemanticRolesObject.swift; sourceTree = "<group>"; };
@@ -1663,6 +1666,7 @@
 		682D30681F7D3BFD005562F9 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				6836B90A2091D6DB006DF944 /* AuthenticationTests.swift */,
 				68B213ED1F8429880052DC00 /* CodableExtensionsTests.swift */,
 				68B213EE1F8429890052DC00 /* JSONValueTests.swift */,
 			);
@@ -3830,9 +3834,11 @@
 				68B213EF1F84298B0052DC00 /* CodableExtensionsTests.swift in Sources */,
 				68B213F01F84298B0052DC00 /* JSONValueTests.swift in Sources */,
 				68BC29031F8C38700042810E /* RestRequest.swift in Sources */,
+				6836B90C20924DE4006DF944 /* Credentials.swift in Sources */,
 				68BC28FE1F8C38700042810E /* CodableExtensions.swift in Sources */,
 				68BC29041F8C38700042810E /* RestToken.swift in Sources */,
 				68BC28FF1F8C38700042810E /* JSONWrapper.swift in Sources */,
+				6836B90B2091D6DB006DF944 /* AuthenticationTests.swift in Sources */,
 				68BC29021F8C38700042810E /* RestError.swift in Sources */,
 				68BC29051F8C38700042810E /* RestUtilities.swift in Sources */,
 				68BC29001F8C38700042810E /* JSON.swift in Sources */,

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -150,6 +150,18 @@
 		6823CEF31F8EA0F700A388EC /* WorkspaceExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6823CE9A1F8EA0AC00A388EC /* WorkspaceExport.swift */; };
 		682ED52F204F348100B17B06 /* WAVRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682ED52E204F348100B17B06 /* WAVRepair.swift */; };
 		6832BBEE2009CE8800BA50A8 /* SpeechToText+Recognize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AF76772008167900D35B2D /* SpeechToText+Recognize.swift */; };
+		6836B8FE2091D1AF006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B8FF2091D237006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9002091D238006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9012091D238006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9022091D239006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9032091D23A006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9042091D23B006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9052091D23C006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9062091D23D006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9072091D23D006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9082091D23E006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
+		6836B9092091D240006DF944 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
 		683947D5202CF4F7007E3CF3 /* RelationArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683947AA202CF4F3007E3CF3 /* RelationArgument.swift */; };
 		683947D6202CF4F7007E3CF3 /* RelationsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683947AB202CF4F3007E3CF3 /* RelationsResult.swift */; };
 		683947D7202CF4F7007E3CF3 /* SemanticRolesObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683947AC202CF4F3007E3CF3 /* SemanticRolesObject.swift */; };
@@ -873,6 +885,7 @@
 		6823CEBD1F8EA0B300A388EC /* CounterexampleCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterexampleCollection.swift; sourceTree = "<group>"; };
 		6823CEBE1F8EA0B300A388EC /* CreateDialogNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDialogNode.swift; sourceTree = "<group>"; };
 		682ED52E204F348100B17B06 /* WAVRepair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WAVRepair.swift; sourceTree = "<group>"; };
+		6836B8FD2091D1AF006DF944 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		683947AA202CF4F3007E3CF3 /* RelationArgument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelationArgument.swift; sourceTree = "<group>"; };
 		683947AB202CF4F3007E3CF3 /* RelationsResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelationsResult.swift; sourceTree = "<group>"; };
 		683947AC202CF4F3007E3CF3 /* SemanticRolesObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemanticRolesObject.swift; sourceTree = "<group>"; };
@@ -1854,9 +1867,10 @@
 		7A61174E1CB5988B009A4DA1 /* RestKit */ = {
 			isa = PBXGroup;
 			children = (
+				6836B8FD2091D1AF006DF944 /* Authentication.swift */,
 				68B213E71F84296D0052DC00 /* CodableExtensions.swift */,
-				7AEBE4361DBEAA130089188C /* JSONWrapper.swift */,
 				68B213E81F84296D0052DC00 /* JSON.swift */,
+				7AEBE4361DBEAA130089188C /* JSONWrapper.swift */,
 				7AD240081DC7B4360002FEB5 /* MultipartFormData.swift */,
 				681BA1B41F7DCB1E006633A3 /* RestError.swift */,
 				7A61174F1CB5988B009A4DA1 /* RestRequest.swift */,
@@ -3509,6 +3523,7 @@
 				683947E5202CF4F7007E3CF3 /* Model.swift in Sources */,
 				683947F5202CF4F7007E3CF3 /* TargetedSentimentResults.swift in Sources */,
 				683947E9202CF4F7007E3CF3 /* CategoriesResult.swift in Sources */,
+				6836B9042091D23B006DF944 /* Authentication.swift in Sources */,
 				683947F0202CF4F7007E3CF3 /* KeywordsResult.swift in Sources */,
 				683947FF202CF4F7007E3CF3 /* EntitiesOptions.swift in Sources */,
 				683947EC202CF4F7007E3CF3 /* SemanticRolesAction.swift in Sources */,
@@ -3554,6 +3569,7 @@
 				689A170D203CCDA9002CFC66 /* Words.swift in Sources */,
 				682ED52F204F348100B17B06 /* WAVRepair.swift in Sources */,
 				68BC28E01F8C35080042810E /* JSON.swift in Sources */,
+				6836B9072091D23D006DF944 /* Authentication.swift in Sources */,
 				689A1707203CCDA9002CFC66 /* Voices.swift in Sources */,
 				689A1709203CCDA9002CFC66 /* UpdateVoiceModel.swift in Sources */,
 				689A170C203CCDA9002CFC66 /* SupportedFeatures.swift in Sources */,
@@ -3659,6 +3675,7 @@
 				68BC28921F8C35010042810E /* RestError.swift in Sources */,
 				68AF8FA02069690300D552E3 /* Configuration.swift in Sources */,
 				683955082077E613009E1C8A /* TopHitsResults.swift in Sources */,
+				6836B9012091D238006DF944 /* Authentication.swift in Sources */,
 				68AF8F6E2069690300D552E3 /* QueryRelationsFilter.swift in Sources */,
 				68AF8F942069690300D552E3 /* ListConfigurationsResponse.swift in Sources */,
 				68AF8F822069690300D552E3 /* NluEnrichmentEntities.swift in Sources */,
@@ -3742,6 +3759,7 @@
 				6800FCB72056D8D50078788A /* Intent.swift in Sources */,
 				6800FCB02056D8D50078788A /* DialogNodeVisitedDetails.swift in Sources */,
 				6800FCBC2056D8D50078788A /* LogMessage.swift in Sources */,
+				6836B8FF2091D237006DF944 /* Authentication.swift in Sources */,
 				6800FC9F2056D8CB0078788A /* Assistant.swift in Sources */,
 				6800FCD52056D8D50078788A /* WorkspaceExport.swift in Sources */,
 				6877FA8A2056D4F100383B25 /* RestUtilities.swift in Sources */,
@@ -3791,6 +3809,7 @@
 				7A6711A01DD0F1790070CA9D /* PersonalityInsights.swift in Sources */,
 				68BC28BE1F8C35050042810E /* CodableExtensions.swift in Sources */,
 				689A16B5203C9946002CFC66 /* Behavior.swift in Sources */,
+				6836B9052091D23C006DF944 /* Authentication.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3817,6 +3836,7 @@
 				68BC29021F8C38700042810E /* RestError.swift in Sources */,
 				68BC29051F8C38700042810E /* RestUtilities.swift in Sources */,
 				68BC29001F8C38700042810E /* JSON.swift in Sources */,
+				6836B8FE2091D1AF006DF944 /* Authentication.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3847,6 +3867,7 @@
 				689A168E203C88C7002CFC66 /* FaceIdentity.swift in Sources */,
 				689A1696203C88C7002CFC66 /* FaceAge.swift in Sources */,
 				689A169B203C88C7002CFC66 /* Classifier.swift in Sources */,
+				6836B9092091D240006DF944 /* Authentication.swift in Sources */,
 				689A1692203C88C7002CFC66 /* ClassResult.swift in Sources */,
 				689A1691203C88C7002CFC66 /* ImageWithFaces.swift in Sources */,
 				689A1698203C88C7002CFC66 /* WarningInfo.swift in Sources */,
@@ -3885,6 +3906,7 @@
 				7AAAF4121CEE9D5300B74848 /* ToneCategory.swift in Sources */,
 				68BC28EA1F8C35080042810E /* RestError.swift in Sources */,
 				68BC28ED1F8C35080042810E /* RestUtilities.swift in Sources */,
+				6836B9082091D23E006DF944 /* Authentication.swift in Sources */,
 				68D09C20200D61870087ADE5 /* UtteranceAnalysis.swift in Sources */,
 				68D09C1F200D61870087ADE5 /* ToneChatInput.swift in Sources */,
 				68D09C23200D61870087ADE5 /* ToneInput.swift in Sources */,
@@ -3943,6 +3965,7 @@
 				68F7FF02207D458900E84DBF /* SpeechModel.swift in Sources */,
 				68F7FF24207D47BD00E84DBF /* RecognitionState.swift in Sources */,
 				68F7FEFC207D458900E84DBF /* AudioResources.swift in Sources */,
+				6836B9062091D23D006DF944 /* Authentication.swift in Sources */,
 				68F7FF1A207D458900E84DBF /* RegisterStatus.swift in Sources */,
 				68F7FF09207D458900E84DBF /* SpeechRecognitionResult.swift in Sources */,
 				68F7FF14207D458900E84DBF /* Words.swift in Sources */,
@@ -3993,6 +4016,7 @@
 				68BC28AC1F8C35030042810E /* RestToken.swift in Sources */,
 				68BC28A71F8C35030042810E /* JSONWrapper.swift in Sources */,
 				7AAAF4C91CEEA11900B74848 /* NaturalLanguageClassifier.swift in Sources */,
+				6836B9032091D23A006DF944 /* Authentication.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4012,6 +4036,7 @@
 				68A6A9A1202A0EE90069585F /* TranslationResult.swift in Sources */,
 				68A6A9A0202A0EE90069585F /* TranslationModel.swift in Sources */,
 				68A6A9A6202A0EE90069585F /* TranslateRequest.swift in Sources */,
+				6836B9022091D239006DF944 /* Authentication.swift in Sources */,
 				68A6A9A5202A0EE90069585F /* IdentifiedLanguage.swift in Sources */,
 				68BC289F1F8C35020042810E /* JSONWrapper.swift in Sources */,
 				68A6A9A4202A0EE90069585F /* IdentifiableLanguages.swift in Sources */,
@@ -4091,6 +4116,7 @@
 				6823CEC11F8EA0F700A388EC /* Counterexample.swift in Sources */,
 				6823CEE31F8EA0F700A388EC /* Synonym.swift in Sources */,
 				68BC28841F8C35000042810E /* RestToken.swift in Sources */,
+				6836B9002091D238006DF944 /* Authentication.swift in Sources */,
 				6823CEE11F8EA0F700A388EC /* RuntimeEntity.swift in Sources */,
 				68BC287E1F8C35000042810E /* CodableExtensions.swift in Sources */,
 				6823CECD1F8EA0F700A388EC /* DialogNodeCollection.swift in Sources */,


### PR DESCRIPTION
**Note: You may want to merge this into a `v1.0` or `develop` branch instead of `master`.**

This pull request updates RestKit to use a single completion handler instead of separate `failure` and `success` functions.

Since a number of changes were made to RestKit in #812, this pull request is branched off of `iam-authentication` instead of `master`. Therefore, #812 should be reviewed/updated/merged first.