### PR TITLE
Generate current dates in the test suite

### DIFF
--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -91,12 +91,20 @@ class AssistantTests: XCTestCase {
             ("testMessageInvalidWorkspaceID", testMessageInvalidWorkspaceID),
         ]
     }
-
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+    
     /** Instantiate Assistant. */
     func instantiateAssistant() {
         let username = Credentials.AssistantUsername
         let password = Credentials.AssistantPassword
-        let version = "2018-02-16"
+        let version = generateDate()
         assistant = Assistant(username: username, password: password, version: version)
         assistant.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         assistant.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -91,12 +91,20 @@ class ConversationTests: XCTestCase {
             ("testMessageInvalidWorkspaceID", testMessageInvalidWorkspaceID),
         ]
     }
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
 
     /** Instantiate Conversation. */
     func instantiateConversation() {
         let username = Credentials.ConversationUsername
         let password = Credentials.ConversationPassword
-        let version = "2018-02-16"
+        let version = generateDate()
         conversation = Conversation(username: username, password: password, version: version)
         conversation.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         conversation.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -38,11 +38,19 @@ class DiscoveryTests: XCTestCase {
         environment = lookupOrCreateTestEnvironment()
         documentURL = loadDocument(name: "KennedySpeech", ext: "html")
     }
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
 
     func instantiateDiscovery() -> Discovery {
         let username = Credentials.DiscoveryUsername
         let password = Credentials.DiscoveryPassword
-        let version = "2017-11-07"
+        let version = generateDate()
         let discovery = Discovery(username: username, password: password, version: version)
         discovery.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         discovery.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
+++ b/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
@@ -55,12 +55,20 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             ("testListModels", testListModels),
         ]
     }
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
 
     /** Instantiate Natural Language Understanding instance. */
     func instantiateNaturalLanguageUnderstanding() {
         let username = Credentials.NaturalLanguageUnderstandingUsername
         let password = Credentials.NaturalLanguageUnderstandingPassword
-        naturalLanguageUnderstanding = NaturalLanguageUnderstanding(username: username, password: password, version: "2016-05-17")
+        naturalLanguageUnderstanding = NaturalLanguageUnderstanding(username: username, password: password, version: generateDate())
         naturalLanguageUnderstanding.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         naturalLanguageUnderstanding.defaultHeaders["X-Watson-Test"] = "true"
     }

--- a/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
@@ -44,11 +44,19 @@ class PersonalityInsightsTests: XCTestCase {
         instantiatePersonalityInsights()
         loadTestResources()
     }
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
 
     func instantiatePersonalityInsights() {
         let username = Credentials.PersonalityInsightsV3Username
         let password = Credentials.PersonalityInsightsV3Password
-        personalityInsights = PersonalityInsights(username: username, password: password, version: "2016-10-20")
+        personalityInsights = PersonalityInsights(username: username, password: password, version: generateDate())
         personalityInsights.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         personalityInsights.defaultHeaders["X-Watson-Test"] = "true"
     }

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -58,12 +58,20 @@ class ToneAnalyzerTests: XCTestCase {
         continueAfterFailure = false
         instantiateToneAnalyzer()
     }
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
 
     /** Instantiate Tone Analyzer. */
     func instantiateToneAnalyzer() {
         let username = Credentials.ToneAnalyzerUsername
         let password = Credentials.ToneAnalyzerPassword
-        toneAnalyzer = ToneAnalyzer(username: username, password: password, version: "2017-09-21")
+        toneAnalyzer = ToneAnalyzer(username: username, password: password, version: generateDate())
         toneAnalyzer.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         toneAnalyzer.defaultHeaders["X-Watson-Test"] = "true"
     }

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
@@ -33,11 +33,19 @@ class VisualRecognitionCoreMLTests: XCTestCase {
         continueAfterFailure = false
         instantiateVisualRecognition()
     }
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
 
     /** Instantiate Visual Recognition */
     func instantiateVisualRecognition() {
         let apiKey = Credentials.VisualRecognitionAPIKey
-        let version = "2018-03-19"
+        let version = generateDate()
         visualRecognition = VisualRecognition(apiKey: apiKey, version: version)
         visualRecognition.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         visualRecognition.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
@@ -44,10 +44,18 @@ class VisualRecognitionUIImageTests: XCTestCase {
         continueAfterFailure = false
         instantiateVisualRecognition()
     }
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
 
     func instantiateVisualRecognition() {
         let apiKey = Credentials.VisualRecognitionAPIKey
-        let version = "2018-03-19"
+        let version = generateDate()
         visualRecognition = VisualRecognition(apiKey: apiKey, version: version)
         visualRecognition.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         visualRecognition.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -80,11 +80,19 @@ class VisualRecognitionTests: XCTestCase {
         continueAfterFailure = false
         instantiateVisualRecognition()
     }
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
 
     /** Instantiate Visual Recognition. */
     func instantiateVisualRecognition() {
         let apiKey = Credentials.VisualRecognitionAPIKey
-        let version = "2018-03-19"
+        let version = generateDate()
         visualRecognition = VisualRecognition(apiKey: apiKey, version: version)
         visualRecognition.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         visualRecognition.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionWithIAMTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionWithIAMTests.swift
@@ -73,11 +73,19 @@ class VisualRecognitionWithIAMTests: XCTestCase {
     }
 
     // MARK: - Positive Tests
+    
+    /** Generate today's date. */
+    func generateDate() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
 
     /** Access service using IAM API Key credentials  */
     func testAccessWithAPIKey() {
         let apiKey = IAMCredentials.VisualRecognitionAPIKey
-        let version = "2018-03-19"
+        let version = generateDate()
         let visualRecognition = VisualRecognition(version: version, apiKey: apiKey)
         visualRecognition.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         visualRecognition.defaultHeaders["X-Watson-Test"] = "true"
@@ -123,7 +131,7 @@ class VisualRecognitionWithIAMTests: XCTestCase {
 
         // Pass the access token as the credentials when instantiating the service
 
-        let version = "2018-03-19"
+        let version = generateDate()
         let visualRecognition = VisualRecognition(version: version, accessToken: accessToken)
         visualRecognition.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         visualRecognition.defaultHeaders["X-Watson-Test"] = "true"


### PR DESCRIPTION
Generate current programmatic dates in the test suite rather than hardcoding them in.

In relation to the following issue: https://github.ibm.com/arf/planning-sdk-squad/issues/500 (the common class aspect of that issue is in a separate branch)