### PR TITLE
Fix run-tests to report success when all tests pass

### DIFF
--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -10,9 +10,6 @@
 # the device to build for
 DESTINATION="OS=11.3,name=iPhone 7"
 
-# the exit code of each build command
-EXIT_CODES=()
-
 # the schemes to build, which must be invoked from the root directory of the project
 SCHEMES=$(xcodebuild -list | awk 'schemes { if (NF>0) { print $1 } } /Schemes:$/ { schemes = 1 }')
 
@@ -35,10 +32,12 @@ brew outdated swiftlint || brew upgrade swiftlint
 # (required to check status code when using xcpretty)
 set -o pipefail
 
+# Make sure RC is not set from the parent environment
+unset RC
+
 # build each scheme
 for SCHEME in ${SCHEMES}; do
-	xcodebuild -scheme "$SCHEME" -destination "$DESTINATION" test | xcpretty
-	EXIT_CODES+=($?)
+	xcodebuild -scheme "$SCHEME" -destination "$DESTINATION" test | xcpretty || RC=${RC:-$?}
 done
 
 ####################
@@ -46,10 +45,4 @@ done
 ####################
 
 # exit with the first non-zero status or zero if all builds exited successfully
-for EXIT_CODE in ${EXIT_CODES[@]}; do
-	if [ $EXIT_CODE -ne 0 ]
-	then
-		exit $EXIT_CODE
-	fi
-done
-exit 0
+exit ${RC:-0}

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -150,9 +150,8 @@ class SpeechToTextTests: XCTestCase {
 
     // MARK: - Wait Functions
 
-    func waitUntil(condition: () -> Bool) {
+    func waitUntil(maxRetries: Int = 5, condition: () -> Bool) {
         let sleepTime: UInt32 = 5
-        let maxRetries = 5
         for retry in 1 ... maxRetries {
             if !condition() && retry < maxRetries {
                 sleep(sleepTime)
@@ -163,7 +162,7 @@ class SpeechToTextTests: XCTestCase {
     }
 
     func waitUntil(_ languageModel: LanguageModel, is status: String) {
-        waitUntil {
+        waitUntil(maxRetries: 12) {
             var hasDesiredStatus = false
             let expectation = self.expectation(description: "getLanguageModel")
             let failure = { (error: Error) in if !error.localizedDescription.contains("locked") { XCTFail(error.localizedDescription) }}

--- a/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/LanguageTranslatorV3.xcscheme
+++ b/WatsonDeveloperCloud.xcodeproj/xcshareddata/xcschemes/LanguageTranslatorV3.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0940"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CAD2685120CAF28A002BA2C4"
+               BuildableName = "LanguageTranslatorV3.framework"
+               BlueprintName = "LanguageTranslatorV3"
+               ReferencedContainer = "container:WatsonDeveloperCloud.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CAD2685920CAF28A002BA2C4"
+               BuildableName = "LanguageTranslatorV3Tests.xctest"
+               BlueprintName = "LanguageTranslatorV3Tests"
+               ReferencedContainer = "container:WatsonDeveloperCloud.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CAD2685120CAF28A002BA2C4"
+            BuildableName = "LanguageTranslatorV3.framework"
+            BlueprintName = "LanguageTranslatorV3"
+            ReferencedContainer = "container:WatsonDeveloperCloud.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CAD2685120CAF28A002BA2C4"
+            BuildableName = "LanguageTranslatorV3.framework"
+            BlueprintName = "LanguageTranslatorV3"
+            ReferencedContainer = "container:WatsonDeveloperCloud.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CAD2685120CAF28A002BA2C4"
+            BuildableName = "LanguageTranslatorV3.framework"
+            BlueprintName = "LanguageTranslatorV3"
+            ReferencedContainer = "container:WatsonDeveloperCloud.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
The run-tests.sh script was reporting a non-zero exit code even when there were no test failures.  This problem did not occur when testing locally.  It turned out that the problem was that the scheme for LanguageTranslatorV3 was not added to the project.

This PR adds the LTv3 scheme and includes a few other minor fixes to improve test reliability.