### PR TITLE
Remove references to Language Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,8 +364,6 @@ The following links provide more information about the IBM Discovery service:
 
 The IBM Watson Language Translator service lets you select a domain, customize it, then identify or select the language of text, and then translate the text from one supported language to another.
 
-Note that the Language Translator service was formerly known as Language Translation. It is recommended to [migrate](https://console.bluemix.net/docs/services/language-translator/migrating.html) to Language Translator, however, existing Language Translation service instances are currently supported by the `LanguageTranslatorV2` framework. To use a legacy Language Translation service, set the `serviceURL` property before executing the first API call to the service.
-
 The following example demonstrates how to use the Language Translator service:
 
 ```swift
@@ -374,9 +372,6 @@ import LanguageTranslatorV2
 let username = "your-username-here"
 let password = "your-password-here"
 let languageTranslator = LanguageTranslator(username: username, password: password)
-
-// set the serviceURL property to use the legacy Language Translation service
-// languageTranslator.serviceURL = "https://gateway.watsonplatform.net/language-translation/api"
 
 let failure = { (error: Error) in print(error) }
 let request = TranslateRequest(text: ["Hello"], source: "en", target: "es")


### PR DESCRIPTION
This PR removes the last references to the old Language Translation service from the README.  All other references except in the Changelog have been removed.

Fixes #721