### PR TITLE
Use bodyEnums to pass body content to methods with multi-consumes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,25 +7,26 @@ disabled_rules: # rule identifiers to exclude from running
   - opening_brace
   - redundant_string_enum_value
   - cyclomatic_complexity
+  - superfluous_disable_command
 
 opt_in_rules:
  - force_unwrapping
 
 file_length:
-  warning: 3000
-  error: 4000
+  warning: 1000
+  error: 2000
 
 type_body_length:
   warning: 3000
   error: 4000
 
 function_body_length:
-  warning: 50
-  error: 80
+  warning: 100
+  error: 200
 
 line_length:
-  warning: 500
-  error: 999
+  warning: 200
+  error: 300
 
 identifier_name:
   excluded: # excluded via string array
@@ -37,5 +38,3 @@ trailing_comma:
 trailing_whitespace:
   severity: error
 
-superfluous_disable_command:
-  severity: warning

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -91,9 +91,6 @@ public class Assistant {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -107,10 +104,10 @@ public class Assistant {
      There is no rate limit for this operation.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter request: The message to be sent. This includes the user's input, along with optional intents, entities, and context from
-       the last response.
-     - parameter nodesVisitedDetails: Whether to include additional diagnostic information about the dialog nodes that were visited during processing
-       of the message.
+     - parameter request: The message to be sent. This includes the user's input, along with optional intents,
+       entities, and context from the last response.
+     - parameter nodesVisitedDetails: Whether to include additional diagnostic information about the dialog nodes that
+       were visited during processing of the message.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -180,10 +177,11 @@ public class Assistant {
 
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -318,9 +316,11 @@ public class Assistant {
      limit is 20 requests per 30 minutes. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -389,10 +389,10 @@ public class Assistant {
      - parameter properties: Valid data defining the new and updated workspace content.
        The maximum size for this data is 50MB. If you need to import a larger amount of workspace data, consider
        importing components such as intents and entities using separate operations.
-     - parameter append: Whether the new data is to be appended to the existing data in the workspace. If **append**=`false`, elements
-       included in the new data completely replace the corresponding existing elements, including all subelements. For
-       example, if the new data includes **entities** and **append**=`false`, all existing entities in the workspace are
-       discarded and replaced with the new entities.
+     - parameter append: Whether the new data is to be appended to the existing data in the workspace. If
+       **append**=`false`, elements included in the new data completely replace the corresponding existing elements,
+       including all subelements. For example, if the new data includes **entities** and **append**=`false`, all
+       existing entities in the workspace are discarded and replaced with the new entities.
        If **append**=`true`, existing elements are preserved, and the new elements are added. If any elements in the new
        data collide with existing elements, the update request fails.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -518,14 +518,16 @@ public class Assistant {
      limit is 400 requests per 30 minutes. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -614,8 +616,8 @@ public class Assistant {
        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.
        - It cannot begin with the reserved prefix `sys-`.
        - It must be no longer than 128 characters.
-     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or
+       tab characters, and it must be no longer than 128 characters.
      - parameter examples: An array of user input examples for the intent.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -685,9 +687,11 @@ public class Assistant {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter intent: The intent name.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -887,10 +891,11 @@ public class Assistant {
      - parameter intent: The intent name.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1043,7 +1048,8 @@ public class Assistant {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter intent: The intent name.
      - parameter text: The text of the user input example.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1237,10 +1243,11 @@ public class Assistant {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1320,7 +1327,8 @@ public class Assistant {
      This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:
+     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following
+       restrictions:
        - It cannot contain carriage return, newline, or tab characters
        - It cannot consist of only whitespace characters
        - It must be no longer than 1024 characters.
@@ -1389,7 +1397,8 @@ public class Assistant {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter text: The text of a user input counterexample (for example, `What are you wearing?`).
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1574,14 +1583,16 @@ public class Assistant {
      limit is 200 requests per 30 minutes. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1732,9 +1743,11 @@ public class Assistant {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1802,10 +1815,10 @@ public class Assistant {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter properties: The updated content of the entity. Any elements included in the new data will completely replace the equivalent
-       existing elements, including all subelements. (Previously existing subelements are not retained unless they are
-       also included in the new data.) For example, if you update the values for an entity, the previously existing
-       values are discarded and replaced with the new values specified in the update.
+     - parameter properties: The updated content of the entity. Any elements included in the new data will completely
+       replace the equivalent existing elements, including all subelements. (Previously existing subelements are not
+       retained unless they are also included in the new data.) For example, if you update the values for an entity, the
+       previously existing values are discarded and replaced with the new values specified in the update.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1927,14 +1940,16 @@ public class Assistant {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2088,9 +2103,11 @@ public class Assistant {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2292,10 +2309,11 @@ public class Assistant {
      - parameter value: The text of the entity value.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2452,7 +2470,8 @@ public class Assistant {
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
      - parameter synonym: The text of the synonym.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2651,10 +2670,11 @@ public class Assistant {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2799,7 +2819,8 @@ public class Assistant {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter dialogNode: The dialog node ID (for example, `get_order`).
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2987,10 +3008,10 @@ public class Assistant {
      specified, the limit is 120 requests per minute. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
-     - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. For more information, see
-       the
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. For
+       more information, see the
        [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter cursor: A token identifying the page of results to retrieve.
@@ -3068,12 +3089,12 @@ public class Assistant {
      If **cursor** is not specified, this operation is limited to 40 requests per 30 minutes. If **cursor** is
      specified, the limit is 120 requests per minute. For more information, see **Rate limiting**.
 
-     - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. You must specify a filter
-       query that includes a value for `language`, as well as a value for `workspace_id` or
+     - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. You
+       must specify a filter query that includes a value for `language`, as well as a value for `workspace_id` or
        `request.context.metadata.deployment`. For more information, see the
        [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter cursor: A token identifying the page of results to retrieve.
      - parameter headers: A dictionary of request headers to be sent with this request.

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -91,6 +91,9 @@ public class Assistant {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)

--- a/Source/AssistantV1/Models/CaptureGroup.swift
+++ b/Source/AssistantV1/Models/CaptureGroup.swift
@@ -39,7 +39,8 @@ public struct CaptureGroup: Codable {
      Initialize a `CaptureGroup` with member variables.
 
      - parameter group: A recognized capture group for the entity.
-     - parameter location: Zero-based character offsets that indicate where the entity value begins and ends in the input text.
+     - parameter location: Zero-based character offsets that indicate where the entity value begins and ends in the
+       input text.
 
      - returns: An initialized `CaptureGroup`.
     */

--- a/Source/AssistantV1/Models/Context.swift
+++ b/Source/AssistantV1/Models/Context.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** State information for the conversation. To maintain state, include the context from the previous response. */
+/**
+ State information for the conversation. To maintain state, include the context from the previous response.
+ */
 public struct Context: Codable {
 
     /**

--- a/Source/AssistantV1/Models/CreateCounterexample.swift
+++ b/Source/AssistantV1/Models/CreateCounterexample.swift
@@ -35,7 +35,8 @@ public struct CreateCounterexample: Encodable {
     /**
      Initialize a `CreateCounterexample` with member variables.
 
-     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:
+     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following
+       restrictions:
        - It cannot contain carriage return, newline, or tab characters
        - It cannot consist of only whitespace characters
        - It must be no longer than 1024 characters.

--- a/Source/AssistantV1/Models/CreateDialogNode.swift
+++ b/Source/AssistantV1/Models/CreateDialogNode.swift
@@ -192,19 +192,20 @@ public struct CreateDialogNode: Encodable {
      - parameter dialogNode: The dialog node ID. This string must conform to the following restrictions:
        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.
        - It must be no longer than 1024 characters.
-     - parameter description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and
-       it must be no longer than 128 characters.
-     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab
-       characters, and it must be no longer than 2048 characters.
+     - parameter description: The description of the dialog node. This string cannot contain carriage return,
+       newline, or tab characters, and it must be no longer than 128 characters.
+     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage
+       return, newline, or tab characters, and it must be no longer than 2048 characters.
      - parameter parent: The ID of the parent dialog node.
      - parameter previousSibling: The ID of the previous dialog node.
-     - parameter output: The output of the dialog node. For more information about how to specify dialog node output, see the
-       [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+     - parameter output: The output of the dialog node. For more information about how to specify dialog node output,
+       see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
      - parameter context: The context for the dialog node.
      - parameter metadata: The metadata for the dialog node.
      - parameter nextStep: The next step to be executed in dialog processing.
      - parameter actions: An array of objects describing any actions to be invoked by the dialog node.
-     - parameter title: The alias used to identify the dialog node. This string must conform to the following restrictions:
+     - parameter title: The alias used to identify the dialog node. This string must conform to the following
+       restrictions:
        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.
        - It must be no longer than 64 characters.
      - parameter nodeType: How the dialog node is processed.

--- a/Source/AssistantV1/Models/CreateEntity.swift
+++ b/Source/AssistantV1/Models/CreateEntity.swift
@@ -64,8 +64,8 @@ public struct CreateEntity: Encodable {
        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
        - It cannot begin with the reserved prefix `sys-`.
        - It must be no longer than 64 characters.
-     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or
+       tab characters, and it must be no longer than 128 characters.
      - parameter metadata: Any metadata related to the value.
      - parameter values: An array of objects describing the entity values.
      - parameter fuzzyMatch: Whether to use fuzzy matching for the entity.

--- a/Source/AssistantV1/Models/CreateIntent.swift
+++ b/Source/AssistantV1/Models/CreateIntent.swift
@@ -52,8 +52,8 @@ public struct CreateIntent: Encodable {
        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.
        - It cannot begin with the reserved prefix `sys-`.
        - It must be no longer than 128 characters.
-     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or
+       tab characters, and it must be no longer than 128 characters.
      - parameter examples: An array of user input examples for the intent.
 
      - returns: An initialized `CreateIntent`.

--- a/Source/AssistantV1/Models/CreateValue.swift
+++ b/Source/AssistantV1/Models/CreateValue.swift
@@ -79,14 +79,14 @@ public struct CreateValue: Encodable {
        - It cannot consist of only whitespace characters.
        - It must be no longer than 64 characters.
      - parameter metadata: Any metadata related to the entity value.
-     - parameter synonyms: An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated
-       by **type**), but not both. A synonym must conform to the following restrictions:
+     - parameter synonyms: An array containing any synonyms for the entity value. You can provide either synonyms or
+       patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:
        - It cannot contain carriage return, newline, or tab characters.
        - It cannot consist of only whitespace characters.
        - It must be no longer than 64 characters.
-     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by
-       **type**), but not both. A pattern is a regular expression no longer than 512 characters. For more information
-       about how to specify a pattern, see the
+     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as
+       indicated by **type**), but not both. A pattern is a regular expression no longer than 512 characters. For more
+       information about how to specify a pattern, see the
        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
      - parameter valueType: Specifies the type of value.
 

--- a/Source/AssistantV1/Models/CreateWorkspace.swift
+++ b/Source/AssistantV1/Models/CreateWorkspace.swift
@@ -83,18 +83,19 @@ public struct CreateWorkspace: Encodable {
     /**
      Initialize a `CreateWorkspace` with member variables.
 
-     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be
-       no longer than 64 characters.
-     - parameter description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab
+       characters, and it must be no longer than 64 characters.
+     - parameter description: The description of the workspace. This string cannot contain carriage return, newline,
+       or tab characters, and it must be no longer than 128 characters.
      - parameter language: The language of the workspace.
      - parameter intents: An array of objects defining the intents for the workspace.
      - parameter entities: An array of objects defining the entities for the workspace.
      - parameter dialogNodes: An array of objects defining the nodes in the workspace dialog.
-     - parameter counterexamples: An array of objects defining input examples that have been marked as irrelevant input.
+     - parameter counterexamples: An array of objects defining input examples that have been marked as irrelevant
+       input.
      - parameter metadata: Any metadata related to the workspace.
-     - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates
-       that workspace training data is not to be used.
+     - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service
+       improvements. `true` indicates that workspace training data is not to be used.
 
      - returns: An initialized `CreateWorkspace`.
     */

--- a/Source/AssistantV1/Models/DialogNodeAction.swift
+++ b/Source/AssistantV1/Models/DialogNodeAction.swift
@@ -68,7 +68,8 @@ public struct DialogNodeAction: Codable {
      - parameter resultVariable: The location in the dialog context where the result of the action is stored.
      - parameter actionType: The type of action to invoke.
      - parameter parameters: A map of key/value pairs to be provided to the action.
-     - parameter credentials: The name of the context variable that the client application will use to pass in credentials for the action.
+     - parameter credentials: The name of the context variable that the client application will use to pass in
+       credentials for the action.
 
      - returns: An initialized `DialogNodeAction`.
     */

--- a/Source/AssistantV1/Models/DialogNodeCollection.swift
+++ b/Source/AssistantV1/Models/DialogNodeCollection.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An array of dialog nodes. */
+/**
+ An array of dialog nodes.
+ */
 public struct DialogNodeCollection: Decodable {
 
     /**

--- a/Source/AssistantV1/Models/DialogNodeNextStep.swift
+++ b/Source/AssistantV1/Models/DialogNodeNextStep.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The next step to execute following this dialog node. */
+/**
+ The next step to execute following this dialog node.
+ */
 public struct DialogNodeNextStep: Codable {
 
     /**
@@ -121,7 +123,8 @@ public struct DialogNodeNextStep: Codable {
            - `skip_slot`
            - `skip_all_slots`
        If you specify `jump_to`, then you must also specify a value for the `dialog_node` property.
-     - parameter dialogNode: The ID of the dialog node to process next. This parameter is required if **behavior**=`jump_to`.
+     - parameter dialogNode: The ID of the dialog node to process next. This parameter is required if
+       **behavior**=`jump_to`.
      - parameter selector: Which part of the dialog node to process next.
 
      - returns: An initialized `DialogNodeNextStep`.

--- a/Source/AssistantV1/Models/EntityCollection.swift
+++ b/Source/AssistantV1/Models/EntityCollection.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An array of entities. */
+/**
+ An array of entities.
+ */
 public struct EntityCollection: Decodable {
 
     /**

--- a/Source/AssistantV1/Models/InputData.swift
+++ b/Source/AssistantV1/Models/InputData.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The user input. */
+/**
+ The user input.
+ */
 public struct InputData: Codable {
 
     /**
@@ -33,8 +35,8 @@ public struct InputData: Codable {
     /**
      Initialize a `InputData` with member variables.
 
-     - parameter text: The text of the user input. This string cannot contain carriage return, newline, or tab characters, and it must
-       be no longer than 2048 characters.
+     - parameter text: The text of the user input. This string cannot contain carriage return, newline, or tab
+       characters, and it must be no longer than 2048 characters.
 
      - returns: An initialized `InputData`.
     */

--- a/Source/AssistantV1/Models/LogMessage.swift
+++ b/Source/AssistantV1/Models/LogMessage.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Log message details. */
+/**
+ Log message details.
+ */
 public struct LogMessage: Codable {
 
     /**

--- a/Source/AssistantV1/Models/LogPagination.swift
+++ b/Source/AssistantV1/Models/LogPagination.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The pagination data for the returned objects. */
+/**
+ The pagination data for the returned objects.
+ */
 public struct LogPagination: Decodable {
 
     /**

--- a/Source/AssistantV1/Models/MessageInput.swift
+++ b/Source/AssistantV1/Models/MessageInput.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The text of the user input. */
+/**
+ The text of the user input.
+ */
 public struct MessageInput: Decodable {
 
     /**

--- a/Source/AssistantV1/Models/MessageRequest.swift
+++ b/Source/AssistantV1/Models/MessageRequest.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A request formatted for the Watson Assistant service. */
+/**
+ A request formatted for the Watson Assistant service.
+ */
 public struct MessageRequest: Codable {
 
     /**
@@ -67,15 +69,16 @@ public struct MessageRequest: Codable {
      Initialize a `MessageRequest` with member variables.
 
      - parameter input: An input object that includes the input text.
-     - parameter alternateIntents: Whether to return more than one intent. Set to `true` to return all matching intents.
-     - parameter context: State information for the conversation. Continue a conversation by including the context object from the previous
-       response.
-     - parameter entities: Entities to use when evaluating the message. Include entities from the previous response to continue using those
-       entities rather than detecting entities in the new input.
-     - parameter intents: Intents to use when evaluating the user input. Include intents from the previous response to continue using those
-       intents rather than trying to recognize intents in the new input.
-     - parameter output: System output. Include the output from the previous response to maintain intermediate information over multiple
-       requests.
+     - parameter alternateIntents: Whether to return more than one intent. Set to `true` to return all matching
+       intents.
+     - parameter context: State information for the conversation. Continue a conversation by including the context
+       object from the previous response.
+     - parameter entities: Entities to use when evaluating the message. Include entities from the previous response
+       to continue using those entities rather than detecting entities in the new input.
+     - parameter intents: Intents to use when evaluating the user input. Include intents from the previous response
+       to continue using those intents rather than trying to recognize intents in the new input.
+     - parameter output: System output. Include the output from the previous response to maintain intermediate
+       information over multiple requests.
 
      - returns: An initialized `MessageRequest`.
     */

--- a/Source/AssistantV1/Models/MessageResponse.swift
+++ b/Source/AssistantV1/Models/MessageResponse.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A response from the Watson Assistant service. */
+/**
+ A response from the Watson Assistant service.
+ */
 public struct MessageResponse: Decodable {
 
     /**

--- a/Source/AssistantV1/Models/OutputData.swift
+++ b/Source/AssistantV1/Models/OutputData.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An output object that includes the response to the user, the nodes that were hit, and messages from the log. */
+/**
+ An output object that includes the response to the user, the nodes that were hit, and messages from the log.
+ */
 public struct OutputData: Codable {
 
     /**
@@ -59,11 +61,12 @@ public struct OutputData: Codable {
 
      - parameter logMessages: An array of up to 50 messages logged with the request.
      - parameter text: An array of responses to the user.
-     - parameter nodesVisited: An array of the nodes that were triggered to create the response, in the order in which they were visited. This
-       information is useful for debugging and for tracing the path taken through the node tree.
-     - parameter nodesVisitedDetails: An array of objects containing detailed diagnostic information about the nodes that were triggered during
-       processing of the input message. Included only if **nodes_visited_details** is set to `true` in the message
-       request.
+     - parameter nodesVisited: An array of the nodes that were triggered to create the response, in the order in
+       which they were visited. This information is useful for debugging and for tracing the path taken through the node
+       tree.
+     - parameter nodesVisitedDetails: An array of objects containing detailed diagnostic information about the nodes
+       that were triggered during processing of the input message. Included only if **nodes_visited_details** is set to
+       `true` in the message request.
 
      - returns: An initialized `OutputData`.
     */

--- a/Source/AssistantV1/Models/Pagination.swift
+++ b/Source/AssistantV1/Models/Pagination.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The pagination data for the returned objects. */
+/**
+ The pagination data for the returned objects.
+ */
 public struct Pagination: Decodable {
 
     /**

--- a/Source/AssistantV1/Models/RuntimeEntity.swift
+++ b/Source/AssistantV1/Models/RuntimeEntity.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A term from the request that was identified as an entity. */
+/**
+ A term from the request that was identified as an entity.
+ */
 public struct RuntimeEntity: Codable {
 
     /**
@@ -68,8 +70,8 @@ public struct RuntimeEntity: Codable {
      Initialize a `RuntimeEntity` with member variables.
 
      - parameter entity: An entity detected in the input.
-     - parameter location: An array of zero-based character offsets that indicate where the detected entity values begin and end in the
-       input text.
+     - parameter location: An array of zero-based character offsets that indicate where the detected entity values
+       begin and end in the input text.
      - parameter value: The term in the input text that was recognized as an entity value.
      - parameter confidence: A decimal percentage that represents Watson's confidence in the entity.
      - parameter metadata: Any metadata for the entity.

--- a/Source/AssistantV1/Models/RuntimeIntent.swift
+++ b/Source/AssistantV1/Models/RuntimeIntent.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An intent identified in the user input. */
+/**
+ An intent identified in the user input.
+ */
 public struct RuntimeIntent: Codable {
 
     /**

--- a/Source/AssistantV1/Models/SystemResponse.swift
+++ b/Source/AssistantV1/Models/SystemResponse.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** For internal use only. */
+/**
+ For internal use only.
+ */
 public struct SystemResponse: Codable {
 
     /// Additional properties associated with this model.

--- a/Source/AssistantV1/Models/UpdateDialogNode.swift
+++ b/Source/AssistantV1/Models/UpdateDialogNode.swift
@@ -192,18 +192,19 @@ public struct UpdateDialogNode: Encodable {
      - parameter dialogNode: The dialog node ID. This string must conform to the following restrictions:
        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.
        - It must be no longer than 1024 characters.
-     - parameter description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and
-       it must be no longer than 128 characters.
-     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab
-       characters, and it must be no longer than 2048 characters.
+     - parameter description: The description of the dialog node. This string cannot contain carriage return,
+       newline, or tab characters, and it must be no longer than 128 characters.
+     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage
+       return, newline, or tab characters, and it must be no longer than 2048 characters.
      - parameter parent: The ID of the parent dialog node.
      - parameter previousSibling: The ID of the previous sibling dialog node.
-     - parameter output: The output of the dialog node. For more information about how to specify dialog node output, see the
-       [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+     - parameter output: The output of the dialog node. For more information about how to specify dialog node output,
+       see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
      - parameter context: The context for the dialog node.
      - parameter metadata: The metadata for the dialog node.
      - parameter nextStep: The next step to be executed in dialog processing.
-     - parameter title: The alias used to identify the dialog node. This string must conform to the following restrictions:
+     - parameter title: The alias used to identify the dialog node. This string must conform to the following
+       restrictions:
        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.
        - It must be no longer than 64 characters.
      - parameter nodeType: How the dialog node is processed.

--- a/Source/AssistantV1/Models/UpdateEntity.swift
+++ b/Source/AssistantV1/Models/UpdateEntity.swift
@@ -64,8 +64,8 @@ public struct UpdateEntity: Encodable {
        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
        - It cannot begin with the reserved prefix `sys-`.
        - It must be no longer than 64 characters.
-     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or
+       tab characters, and it must be no longer than 128 characters.
      - parameter metadata: Any metadata related to the entity.
      - parameter fuzzyMatch: Whether to use fuzzy matching for the entity.
      - parameter values: An array of entity values.

--- a/Source/AssistantV1/Models/UpdateValue.swift
+++ b/Source/AssistantV1/Models/UpdateValue.swift
@@ -80,14 +80,14 @@ public struct UpdateValue: Encodable {
        - It must be no longer than 64 characters.
      - parameter metadata: Any metadata related to the entity value.
      - parameter valueType: Specifies the type of value.
-     - parameter synonyms: An array of synonyms for the entity value. You can provide either synonyms or patterns (as indicated by
-       **type**), but not both. A synonym must conform to the following resrictions:
+     - parameter synonyms: An array of synonyms for the entity value. You can provide either synonyms or patterns (as
+       indicated by **type**), but not both. A synonym must conform to the following resrictions:
        - It cannot contain carriage return, newline, or tab characters.
        - It cannot consist of only whitespace characters.
        - It must be no longer than 64 characters.
-     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by
-       **type**), but not both. A pattern is a regular expression no longer than 512 characters. For more information
-       about how to specify a pattern, see the
+     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as
+       indicated by **type**), but not both. A pattern is a regular expression no longer than 512 characters. For more
+       information about how to specify a pattern, see the
        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
 
      - returns: An initialized `UpdateValue`.

--- a/Source/AssistantV1/Models/UpdateWorkspace.swift
+++ b/Source/AssistantV1/Models/UpdateWorkspace.swift
@@ -83,18 +83,19 @@ public struct UpdateWorkspace: Encodable {
     /**
      Initialize a `UpdateWorkspace` with member variables.
 
-     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be
-       no longer than 64 characters.
-     - parameter description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab
+       characters, and it must be no longer than 64 characters.
+     - parameter description: The description of the workspace. This string cannot contain carriage return, newline,
+       or tab characters, and it must be no longer than 128 characters.
      - parameter language: The language of the workspace.
      - parameter intents: An array of objects defining the intents for the workspace.
      - parameter entities: An array of objects defining the entities for the workspace.
      - parameter dialogNodes: An array of objects defining the nodes in the workspace dialog.
-     - parameter counterexamples: An array of objects defining input examples that have been marked as irrelevant input.
+     - parameter counterexamples: An array of objects defining input examples that have been marked as irrelevant
+       input.
      - parameter metadata: Any metadata related to the workspace.
-     - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates
-       that workspace training data is not to be used.
+     - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service
+       improvements. `true` indicates that workspace training data is not to be used.
 
      - returns: An initialized `UpdateWorkspace`.
     */

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -21,7 +21,6 @@ import Foundation
  The IBM Watson&trade; Conversation service combines machine learning, natural language understanding, and integrated
  dialog tools to create conversation flows between your apps and your users.
  */
-@available(*, deprecated, message: "The IBM Watson Conversation service has been renamed to Assistant. Please use the `Assistant` class instead of `Conversation`. The `Conversation` class will be removed in a future release.")
 public class Conversation {
 
     /// The base URL to use when contacting the service.
@@ -92,9 +91,6 @@ public class Conversation {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -108,10 +104,10 @@ public class Conversation {
      There is no rate limit for this operation.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter request: The message to be sent. This includes the user's input, along with optional intents, entities, and context from
-       the last response.
-     - parameter nodesVisitedDetails: Whether to include additional diagnostic information about the dialog nodes that were visited during processing
-       of the message.
+     - parameter request: The message to be sent. This includes the user's input, along with optional intents,
+       entities, and context from the last response.
+     - parameter nodesVisitedDetails: Whether to include additional diagnostic information about the dialog nodes that
+       were visited during processing of the message.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -181,10 +177,11 @@ public class Conversation {
 
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -319,9 +316,11 @@ public class Conversation {
      limit is 20 requests per 30 minutes. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -390,10 +389,10 @@ public class Conversation {
      - parameter properties: Valid data defining the new and updated workspace content.
        The maximum size for this data is 50MB. If you need to import a larger amount of workspace data, consider
        importing components such as intents and entities using separate operations.
-     - parameter append: Whether the new data is to be appended to the existing data in the workspace. If **append**=`false`, elements
-       included in the new data completely replace the corresponding existing elements, including all subelements. For
-       example, if the new data includes **entities** and **append**=`false`, all existing entities in the workspace are
-       discarded and replaced with the new entities.
+     - parameter append: Whether the new data is to be appended to the existing data in the workspace. If
+       **append**=`false`, elements included in the new data completely replace the corresponding existing elements,
+       including all subelements. For example, if the new data includes **entities** and **append**=`false`, all
+       existing entities in the workspace are discarded and replaced with the new entities.
        If **append**=`true`, existing elements are preserved, and the new elements are added. If any elements in the new
        data collide with existing elements, the update request fails.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -519,14 +518,16 @@ public class Conversation {
      limit is 400 requests per 30 minutes. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -615,8 +616,8 @@ public class Conversation {
        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.
        - It cannot begin with the reserved prefix `sys-`.
        - It must be no longer than 128 characters.
-     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or
+       tab characters, and it must be no longer than 128 characters.
      - parameter examples: An array of user input examples for the intent.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -686,9 +687,11 @@ public class Conversation {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter intent: The intent name.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -888,10 +891,11 @@ public class Conversation {
      - parameter intent: The intent name.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1044,7 +1048,8 @@ public class Conversation {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter intent: The intent name.
      - parameter text: The text of the user input example.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1238,10 +1243,11 @@ public class Conversation {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1321,7 +1327,8 @@ public class Conversation {
      This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:
+     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following
+       restrictions:
        - It cannot contain carriage return, newline, or tab characters
        - It cannot consist of only whitespace characters
        - It must be no longer than 1024 characters.
@@ -1390,7 +1397,8 @@ public class Conversation {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter text: The text of a user input counterexample (for example, `What are you wearing?`).
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1575,14 +1583,16 @@ public class Conversation {
      limit is 200 requests per 30 minutes. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1733,9 +1743,11 @@ public class Conversation {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1803,10 +1815,10 @@ public class Conversation {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter properties: The updated content of the entity. Any elements included in the new data will completely replace the equivalent
-       existing elements, including all subelements. (Previously existing subelements are not retained unless they are
-       also included in the new data.) For example, if you update the values for an entity, the previously existing
-       values are discarded and replaced with the new values specified in the update.
+     - parameter properties: The updated content of the entity. Any elements included in the new data will completely
+       replace the equivalent existing elements, including all subelements. (Previously existing subelements are not
+       retained unless they are also included in the new data.) For example, if you update the values for an entity, the
+       previously existing values are discarded and replaced with the new values specified in the update.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1928,14 +1940,16 @@ public class Conversation {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2089,9 +2103,11 @@ public class Conversation {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
-     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes
-       only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter export: Whether to include all element content in the returned data. If **export**=`false`, the
+       returned data includes only information about the element itself. If **export**=`true`, all content, including
+       subelements, is included.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2293,10 +2309,11 @@ public class Conversation {
      - parameter value: The text of the entity value.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2453,7 +2470,8 @@ public class Conversation {
      - parameter entity: The name of the entity.
      - parameter value: The text of the entity value.
      - parameter synonym: The text of the synonym.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2652,10 +2670,11 @@ public class Conversation {
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter includeCount: Whether to include information about the number of records returned.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter cursor: A token identifying the page of results to retrieve.
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2800,7 +2819,8 @@ public class Conversation {
 
      - parameter workspaceID: Unique identifier of the workspace.
      - parameter dialogNode: The dialog node ID (for example, `get_order`).
-     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+     - parameter includeAudit: Whether to include the audit properties (`created` and `updated` timestamps) in the
+       response.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2988,10 +3008,10 @@ public class Conversation {
      specified, the limit is 120 requests per minute. For more information, see **Rate limiting**.
 
      - parameter workspaceID: Unique identifier of the workspace.
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
-     - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. For more information, see
-       the
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. For
+       more information, see the
        [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter cursor: A token identifying the page of results to retrieve.
@@ -3069,12 +3089,12 @@ public class Conversation {
      If **cursor** is not specified, this operation is limited to 40 requests per 30 minutes. If **cursor** is
      specified, the limit is 120 requests per minute. For more information, see **Rate limiting**.
 
-     - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. You must specify a filter
-       query that includes a value for `language`, as well as a value for `workspace_id` or
+     - parameter filter: A cacheable parameter that limits the results to those matching the specified filter. You
+       must specify a filter query that includes a value for `language`, as well as a value for `workspace_id` or
        `request.context.metadata.deployment`. For more information, see the
        [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
-     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus
-       sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+     - parameter sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the
+       value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
      - parameter pageLimit: The number of records to return in each page of results.
      - parameter cursor: A token identifying the page of results to retrieve.
      - parameter headers: A dictionary of request headers to be sent with this request.

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -21,6 +21,7 @@ import Foundation
  The IBM Watson&trade; Conversation service combines machine learning, natural language understanding, and integrated
  dialog tools to create conversation flows between your apps and your users.
  */
+@available(*, deprecated, message: "The IBM Watson Conversation service has been renamed to Assistant. Please use the `Assistant` class instead of `Conversation`. The `Conversation` class will be removed in a future release.")
 public class Conversation {
 
     /// The base URL to use when contacting the service.
@@ -91,6 +92,9 @@ public class Conversation {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)

--- a/Source/ConversationV1/Models/CaptureGroup.swift
+++ b/Source/ConversationV1/Models/CaptureGroup.swift
@@ -39,7 +39,8 @@ public struct CaptureGroup: Codable {
      Initialize a `CaptureGroup` with member variables.
 
      - parameter group: A recognized capture group for the entity.
-     - parameter location: Zero-based character offsets that indicate where the entity value begins and ends in the input text.
+     - parameter location: Zero-based character offsets that indicate where the entity value begins and ends in the
+       input text.
 
      - returns: An initialized `CaptureGroup`.
     */

--- a/Source/ConversationV1/Models/Context.swift
+++ b/Source/ConversationV1/Models/Context.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** State information for the conversation. To maintain state, include the context from the previous response. */
+/**
+ State information for the conversation. To maintain state, include the context from the previous response.
+ */
 public struct Context: Codable {
 
     /**

--- a/Source/ConversationV1/Models/CreateCounterexample.swift
+++ b/Source/ConversationV1/Models/CreateCounterexample.swift
@@ -35,7 +35,8 @@ public struct CreateCounterexample: Encodable {
     /**
      Initialize a `CreateCounterexample` with member variables.
 
-     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:
+     - parameter text: The text of a user input marked as irrelevant input. This string must conform to the following
+       restrictions:
        - It cannot contain carriage return, newline, or tab characters
        - It cannot consist of only whitespace characters
        - It must be no longer than 1024 characters.

--- a/Source/ConversationV1/Models/CreateDialogNode.swift
+++ b/Source/ConversationV1/Models/CreateDialogNode.swift
@@ -192,19 +192,20 @@ public struct CreateDialogNode: Encodable {
      - parameter dialogNode: The dialog node ID. This string must conform to the following restrictions:
        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.
        - It must be no longer than 1024 characters.
-     - parameter description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and
-       it must be no longer than 128 characters.
-     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab
-       characters, and it must be no longer than 2048 characters.
+     - parameter description: The description of the dialog node. This string cannot contain carriage return,
+       newline, or tab characters, and it must be no longer than 128 characters.
+     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage
+       return, newline, or tab characters, and it must be no longer than 2048 characters.
      - parameter parent: The ID of the parent dialog node.
      - parameter previousSibling: The ID of the previous dialog node.
-     - parameter output: The output of the dialog node. For more information about how to specify dialog node output, see the
-       [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+     - parameter output: The output of the dialog node. For more information about how to specify dialog node output,
+       see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
      - parameter context: The context for the dialog node.
      - parameter metadata: The metadata for the dialog node.
      - parameter nextStep: The next step to be executed in dialog processing.
      - parameter actions: An array of objects describing any actions to be invoked by the dialog node.
-     - parameter title: The alias used to identify the dialog node. This string must conform to the following restrictions:
+     - parameter title: The alias used to identify the dialog node. This string must conform to the following
+       restrictions:
        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.
        - It must be no longer than 64 characters.
      - parameter nodeType: How the dialog node is processed.

--- a/Source/ConversationV1/Models/CreateEntity.swift
+++ b/Source/ConversationV1/Models/CreateEntity.swift
@@ -64,8 +64,8 @@ public struct CreateEntity: Encodable {
        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
        - It cannot begin with the reserved prefix `sys-`.
        - It must be no longer than 64 characters.
-     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or
+       tab characters, and it must be no longer than 128 characters.
      - parameter metadata: Any metadata related to the value.
      - parameter values: An array of objects describing the entity values.
      - parameter fuzzyMatch: Whether to use fuzzy matching for the entity.

--- a/Source/ConversationV1/Models/CreateIntent.swift
+++ b/Source/ConversationV1/Models/CreateIntent.swift
@@ -52,8 +52,8 @@ public struct CreateIntent: Encodable {
        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.
        - It cannot begin with the reserved prefix `sys-`.
        - It must be no longer than 128 characters.
-     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter description: The description of the intent. This string cannot contain carriage return, newline, or
+       tab characters, and it must be no longer than 128 characters.
      - parameter examples: An array of user input examples for the intent.
 
      - returns: An initialized `CreateIntent`.

--- a/Source/ConversationV1/Models/CreateValue.swift
+++ b/Source/ConversationV1/Models/CreateValue.swift
@@ -79,14 +79,14 @@ public struct CreateValue: Encodable {
        - It cannot consist of only whitespace characters.
        - It must be no longer than 64 characters.
      - parameter metadata: Any metadata related to the entity value.
-     - parameter synonyms: An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated
-       by **type**), but not both. A synonym must conform to the following restrictions:
+     - parameter synonyms: An array containing any synonyms for the entity value. You can provide either synonyms or
+       patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:
        - It cannot contain carriage return, newline, or tab characters.
        - It cannot consist of only whitespace characters.
        - It must be no longer than 64 characters.
-     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by
-       **type**), but not both. A pattern is a regular expression no longer than 512 characters. For more information
-       about how to specify a pattern, see the
+     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as
+       indicated by **type**), but not both. A pattern is a regular expression no longer than 512 characters. For more
+       information about how to specify a pattern, see the
        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
      - parameter valueType: Specifies the type of value.
 

--- a/Source/ConversationV1/Models/CreateWorkspace.swift
+++ b/Source/ConversationV1/Models/CreateWorkspace.swift
@@ -83,18 +83,19 @@ public struct CreateWorkspace: Encodable {
     /**
      Initialize a `CreateWorkspace` with member variables.
 
-     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be
-       no longer than 64 characters.
-     - parameter description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab
+       characters, and it must be no longer than 64 characters.
+     - parameter description: The description of the workspace. This string cannot contain carriage return, newline,
+       or tab characters, and it must be no longer than 128 characters.
      - parameter language: The language of the workspace.
      - parameter intents: An array of objects defining the intents for the workspace.
      - parameter entities: An array of objects defining the entities for the workspace.
      - parameter dialogNodes: An array of objects defining the nodes in the workspace dialog.
-     - parameter counterexamples: An array of objects defining input examples that have been marked as irrelevant input.
+     - parameter counterexamples: An array of objects defining input examples that have been marked as irrelevant
+       input.
      - parameter metadata: Any metadata related to the workspace.
-     - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates
-       that workspace training data is not to be used.
+     - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service
+       improvements. `true` indicates that workspace training data is not to be used.
 
      - returns: An initialized `CreateWorkspace`.
     */

--- a/Source/ConversationV1/Models/DialogNodeAction.swift
+++ b/Source/ConversationV1/Models/DialogNodeAction.swift
@@ -68,7 +68,8 @@ public struct DialogNodeAction: Codable {
      - parameter resultVariable: The location in the dialog context where the result of the action is stored.
      - parameter actionType: The type of action to invoke.
      - parameter parameters: A map of key/value pairs to be provided to the action.
-     - parameter credentials: The name of the context variable that the client application will use to pass in credentials for the action.
+     - parameter credentials: The name of the context variable that the client application will use to pass in
+       credentials for the action.
 
      - returns: An initialized `DialogNodeAction`.
     */

--- a/Source/ConversationV1/Models/DialogNodeCollection.swift
+++ b/Source/ConversationV1/Models/DialogNodeCollection.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An array of dialog nodes. */
+/**
+ An array of dialog nodes.
+ */
 public struct DialogNodeCollection: Decodable {
 
     /**

--- a/Source/ConversationV1/Models/DialogNodeNextStep.swift
+++ b/Source/ConversationV1/Models/DialogNodeNextStep.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The next step to execute following this dialog node. */
+/**
+ The next step to execute following this dialog node.
+ */
 public struct DialogNodeNextStep: Codable {
 
     /**
@@ -121,7 +123,8 @@ public struct DialogNodeNextStep: Codable {
            - `skip_slot`
            - `skip_all_slots`
        If you specify `jump_to`, then you must also specify a value for the `dialog_node` property.
-     - parameter dialogNode: The ID of the dialog node to process next. This parameter is required if **behavior**=`jump_to`.
+     - parameter dialogNode: The ID of the dialog node to process next. This parameter is required if
+       **behavior**=`jump_to`.
      - parameter selector: Which part of the dialog node to process next.
 
      - returns: An initialized `DialogNodeNextStep`.

--- a/Source/ConversationV1/Models/EntityCollection.swift
+++ b/Source/ConversationV1/Models/EntityCollection.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An array of entities. */
+/**
+ An array of entities.
+ */
 public struct EntityCollection: Decodable {
 
     /**

--- a/Source/ConversationV1/Models/InputData.swift
+++ b/Source/ConversationV1/Models/InputData.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The user input. */
+/**
+ The user input.
+ */
 public struct InputData: Codable {
 
     /**
@@ -33,8 +35,8 @@ public struct InputData: Codable {
     /**
      Initialize a `InputData` with member variables.
 
-     - parameter text: The text of the user input. This string cannot contain carriage return, newline, or tab characters, and it must
-       be no longer than 2048 characters.
+     - parameter text: The text of the user input. This string cannot contain carriage return, newline, or tab
+       characters, and it must be no longer than 2048 characters.
 
      - returns: An initialized `InputData`.
     */

--- a/Source/ConversationV1/Models/LogMessage.swift
+++ b/Source/ConversationV1/Models/LogMessage.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Log message details. */
+/**
+ Log message details.
+ */
 public struct LogMessage: Codable {
 
     /**

--- a/Source/ConversationV1/Models/LogPagination.swift
+++ b/Source/ConversationV1/Models/LogPagination.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The pagination data for the returned objects. */
+/**
+ The pagination data for the returned objects.
+ */
 public struct LogPagination: Decodable {
 
     /**

--- a/Source/ConversationV1/Models/MessageInput.swift
+++ b/Source/ConversationV1/Models/MessageInput.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The text of the user input. */
+/**
+ The text of the user input.
+ */
 public struct MessageInput: Decodable {
 
     /**

--- a/Source/ConversationV1/Models/MessageRequest.swift
+++ b/Source/ConversationV1/Models/MessageRequest.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A request formatted for the Conversation service. */
+/**
+ A request formatted for the Conversation service.
+ */
 public struct MessageRequest: Codable {
 
     /**
@@ -67,15 +69,16 @@ public struct MessageRequest: Codable {
      Initialize a `MessageRequest` with member variables.
 
      - parameter input: An input object that includes the input text.
-     - parameter alternateIntents: Whether to return more than one intent. Set to `true` to return all matching intents.
-     - parameter context: State information for the conversation. Continue a conversation by including the context object from the previous
-       response.
-     - parameter entities: Entities to use when evaluating the message. Include entities from the previous response to continue using those
-       entities rather than detecting entities in the new input.
-     - parameter intents: Intents to use when evaluating the user input. Include intents from the previous response to continue using those
-       intents rather than trying to recognize intents in the new input.
-     - parameter output: System output. Include the output from the previous response to maintain intermediate information over multiple
-       requests.
+     - parameter alternateIntents: Whether to return more than one intent. Set to `true` to return all matching
+       intents.
+     - parameter context: State information for the conversation. Continue a conversation by including the context
+       object from the previous response.
+     - parameter entities: Entities to use when evaluating the message. Include entities from the previous response
+       to continue using those entities rather than detecting entities in the new input.
+     - parameter intents: Intents to use when evaluating the user input. Include intents from the previous response
+       to continue using those intents rather than trying to recognize intents in the new input.
+     - parameter output: System output. Include the output from the previous response to maintain intermediate
+       information over multiple requests.
 
      - returns: An initialized `MessageRequest`.
     */

--- a/Source/ConversationV1/Models/MessageResponse.swift
+++ b/Source/ConversationV1/Models/MessageResponse.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A response from the Conversation service. */
+/**
+ A response from the Conversation service.
+ */
 public struct MessageResponse: Decodable {
 
     /**

--- a/Source/ConversationV1/Models/OutputData.swift
+++ b/Source/ConversationV1/Models/OutputData.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An output object that includes the response to the user, the nodes that were hit, and messages from the log. */
+/**
+ An output object that includes the response to the user, the nodes that were hit, and messages from the log.
+ */
 public struct OutputData: Codable {
 
     /**
@@ -59,11 +61,12 @@ public struct OutputData: Codable {
 
      - parameter logMessages: An array of up to 50 messages logged with the request.
      - parameter text: An array of responses to the user.
-     - parameter nodesVisited: An array of the nodes that were triggered to create the response, in the order in which they were visited. This
-       information is useful for debugging and for tracing the path taken through the node tree.
-     - parameter nodesVisitedDetails: An array of objects containing detailed diagnostic information about the nodes that were triggered during
-       processing of the input message. Included only if **nodes_visited_details** is set to `true` in the message
-       request.
+     - parameter nodesVisited: An array of the nodes that were triggered to create the response, in the order in
+       which they were visited. This information is useful for debugging and for tracing the path taken through the node
+       tree.
+     - parameter nodesVisitedDetails: An array of objects containing detailed diagnostic information about the nodes
+       that were triggered during processing of the input message. Included only if **nodes_visited_details** is set to
+       `true` in the message request.
 
      - returns: An initialized `OutputData`.
     */

--- a/Source/ConversationV1/Models/Pagination.swift
+++ b/Source/ConversationV1/Models/Pagination.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The pagination data for the returned objects. */
+/**
+ The pagination data for the returned objects.
+ */
 public struct Pagination: Decodable {
 
     /**

--- a/Source/ConversationV1/Models/RuntimeEntity.swift
+++ b/Source/ConversationV1/Models/RuntimeEntity.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A term from the request that was identified as an entity. */
+/**
+ A term from the request that was identified as an entity.
+ */
 public struct RuntimeEntity: Codable {
 
     /**
@@ -68,8 +70,8 @@ public struct RuntimeEntity: Codable {
      Initialize a `RuntimeEntity` with member variables.
 
      - parameter entity: An entity detected in the input.
-     - parameter location: An array of zero-based character offsets that indicate where the detected entity values begin and end in the
-       input text.
+     - parameter location: An array of zero-based character offsets that indicate where the detected entity values
+       begin and end in the input text.
      - parameter value: The term in the input text that was recognized as an entity value.
      - parameter confidence: A decimal percentage that represents Watson's confidence in the entity.
      - parameter metadata: Any metadata for the entity.

--- a/Source/ConversationV1/Models/RuntimeIntent.swift
+++ b/Source/ConversationV1/Models/RuntimeIntent.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An intent identified in the user input. */
+/**
+ An intent identified in the user input.
+ */
 public struct RuntimeIntent: Codable {
 
     /**

--- a/Source/ConversationV1/Models/SystemResponse.swift
+++ b/Source/ConversationV1/Models/SystemResponse.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** For internal use only. */
+/**
+ For internal use only.
+ */
 public struct SystemResponse: Codable {
 
     /// Additional properties associated with this model.

--- a/Source/ConversationV1/Models/UpdateDialogNode.swift
+++ b/Source/ConversationV1/Models/UpdateDialogNode.swift
@@ -192,18 +192,19 @@ public struct UpdateDialogNode: Encodable {
      - parameter dialogNode: The dialog node ID. This string must conform to the following restrictions:
        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.
        - It must be no longer than 1024 characters.
-     - parameter description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and
-       it must be no longer than 128 characters.
-     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab
-       characters, and it must be no longer than 2048 characters.
+     - parameter description: The description of the dialog node. This string cannot contain carriage return,
+       newline, or tab characters, and it must be no longer than 128 characters.
+     - parameter conditions: The condition that will trigger the dialog node. This string cannot contain carriage
+       return, newline, or tab characters, and it must be no longer than 2048 characters.
      - parameter parent: The ID of the parent dialog node.
      - parameter previousSibling: The ID of the previous sibling dialog node.
-     - parameter output: The output of the dialog node. For more information about how to specify dialog node output, see the
-       [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+     - parameter output: The output of the dialog node. For more information about how to specify dialog node output,
+       see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
      - parameter context: The context for the dialog node.
      - parameter metadata: The metadata for the dialog node.
      - parameter nextStep: The next step to be executed in dialog processing.
-     - parameter title: The alias used to identify the dialog node. This string must conform to the following restrictions:
+     - parameter title: The alias used to identify the dialog node. This string must conform to the following
+       restrictions:
        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.
        - It must be no longer than 64 characters.
      - parameter nodeType: How the dialog node is processed.

--- a/Source/ConversationV1/Models/UpdateEntity.swift
+++ b/Source/ConversationV1/Models/UpdateEntity.swift
@@ -64,8 +64,8 @@ public struct UpdateEntity: Encodable {
        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
        - It cannot begin with the reserved prefix `sys-`.
        - It must be no longer than 64 characters.
-     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter description: The description of the entity. This string cannot contain carriage return, newline, or
+       tab characters, and it must be no longer than 128 characters.
      - parameter metadata: Any metadata related to the entity.
      - parameter fuzzyMatch: Whether to use fuzzy matching for the entity.
      - parameter values: An array of entity values.

--- a/Source/ConversationV1/Models/UpdateValue.swift
+++ b/Source/ConversationV1/Models/UpdateValue.swift
@@ -80,14 +80,14 @@ public struct UpdateValue: Encodable {
        - It must be no longer than 64 characters.
      - parameter metadata: Any metadata related to the entity value.
      - parameter valueType: Specifies the type of value.
-     - parameter synonyms: An array of synonyms for the entity value. You can provide either synonyms or patterns (as indicated by
-       **type**), but not both. A synonym must conform to the following resrictions:
+     - parameter synonyms: An array of synonyms for the entity value. You can provide either synonyms or patterns (as
+       indicated by **type**), but not both. A synonym must conform to the following resrictions:
        - It cannot contain carriage return, newline, or tab characters.
        - It cannot consist of only whitespace characters.
        - It must be no longer than 64 characters.
-     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by
-       **type**), but not both. A pattern is a regular expression no longer than 512 characters. For more information
-       about how to specify a pattern, see the
+     - parameter patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as
+       indicated by **type**), but not both. A pattern is a regular expression no longer than 512 characters. For more
+       information about how to specify a pattern, see the
        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
 
      - returns: An initialized `UpdateValue`.

--- a/Source/ConversationV1/Models/UpdateWorkspace.swift
+++ b/Source/ConversationV1/Models/UpdateWorkspace.swift
@@ -83,18 +83,19 @@ public struct UpdateWorkspace: Encodable {
     /**
      Initialize a `UpdateWorkspace` with member variables.
 
-     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be
-       no longer than 64 characters.
-     - parameter description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it
-       must be no longer than 128 characters.
+     - parameter name: The name of the workspace. This string cannot contain carriage return, newline, or tab
+       characters, and it must be no longer than 64 characters.
+     - parameter description: The description of the workspace. This string cannot contain carriage return, newline,
+       or tab characters, and it must be no longer than 128 characters.
      - parameter language: The language of the workspace.
      - parameter intents: An array of objects defining the intents for the workspace.
      - parameter entities: An array of objects defining the entities for the workspace.
      - parameter dialogNodes: An array of objects defining the nodes in the workspace dialog.
-     - parameter counterexamples: An array of objects defining input examples that have been marked as irrelevant input.
+     - parameter counterexamples: An array of objects defining input examples that have been marked as irrelevant
+       input.
      - parameter metadata: Any metadata related to the workspace.
-     - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates
-       that workspace training data is not to be used.
+     - parameter learningOptOut: Whether training data from the workspace can be used by IBM for general service
+       improvements. `true` indicates that workspace training data is not to be used.
 
      - returns: An initialized `UpdateWorkspace`.
     */

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -93,6 +93,12 @@ public class Discovery {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
+            if case let .some(.string(description)) = json["description"] {
+                userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -93,12 +93,6 @@ public class Discovery {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
-            if case let .some(.string(description)) = json["description"] {
-                userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -457,8 +451,8 @@ public class Discovery {
      it possible for the tooling to add additional metadata and information to the configuration.
 
      - parameter environmentID: The ID of the environment.
-     - parameter configuration: Input an object that enables you to customize how your content is ingested and what enrichments are added to your
-       data.
+     - parameter configuration: Input an object that enables you to customize how your content is ingested and what
+       enrichments are added to your data.
        `name` is required and must be unique within the current `environment`. All other properties are optional.
        If the input configuration contains the `configuration_id`, `created`, or `updated` properties, then they will be
        ignored and overridden by the system (an error is not returned so that the overridden fields do not need to be
@@ -647,8 +641,8 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter configurationID: The ID of the configuration.
-     - parameter configuration: Input an object that enables you to update and customize how your data is ingested and what enrichments are added
-       to your data.
+     - parameter configuration: Input an object that enables you to update and customize how your data is ingested and
+       what enrichments are added to your data.
        The `name` parameter is required and must be unique within the current `environment`. All other properties are
        optional, but if they are omitted  the default values replace the current value of each omitted property.
        If the input configuration contains the `configuration_id`, `created`, or `updated` properties, they are ignored
@@ -779,20 +773,20 @@ public class Discovery {
      help you understand how the document was processed. The document is not added to the index.
 
      - parameter environmentID: The ID of the environment.
-     - parameter configuration: The configuration to use to process the document. If this part is provided, then the provided configuration is
-       used to process the document. If the `configuration_id` is also provided (both are present at the same time),
-       then request is rejected. The maximum supported configuration size is 1 MB. Configuration parts larger than 1 MB
-       are rejected.
+     - parameter configuration: The configuration to use to process the document. If this part is provided, then the
+       provided configuration is used to process the document. If the `configuration_id` is also provided (both are
+       present at the same time), then request is rejected. The maximum supported configuration size is 1 MB.
+       Configuration parts larger than 1 MB are rejected.
        See the `GET /configurations/{configuration_id}` operation for an example configuration.
-     - parameter step: Specify to only run the input document through the given step instead of running the input document through the
-       entire ingestion workflow. Valid values are `convert`, `enrich`, and `normalize`.
-     - parameter configurationID: The ID of the configuration to use to process the document. If the `configuration` form part is also provided
-       (both are present at the same time), then request will be rejected.
-     - parameter file: The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50
-       megabytes is rejected.
-     - parameter metadata: If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata
-       that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1
-       MB are rejected.
+     - parameter step: Specify to only run the input document through the given step instead of running the input
+       document through the entire ingestion workflow. Valid values are `convert`, `enrich`, and `normalize`.
+     - parameter configurationID: The ID of the configuration to use to process the document. If the `configuration`
+       form part is also provided (both are present at the same time), then request will be rejected.
+     - parameter file: The content of the document to ingest. The maximum supported file size is 50 megabytes. Files
+       larger than 50 megabytes is rejected.
+     - parameter metadata: If you're using the Data Crawler to upload your documents, you can test a document against
+       the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata
+       parts larger than 1 MB are rejected.
        Example:  ``` {
          \"Creator\": \"Johnny Appleseed\",
          \"Subject\": \"Apples\"
@@ -1440,11 +1434,11 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter collectionID: The ID of the collection.
-     - parameter file: The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50
-       megabytes is rejected.
-     - parameter metadata: If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata
-       that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1
-       MB are rejected.
+     - parameter file: The content of the document to ingest. The maximum supported file size is 50 megabytes. Files
+       larger than 50 megabytes is rejected.
+     - parameter metadata: If you're using the Data Crawler to upload your documents, you can test a document against
+       the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata
+       parts larger than 1 MB are rejected.
        Example:  ``` {
          \"Creator\": \"Johnny Appleseed\",
          \"Subject\": \"Apples\"
@@ -1587,11 +1581,11 @@ public class Discovery {
      - parameter environmentID: The ID of the environment.
      - parameter collectionID: The ID of the collection.
      - parameter documentID: The ID of the document.
-     - parameter file: The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50
-       megabytes is rejected.
-     - parameter metadata: If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata
-       that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1
-       MB are rejected.
+     - parameter file: The content of the document to ingest. The maximum supported file size is 50 megabytes. Files
+       larger than 50 megabytes is rejected.
+     - parameter metadata: If you're using the Data Crawler to upload your documents, you can test a document against
+       the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata
+       parts larger than 1 MB are rejected.
        Example:  ``` {
          \"Creator\": \"Johnny Appleseed\",
          \"Subject\": \"Apples\"
@@ -1735,47 +1729,48 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter collectionID: The ID of the collection.
-     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't mention the query
-       content. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts
-       in the data set.
-     - parameter query: A query search returns all documents in your data set with full enrichments and full text, but with the most
-       relevant documents listed first. Use a query search when you want to find the most relevant search results. You
-       cannot use `natural_language_query` and `query` at the same time.
-     - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training data and natural language
-       understanding. You cannot use `natural_language_query` and `query` at the same time.
+     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't
+       mention the query content. Filter searches are better for metadata type searches and when you are trying to get a
+       sense of concepts in the data set.
+     - parameter query: A query search returns all documents in your data set with full enrichments and full text, but
+       with the most relevant documents listed first. Use a query search when you want to find the most relevant search
+       results. You cannot use `natural_language_query` and `query` at the same time.
+     - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training
+       data and natural language understanding. You cannot use `natural_language_query` and `query` at the same time.
      - parameter passages: A passages query that returns the most relevant passages from the results.
-     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are
-       useful for building applications, because you can use them to build lists, tables, and time series. For a full
-       list of possible aggregrations, see the Query reference.
+     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact
+       answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and
+       time series. For a full list of possible aggregrations, see the Query reference.
      - parameter count: Number of documents to return.
      - parameter returnFields: A comma separated list of the portion of the document hierarchy to return.
-     - parameter offset: The number of query results to skip at the beginning. For example, if the total number of results that are
-       returned is 10, and the offset is 8, it returns the last two results.
-     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by
-       prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no
-       prefix is specified.
-     - parameter highlight: When true a highlight field is returned for each result which contains the fields that match the query with
-       `<em></em>` tags around the matching query terms. Defaults to false.
-     - parameter passagesFields: A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all
-       top-level fields are included.
-     - parameter passagesCount: The maximum number of passages to return. The search returns fewer passages if the requested total is not found.
-       The default is `10`. The maximum is `100`.
-     - parameter passagesCharacters: The approximate number of characters that any one passage will have. The default is `400`. The minimum is `50`.
-       The maximum is `2000`.
-     - parameter deduplicate: When `true` and used with a Watson Discovery News collection, duplicate results (based on the contents of the
-       `title` field) are removed. Duplicate comparison is limited to the current query only, `offset` is not
-       considered. Defaults to `false`. This parameter is currently Beta functionality.
-     - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the returned results. Duplicate
-       comparison is limited to the current query only, `offset` is not considered. This parameter is currently Beta
-       functionality.
-     - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in the
-       `similar.document_ids` parameter. The default is `false`.
-     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar documents.
+     - parameter offset: The number of query results to skip at the beginning. For example, if the total number of
+       results that are returned is 10, and the offset is 8, it returns the last two results.
+     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort
+       direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort
+       direction if no prefix is specified.
+     - parameter highlight: When true a highlight field is returned for each result which contains the fields that
+       match the query with `<em></em>` tags around the matching query terms. Defaults to false.
+     - parameter passagesFields: A comma-separated list of fields that passages are drawn from. If this parameter not
+       specified, then all top-level fields are included.
+     - parameter passagesCount: The maximum number of passages to return. The search returns fewer passages if the
+       requested total is not found. The default is `10`. The maximum is `100`.
+     - parameter passagesCharacters: The approximate number of characters that any one passage will have. The default
+       is `400`. The minimum is `50`. The maximum is `2000`.
+     - parameter deduplicate: When `true` and used with a Watson Discovery News collection, duplicate results (based
+       on the contents of the `title` field) are removed. Duplicate comparison is limited to the current query only,
+       `offset` is not considered. Defaults to `false`. This parameter is currently Beta functionality.
+     - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the
+       returned results. Duplicate comparison is limited to the current query only, `offset` is not considered. This
+       parameter is currently Beta functionality.
+     - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in
+       the `similar.document_ids` parameter. The default is `false`.
+     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar
+       documents.
        **Note:** If the `natural_language_query` parameter is also specified, it will be used to expand the scope of the
        document similarity search to include the natural language query. Other query parameters, such as `filter` and
        `query` are subsequently applied and reduce the query scope.
-     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to identify similar documents.
-       If not specified, the entire document is used for comparison.
+     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to
+       identify similar documents. If not specified, the entire document is used for comparison.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1924,44 +1919,45 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter collectionID: The ID of the collection.
-     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't mention the query
-       content. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts
-       in the data set.
-     - parameter query: A query search returns all documents in your data set with full enrichments and full text, but with the most
-       relevant documents listed first. Use a query search when you want to find the most relevant search results. You
-       cannot use `natural_language_query` and `query` at the same time.
-     - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training data and natural language
-       understanding. You cannot use `natural_language_query` and `query` at the same time.
+     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't
+       mention the query content. Filter searches are better for metadata type searches and when you are trying to get a
+       sense of concepts in the data set.
+     - parameter query: A query search returns all documents in your data set with full enrichments and full text, but
+       with the most relevant documents listed first. Use a query search when you want to find the most relevant search
+       results. You cannot use `natural_language_query` and `query` at the same time.
+     - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training
+       data and natural language understanding. You cannot use `natural_language_query` and `query` at the same time.
      - parameter passages: A passages query that returns the most relevant passages from the results.
-     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are
-       useful for building applications, because you can use them to build lists, tables, and time series. For a full
-       list of possible aggregrations, see the Query reference.
+     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact
+       answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and
+       time series. For a full list of possible aggregrations, see the Query reference.
      - parameter count: Number of documents to return.
      - parameter returnFields: A comma separated list of the portion of the document hierarchy to return.
-     - parameter offset: The number of query results to skip at the beginning. For example, if the total number of results that are
-       returned is 10, and the offset is 8, it returns the last two results.
-     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by
-       prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no
-       prefix is specified.
-     - parameter highlight: When true a highlight field is returned for each result which contains the fields that match the query with
-       `<em></em>` tags around the matching query terms. Defaults to false.
-     - parameter passagesFields: A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all
-       top-level fields are included.
-     - parameter passagesCount: The maximum number of passages to return. The search returns fewer passages if the requested total is not found.
-       The default is `10`. The maximum is `100`.
-     - parameter passagesCharacters: The approximate number of characters that any one passage will have. The default is `400`. The minimum is `50`.
-       The maximum is `2000`.
-     - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the returned results. Duplicate
-       comparison is limited to the current query only, `offset` is not considered. This parameter is currently Beta
-       functionality.
-     - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in the
-       `similar.document_ids` parameter. The default is `false`.
-     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar documents.
+     - parameter offset: The number of query results to skip at the beginning. For example, if the total number of
+       results that are returned is 10, and the offset is 8, it returns the last two results.
+     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort
+       direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort
+       direction if no prefix is specified.
+     - parameter highlight: When true a highlight field is returned for each result which contains the fields that
+       match the query with `<em></em>` tags around the matching query terms. Defaults to false.
+     - parameter passagesFields: A comma-separated list of fields that passages are drawn from. If this parameter not
+       specified, then all top-level fields are included.
+     - parameter passagesCount: The maximum number of passages to return. The search returns fewer passages if the
+       requested total is not found. The default is `10`. The maximum is `100`.
+     - parameter passagesCharacters: The approximate number of characters that any one passage will have. The default
+       is `400`. The minimum is `50`. The maximum is `2000`.
+     - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the
+       returned results. Duplicate comparison is limited to the current query only, `offset` is not considered. This
+       parameter is currently Beta functionality.
+     - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in
+       the `similar.document_ids` parameter. The default is `false`.
+     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar
+       documents.
        **Note:** If the `natural_language_query` parameter is also specified, it will be used to expand the scope of the
        document similarity search to include the natural language query. Other query parameters, such as `filter` and
        `query` are subsequently applied and reduce the query scope.
-     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to identify similar documents.
-       If not specified, the entire document is used for comparison.
+     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to
+       identify similar documents. If not specified, the entire document is used for comparison.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2103,40 +2099,41 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter collectionIds: A comma-separated list of collection IDs to be queried against.
-     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't mention the query
-       content. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts
-       in the data set.
-     - parameter query: A query search returns all documents in your data set with full enrichments and full text, but with the most
-       relevant documents listed first. Use a query search when you want to find the most relevant search results. You
-       cannot use `natural_language_query` and `query` at the same time.
-     - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training data and natural language
-       understanding. You cannot use `natural_language_query` and `query` at the same time.
-     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are
-       useful for building applications, because you can use them to build lists, tables, and time series. For a full
-       list of possible aggregrations, see the Query reference.
+     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't
+       mention the query content. Filter searches are better for metadata type searches and when you are trying to get a
+       sense of concepts in the data set.
+     - parameter query: A query search returns all documents in your data set with full enrichments and full text, but
+       with the most relevant documents listed first. Use a query search when you want to find the most relevant search
+       results. You cannot use `natural_language_query` and `query` at the same time.
+     - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training
+       data and natural language understanding. You cannot use `natural_language_query` and `query` at the same time.
+     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact
+       answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and
+       time series. For a full list of possible aggregrations, see the Query reference.
      - parameter count: Number of documents to return.
      - parameter returnFields: A comma separated list of the portion of the document hierarchy to return.
-     - parameter offset: The number of query results to skip at the beginning. For example, if the total number of results that are
-       returned is 10, and the offset is 8, it returns the last two results.
-     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by
-       prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no
-       prefix is specified.
-     - parameter highlight: When true a highlight field is returned for each result which contains the fields that match the query with
-       `<em></em>` tags around the matching query terms. Defaults to false.
-     - parameter deduplicate: When `true` and used with a Watson Discovery News collection, duplicate results (based on the contents of the
-       `title` field) are removed. Duplicate comparison is limited to the current query only, `offset` is not
-       considered. Defaults to `false`. This parameter is currently Beta functionality.
-     - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the returned results. Duplicate
-       comparison is limited to the current query only, `offset` is not considered. This parameter is currently Beta
-       functionality.
-     - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in the
-       `similar.document_ids` parameter. The default is `false`.
-     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar documents.
+     - parameter offset: The number of query results to skip at the beginning. For example, if the total number of
+       results that are returned is 10, and the offset is 8, it returns the last two results.
+     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort
+       direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort
+       direction if no prefix is specified.
+     - parameter highlight: When true a highlight field is returned for each result which contains the fields that
+       match the query with `<em></em>` tags around the matching query terms. Defaults to false.
+     - parameter deduplicate: When `true` and used with a Watson Discovery News collection, duplicate results (based
+       on the contents of the `title` field) are removed. Duplicate comparison is limited to the current query only,
+       `offset` is not considered. Defaults to `false`. This parameter is currently Beta functionality.
+     - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the
+       returned results. Duplicate comparison is limited to the current query only, `offset` is not considered. This
+       parameter is currently Beta functionality.
+     - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in
+       the `similar.document_ids` parameter. The default is `false`.
+     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar
+       documents.
        **Note:** If the `natural_language_query` parameter is also specified, it will be used to expand the scope of the
        document similarity search to include the natural language query. Other query parameters, such as `filter` and
        `query` are subsequently applied and reduce the query scope.
-     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to identify similar documents.
-       If not specified, the entire document is used for comparison.
+     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to
+       identify similar documents. If not specified, the entire document is used for comparison.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2266,37 +2263,38 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter collectionIds: A comma-separated list of collection IDs to be queried against.
-     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't mention the query
-       content. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts
-       in the data set.
-     - parameter query: A query search returns all documents in your data set with full enrichments and full text, but with the most
-       relevant documents listed first. Use a query search when you want to find the most relevant search results. You
-       cannot use `natural_language_query` and `query` at the same time.
-     - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training data and natural language
-       understanding. You cannot use `natural_language_query` and `query` at the same time.
-     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are
-       useful for building applications, because you can use them to build lists, tables, and time series. For a full
-       list of possible aggregrations, see the Query reference.
+     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't
+       mention the query content. Filter searches are better for metadata type searches and when you are trying to get a
+       sense of concepts in the data set.
+     - parameter query: A query search returns all documents in your data set with full enrichments and full text, but
+       with the most relevant documents listed first. Use a query search when you want to find the most relevant search
+       results. You cannot use `natural_language_query` and `query` at the same time.
+     - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training
+       data and natural language understanding. You cannot use `natural_language_query` and `query` at the same time.
+     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact
+       answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and
+       time series. For a full list of possible aggregrations, see the Query reference.
      - parameter count: Number of documents to return.
      - parameter returnFields: A comma separated list of the portion of the document hierarchy to return.
-     - parameter offset: The number of query results to skip at the beginning. For example, if the total number of results that are
-       returned is 10, and the offset is 8, it returns the last two results.
-     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by
-       prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no
-       prefix is specified.
-     - parameter highlight: When true a highlight field is returned for each result which contains the fields that match the query with
-       `<em></em>` tags around the matching query terms. Defaults to false.
-     - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the returned results. Duplicate
-       comparison is limited to the current query only, `offset` is not considered. This parameter is currently Beta
-       functionality.
-     - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in the
-       `similar.document_ids` parameter. The default is `false`.
-     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar documents.
+     - parameter offset: The number of query results to skip at the beginning. For example, if the total number of
+       results that are returned is 10, and the offset is 8, it returns the last two results.
+     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort
+       direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort
+       direction if no prefix is specified.
+     - parameter highlight: When true a highlight field is returned for each result which contains the fields that
+       match the query with `<em></em>` tags around the matching query terms. Defaults to false.
+     - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the
+       returned results. Duplicate comparison is limited to the current query only, `offset` is not considered. This
+       parameter is currently Beta functionality.
+     - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in
+       the `similar.document_ids` parameter. The default is `false`.
+     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar
+       documents.
        **Note:** If the `natural_language_query` parameter is also specified, it will be used to expand the scope of the
        document similarity search to include the natural language query. Other query parameters, such as `filter` and
        `query` are subsequently applied and reduce the query scope.
-     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to identify similar documents.
-       If not specified, the entire document is used for comparison.
+     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to
+       identify similar documents. If not specified, the entire document is used for comparison.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2419,7 +2417,8 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter collectionID: The ID of the collection.
-     - parameter entityQuery: An object specifying the entities to query, which functions to perform, and any additional constraints.
+     - parameter entityQuery: An object specifying the entities to query, which functions to perform, and any
+       additional constraints.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2485,7 +2484,8 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter collectionID: The ID of the collection.
-     - parameter relationshipQuery: An object that describes the relationships to be queried and any query constraints (such as filters).
+     - parameter relationshipQuery: An object that describes the relationships to be queried and any query constraints
+       (such as filters).
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.

--- a/Source/DiscoveryV1/Models/AggregationResult.swift
+++ b/Source/DiscoveryV1/Models/AggregationResult.swift
@@ -41,4 +41,12 @@ public struct AggregationResult: Decodable {
         case aggregations = "aggregations"
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let keyAsString = try? container.decode(String.self, forKey: .key) { key = keyAsString }
+        if let keyAsInt = try? container.decode(Int.self, forKey: .key) { key = "\(keyAsInt)" }
+        matchingResults = try container.decodeIfPresent(Int.self, forKey: .matchingResults)
+        aggregations = try container.decodeIfPresent([QueryAggregation].self, forKey: .aggregations)
+    }
+
 }

--- a/Source/DiscoveryV1/Models/AggregationResult.swift
+++ b/Source/DiscoveryV1/Models/AggregationResult.swift
@@ -41,12 +41,4 @@ public struct AggregationResult: Decodable {
         case aggregations = "aggregations"
     }
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let keyAsString = try? container.decode(String.self, forKey: .key) { key = keyAsString }
-        if let keyAsInt = try? container.decode(Int.self, forKey: .key) { key = "\(keyAsInt)" }
-        matchingResults = try container.decodeIfPresent(Int.self, forKey: .matchingResults)
-        aggregations = try container.decodeIfPresent([QueryAggregation].self, forKey: .aggregations)
-    }
-
 }

--- a/Source/DiscoveryV1/Models/Collection.swift
+++ b/Source/DiscoveryV1/Models/Collection.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A collection for storing documents. */
+/**
+ A collection for storing documents.
+ */
 public struct Collection: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/CollectionDiskUsage.swift
+++ b/Source/DiscoveryV1/Models/CollectionDiskUsage.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Summary of the disk usage statistics for this collection. */
+/**
+ Summary of the disk usage statistics for this collection.
+ */
 public struct CollectionDiskUsage: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/CollectionUsage.swift
+++ b/Source/DiscoveryV1/Models/CollectionUsage.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Summary of the collection usage in the environment. */
+/**
+ Summary of the collection usage in the environment.
+ */
 public struct CollectionUsage: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/Configuration.swift
+++ b/Source/DiscoveryV1/Models/Configuration.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A custom configuration for the environment. */
+/**
+ A custom configuration for the environment.
+ */
 public struct Configuration: Codable {
 
     /**
@@ -78,12 +80,13 @@ public struct Configuration: Codable {
      - parameter name: The name of the configuration.
      - parameter configurationID: The unique identifier of the configuration.
      - parameter created: The creation date of the configuration in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
-     - parameter updated: The timestamp of when the configuration was last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+     - parameter updated: The timestamp of when the configuration was last updated in the format
+       yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
      - parameter description: The description of the configuration, if available.
      - parameter conversions: The document conversion settings for the configuration.
      - parameter enrichments: An array of document enrichment settings for the configuration.
-     - parameter normalizations: Defines operations that can be used to transform the final output JSON into a normalized form. Operations are
-       executed in the order that they appear in the array.
+     - parameter normalizations: Defines operations that can be used to transform the final output JSON into a
+       normalized form. Operations are executed in the order that they appear in the array.
 
      - returns: An initialized `Configuration`.
     */

--- a/Source/DiscoveryV1/Models/Conversions.swift
+++ b/Source/DiscoveryV1/Models/Conversions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Document conversion settings. */
+/**
+ Document conversion settings.
+ */
 public struct Conversions: Codable {
 
     /**
@@ -61,8 +63,8 @@ public struct Conversions: Codable {
      - parameter word: A list of Word conversion settings.
      - parameter html: A list of HTML conversion settings.
      - parameter segment: A list of Document Segmentation settings.
-     - parameter jsonNormalizations: Defines operations that can be used to transform the final output JSON into a normalized form. Operations are
-       executed in the order that they appear in the array.
+     - parameter jsonNormalizations: Defines operations that can be used to transform the final output JSON into a
+       normalized form. Operations are executed in the order that they appear in the array.
 
      - returns: An initialized `Conversions`.
     */

--- a/Source/DiscoveryV1/Models/CreateCollectionRequest.swift
+++ b/Source/DiscoveryV1/Models/CreateCollectionRequest.swift
@@ -68,7 +68,8 @@ public struct CreateCollectionRequest: Encodable {
      - parameter name: The name of the collection to be created.
      - parameter description: A description of the collection.
      - parameter configurationID: The ID of the configuration in which the collection is to be created.
-     - parameter language: The language of the documents stored in the collection, in the form of an ISO 639-1 language code.
+     - parameter language: The language of the documents stored in the collection, in the form of an ISO 639-1
+       language code.
 
      - returns: An initialized `CreateCollectionRequest`.
     */

--- a/Source/DiscoveryV1/Models/DiskUsage.swift
+++ b/Source/DiscoveryV1/Models/DiskUsage.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Summary of the disk usage statistics for the environment. */
+/**
+ Summary of the disk usage statistics for the environment.
+ */
 public struct DiskUsage: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/DocumentStatus.swift
+++ b/Source/DiscoveryV1/Models/DocumentStatus.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Status information about a submitted document. */
+/**
+ Status information about a submitted document.
+ */
 public struct DocumentStatus: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/Enrichment.swift
+++ b/Source/DiscoveryV1/Models/Enrichment.swift
@@ -77,11 +77,12 @@ public struct Enrichment: Codable {
     /**
      Initialize a `Enrichment` with member variables.
 
-     - parameter destinationField: Field where enrichments will be stored. This field must already exist or be at most 1 level deeper than an
-       existing field. For example, if `text` is a top-level field with no sub-fields, `text.foo` is a valid destination
-       but `text.foo.bar` is not.
+     - parameter destinationField: Field where enrichments will be stored. This field must already exist or be at
+       most 1 level deeper than an existing field. For example, if `text` is a top-level field with no sub-fields,
+       `text.foo` is a valid destination but `text.foo.bar` is not.
      - parameter sourceField: Field to be enriched.
-     - parameter enrichmentName: Name of the enrichment service to call. Current options are `natural_language_understanding` and `elements`.
+     - parameter enrichmentName: Name of the enrichment service to call. Current options are
+       `natural_language_understanding` and `elements`.
         When using `natual_language_understanding`, the `options` object must contain Natural Language Understanding
        Options.
         When using `elements` the `options` object must contain Element Classification options. Additionally, when using
@@ -89,9 +90,10 @@ public struct Enrichment: Codable {
        [the documentation](https://console.bluemix.net/docs/services/discovery/element-classification.html)
         Previous API versions also supported `alchemy_language`.
      - parameter description: Describes what the enrichment step does.
-     - parameter overwrite: Indicates that the enrichments will overwrite the destination_field field if it already exists.
-     - parameter ignoreDownstreamErrors: If true, then most errors generated during the enrichment process will be treated as warnings and will not cause
-       the document to fail processing.
+     - parameter overwrite: Indicates that the enrichments will overwrite the destination_field field if it already
+       exists.
+     - parameter ignoreDownstreamErrors: If true, then most errors generated during the enrichment process will be
+       treated as warnings and will not cause the document to fail processing.
      - parameter options: A list of options specific to the enrichment.
 
      - returns: An initialized `Enrichment`.

--- a/Source/DiscoveryV1/Models/EnrichmentOptions.swift
+++ b/Source/DiscoveryV1/Models/EnrichmentOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Options which are specific to a particular enrichment. */
+/**
+ Options which are specific to a particular enrichment.
+ */
 public struct EnrichmentOptions: Codable {
 
     /**
@@ -38,9 +40,10 @@ public struct EnrichmentOptions: Codable {
     /**
      Initialize a `EnrichmentOptions` with member variables.
 
-     - parameter features: An object representing the enrichment features that will be applied to the specified field.
-     - parameter model: *For use with `elements` enrichments only.* The element extraction model to use. Models available are:
-       `contract`.
+     - parameter features: An object representing the enrichment features that will be applied to the specified
+       field.
+     - parameter model: *For use with `elements` enrichments only.* The element extraction model to use. Models
+       available are: `contract`.
 
      - returns: An initialized `EnrichmentOptions`.
     */

--- a/Source/DiscoveryV1/Models/Environment.swift
+++ b/Source/DiscoveryV1/Models/Environment.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Details about an environment. */
+/**
+ Details about an environment.
+ */
 public struct Environment: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/EnvironmentDocuments.swift
+++ b/Source/DiscoveryV1/Models/EnvironmentDocuments.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Summary of the document usage statistics for the environment. */
+/**
+ Summary of the document usage statistics for the environment.
+ */
 public struct EnvironmentDocuments: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/Expansion.swift
+++ b/Source/DiscoveryV1/Models/Expansion.swift
@@ -16,7 +16,10 @@
 
 import Foundation
 
-/** An expansion definition. Each object respresents one set of expandable strings. For example, you could have expansions for the word `hot` in one object, and expansions for the word `cold` in another. */
+/**
+ An expansion definition. Each object respresents one set of expandable strings. For example, you could have expansions
+ for the word `hot` in one object, and expansions for the word `cold` in another.
+ */
 public struct Expansion: Codable {
 
     /**
@@ -39,9 +42,10 @@ public struct Expansion: Codable {
     /**
      Initialize a `Expansion` with member variables.
 
-     - parameter expandedTerms: A list of terms that this expansion will be expanded to. If specified without `input_terms`, it also functions as
-       the input term list.
-     - parameter inputTerms: A list of terms that will be expanded for this expansion. If specified, only the items in this list are expanded.
+     - parameter expandedTerms: A list of terms that this expansion will be expanded to. If specified without
+       `input_terms`, it also functions as the input term list.
+     - parameter inputTerms: A list of terms that will be expanded for this expansion. If specified, only the items
+       in this list are expanded.
 
      - returns: An initialized `Expansion`.
     */

--- a/Source/DiscoveryV1/Models/Expansions.swift
+++ b/Source/DiscoveryV1/Models/Expansions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The query expansion definitions for the specified collection. */
+/**
+ The query expansion definitions for the specified collection.
+ */
 public struct Expansions: Codable {
 
     /**

--- a/Source/DiscoveryV1/Models/HtmlSettings.swift
+++ b/Source/DiscoveryV1/Models/HtmlSettings.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A list of HTML conversion settings. */
+/**
+ A list of HTML conversion settings.
+ */
 public struct HtmlSettings: Codable {
 
     public var excludeTagsCompletely: [String]?

--- a/Source/DiscoveryV1/Models/IndexCapacity.swift
+++ b/Source/DiscoveryV1/Models/IndexCapacity.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Details about the resource usage and capacity of the environment. */
+/**
+ Details about the resource usage and capacity of the environment.
+ */
 public struct IndexCapacity: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/ListCollectionFieldsResponse.swift
+++ b/Source/DiscoveryV1/Models/ListCollectionFieldsResponse.swift
@@ -16,15 +16,16 @@
 
 import Foundation
 
-/** The list of fetched fields.
-
-The fields are returned using a fully qualified name format, however, the format differs slightly from that used by the query operations.
-
-  * Fields which contain nested JSON objects are assigned a type of "nested".
-
-  * Fields which belong to a nested object are prefixed with `.properties` (for example, `warnings.properties.severity` means that the `warnings` object has a property called `severity`).
-
-  * Fields returned from the News collection are prefixed with `v{N}-fullnews-t3-{YEAR}.mappings` (for example, `v5-fullnews-t3-2016.mappings.text.properties.author`). */
+/**
+ The list of fetched fields.
+ The fields are returned using a fully qualified name format, however, the format differs slightly from that used by the
+ query operations.
+   * Fields which contain nested JSON objects are assigned a type of "nested".
+   * Fields which belong to a nested object are prefixed with `.properties` (for example, `warnings.properties.severity`
+ means that the `warnings` object has a property called `severity`).
+   * Fields returned from the News collection are prefixed with `v{N}-fullnews-t3-{YEAR}.mappings` (for example,
+ `v5-fullnews-t3-2016.mappings.text.properties.author`).
+ */
 public struct ListCollectionFieldsResponse: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/MemoryUsage.swift
+++ b/Source/DiscoveryV1/Models/MemoryUsage.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** **Deprecated**: Summary of the memory usage statistics for this environment. */
+/**
+ **Deprecated**: Summary of the memory usage statistics for this environment.
+ */
 public struct MemoryUsage: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/NluEnrichmentCategories.swift
+++ b/Source/DiscoveryV1/Models/NluEnrichmentCategories.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object that indicates the Categories enrichment will be applied to the specified field. */
+/**
+ An object that indicates the Categories enrichment will be applied to the specified field.
+ */
 public struct NluEnrichmentCategories: Codable {
 
     /// Additional properties associated with this model.

--- a/Source/DiscoveryV1/Models/NluEnrichmentEmotion.swift
+++ b/Source/DiscoveryV1/Models/NluEnrichmentEmotion.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object specifying the emotion detection enrichment and related parameters. */
+/**
+ An object specifying the emotion detection enrichment and related parameters.
+ */
 public struct NluEnrichmentEmotion: Codable {
 
     /**

--- a/Source/DiscoveryV1/Models/NluEnrichmentEntities.swift
+++ b/Source/DiscoveryV1/Models/NluEnrichmentEntities.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object speficying the Entities enrichment and related parameters. */
+/**
+ An object speficying the Entities enrichment and related parameters.
+ */
 public struct NluEnrichmentEntities: Codable {
 
     /**
@@ -73,12 +75,14 @@ public struct NluEnrichmentEntities: Codable {
      - parameter sentiment: When `true`, sentiment analysis of entities will be performed on the specified field.
      - parameter emotion: When `true`, emotion detection of entities will be performed on the specified field.
      - parameter limit: The maximum number of entities to extract for each instance of the specified field.
-     - parameter mentions: When `true`, the number of mentions of each identified entity is recorded. The default is `false`.
-     - parameter mentionTypes: When `true`, the types of mentions for each idetifieid entity is recorded. The default is `false`.
-     - parameter sentenceLocation: When `true`, a list of sentence locations for each instance of each identified entity is recorded. The default is
+     - parameter mentions: When `true`, the number of mentions of each identified entity is recorded. The default is
        `false`.
-     - parameter model: The enrichement model to use with entity extraction. May be a custom model provided by Watson Knowledge Studio,
-       the public model for use with Knowledge Graph `en-news`, or the default public model `alchemy`.
+     - parameter mentionTypes: When `true`, the types of mentions for each idetifieid entity is recorded. The default
+       is `false`.
+     - parameter sentenceLocation: When `true`, a list of sentence locations for each instance of each identified
+       entity is recorded. The default is `false`.
+     - parameter model: The enrichement model to use with entity extraction. May be a custom model provided by Watson
+       Knowledge Studio, the public model for use with Knowledge Graph `en-news`, or the default public model `alchemy`.
 
      - returns: An initialized `NluEnrichmentEntities`.
     */

--- a/Source/DiscoveryV1/Models/NluEnrichmentKeywords.swift
+++ b/Source/DiscoveryV1/Models/NluEnrichmentKeywords.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object specifying the Keyword enrichment and related parameters. */
+/**
+ An object specifying the Keyword enrichment and related parameters.
+ */
 public struct NluEnrichmentKeywords: Codable {
 
     /**

--- a/Source/DiscoveryV1/Models/NluEnrichmentRelations.swift
+++ b/Source/DiscoveryV1/Models/NluEnrichmentRelations.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object specifying the relations enrichment and related parameters. */
+/**
+ An object specifying the relations enrichment and related parameters.
+ */
 public struct NluEnrichmentRelations: Codable {
 
     /**
@@ -34,9 +36,9 @@ public struct NluEnrichmentRelations: Codable {
     /**
      Initialize a `NluEnrichmentRelations` with member variables.
 
-     - parameter model: *For use with `natural_language_understanding` enrichments only.* The enrichement model to use with relationship
-       extraction. May be a custom model provided by Watson Knowledge Studio, the public model for use with Knowledge
-       Graph `en-news`, the default is`en-news`.
+     - parameter model: *For use with `natural_language_understanding` enrichments only.* The enrichement model to
+       use with relationship extraction. May be a custom model provided by Watson Knowledge Studio, the public model for
+       use with Knowledge Graph `en-news`, the default is`en-news`.
 
      - returns: An initialized `NluEnrichmentRelations`.
     */

--- a/Source/DiscoveryV1/Models/NluEnrichmentSemanticRoles.swift
+++ b/Source/DiscoveryV1/Models/NluEnrichmentSemanticRoles.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object specifiying the semantic roles enrichment and related parameters. */
+/**
+ An object specifiying the semantic roles enrichment and related parameters.
+ */
 public struct NluEnrichmentSemanticRoles: Codable {
 
     /**
@@ -46,7 +48,8 @@ public struct NluEnrichmentSemanticRoles: Codable {
 
      - parameter entities: When `true` entities are extracted from the identified sentence parts.
      - parameter keywords: When `true`, keywords are extracted from the identified sentence parts.
-     - parameter limit: The maximum number of semantic roles enrichments to extact from each instance of the specified field.
+     - parameter limit: The maximum number of semantic roles enrichments to extact from each instance of the
+       specified field.
 
      - returns: An initialized `NluEnrichmentSemanticRoles`.
     */

--- a/Source/DiscoveryV1/Models/NluEnrichmentSentiment.swift
+++ b/Source/DiscoveryV1/Models/NluEnrichmentSentiment.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object specifying the sentiment extraction enrichment and related parameters. */
+/**
+ An object specifying the sentiment extraction enrichment and related parameters.
+ */
 public struct NluEnrichmentSentiment: Codable {
 
     /**

--- a/Source/DiscoveryV1/Models/Notice.swift
+++ b/Source/DiscoveryV1/Models/Notice.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A notice produced for the collection. */
+/**
+ A notice produced for the collection.
+ */
 public struct Notice: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/PdfSettings.swift
+++ b/Source/DiscoveryV1/Models/PdfSettings.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A list of PDF conversion settings. */
+/**
+ A list of PDF conversion settings.
+ */
 public struct PdfSettings: Codable {
 
     public var heading: PdfHeadingDetection?

--- a/Source/DiscoveryV1/Models/QueryAggregation.swift
+++ b/Source/DiscoveryV1/Models/QueryAggregation.swift
@@ -16,50 +16,34 @@
 
 import Foundation
 
-/** An aggregation produced by the Discovery service to analyze the input provided. */
-public enum QueryAggregation: Decodable {
+/**
+ An aggregation produced by the Discovery service to analyze the input provided.
+ */
+public struct QueryAggregation: Decodable {
 
-    // reference: https://console.bluemix.net/docs/services/discovery/query-reference.html#aggregations
+    /**
+     The type of aggregation command used. For example: term, filter, max, min, etc.
+     */
+    public var type: String?
 
-    case term(Term)
-    case filter(Filter)
-    case nested(Nested)
-    case histogram(Histogram)
-    case timeslice(Timeslice)
-    case topHits(TopHits)
-    case uniqueCount(Calculation)
-    case max(Calculation)
-    case min(Calculation)
-    case average(Calculation)
-    case sum(Calculation)
-    case generic(GenericQueryAggregation)
+    public var results: [AggregationResult]?
 
+    /**
+     Number of matching results.
+     */
+    public var matchingResults: Int?
+
+    /**
+     Aggregations returned by the Discovery service.
+     */
+    public var aggregations: [QueryAggregation]?
+
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case type = "type"
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        guard let type = try container.decodeIfPresent(String.self, forKey: .type) else {
-            // the specification does not identify `type` as a required field,
-            // so we need a generic catch-all in case it is not present
-            self = .generic(try GenericQueryAggregation(from: decoder))
-            return
-        }
-        switch type {
-        case "term": self = .term(try Term(from: decoder))
-        case "filter": self = .filter(try Filter(from: decoder))
-        case "nested": self = .nested(try Nested(from: decoder))
-        case "histogram": self = .histogram(try Histogram(from: decoder))
-        case "timeslice": self = .timeslice(try Timeslice(from: decoder))
-        case "top_hits": self = .topHits(try TopHits(from: decoder))
-        case "unique_count": self = .uniqueCount(try Calculation(from: decoder))
-        case "max": self = .max(try Calculation(from: decoder))
-        case "min": self = .min(try Calculation(from: decoder))
-        case "average": self = .average(try Calculation(from: decoder))
-        case "sum": self = .sum(try Calculation(from: decoder))
-        default: self = .generic(try GenericQueryAggregation(from: decoder))
-        }
+        case results = "results"
+        case matchingResults = "matching_results"
+        case aggregations = "aggregations"
     }
 
 }

--- a/Source/DiscoveryV1/Models/QueryAggregation.swift
+++ b/Source/DiscoveryV1/Models/QueryAggregation.swift
@@ -16,34 +16,50 @@
 
 import Foundation
 
-/**
- An aggregation produced by the Discovery service to analyze the input provided.
- */
-public struct QueryAggregation: Decodable {
+/** An aggregation produced by the Discovery service to analyze the input provided. */
+public enum QueryAggregation: Decodable {
 
-    /**
-     The type of aggregation command used. For example: term, filter, max, min, etc.
-     */
-    public var type: String?
+    // reference: https://console.bluemix.net/docs/services/discovery/query-reference.html#aggregations
 
-    public var results: [AggregationResult]?
+    case term(Term)
+    case filter(Filter)
+    case nested(Nested)
+    case histogram(Histogram)
+    case timeslice(Timeslice)
+    case topHits(TopHits)
+    case uniqueCount(Calculation)
+    case max(Calculation)
+    case min(Calculation)
+    case average(Calculation)
+    case sum(Calculation)
+    case generic(GenericQueryAggregation)
 
-    /**
-     Number of matching results.
-     */
-    public var matchingResults: Int?
-
-    /**
-     Aggregations returned by the Discovery service.
-     */
-    public var aggregations: [QueryAggregation]?
-
-    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case type = "type"
-        case results = "results"
-        case matchingResults = "matching_results"
-        case aggregations = "aggregations"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard let type = try container.decodeIfPresent(String.self, forKey: .type) else {
+            // the specification does not identify `type` as a required field,
+            // so we need a generic catch-all in case it is not present
+            self = .generic(try GenericQueryAggregation(from: decoder))
+            return
+        }
+        switch type {
+        case "term": self = .term(try Term(from: decoder))
+        case "filter": self = .filter(try Filter(from: decoder))
+        case "nested": self = .nested(try Nested(from: decoder))
+        case "histogram": self = .histogram(try Histogram(from: decoder))
+        case "timeslice": self = .timeslice(try Timeslice(from: decoder))
+        case "top_hits": self = .topHits(try TopHits(from: decoder))
+        case "unique_count": self = .uniqueCount(try Calculation(from: decoder))
+        case "max": self = .max(try Calculation(from: decoder))
+        case "min": self = .min(try Calculation(from: decoder))
+        case "average": self = .average(try Calculation(from: decoder))
+        case "sum": self = .sum(try Calculation(from: decoder))
+        default: self = .generic(try GenericQueryAggregation(from: decoder))
+        }
     }
 
 }

--- a/Source/DiscoveryV1/Models/QueryEntities.swift
+++ b/Source/DiscoveryV1/Models/QueryEntities.swift
@@ -58,13 +58,15 @@ public struct QueryEntities: Encodable {
     /**
      Initialize a `QueryEntities` with member variables.
 
-     - parameter feature: The entity query feature to perform. Supported features are `disambiguate` and `similar_entities`.
+     - parameter feature: The entity query feature to perform. Supported features are `disambiguate` and
+       `similar_entities`.
      - parameter entity: A text string that appears within the entity text field.
-     - parameter context: Entity text to provide context for the queried entity and rank based on that association. For example, if you
-       wanted to query the city of London in England your query would look for `London` with the context of `England`.
+     - parameter context: Entity text to provide context for the queried entity and rank based on that association.
+       For example, if you wanted to query the city of London in England your query would look for `London` with the
+       context of `England`.
      - parameter count: The number of results to return. The default is `10`. The maximum is `1000`.
-     - parameter evidenceCount: The number of evidence items to return for each result. The default is `0`. The maximum number of evidence items
-       per query is 10,000.
+     - parameter evidenceCount: The number of evidence items to return for each result. The default is `0`. The
+       maximum number of evidence items per query is 10,000.
 
      - returns: An initialized `QueryEntities`.
     */

--- a/Source/DiscoveryV1/Models/QueryEntitiesContext.swift
+++ b/Source/DiscoveryV1/Models/QueryEntitiesContext.swift
@@ -16,7 +16,10 @@
 
 import Foundation
 
-/** Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`. */
+/**
+ Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to
+ query the city of London in England your query would look for `London` with the context of `England`.
+ */
 public struct QueryEntitiesContext: Encodable {
 
     /**
@@ -33,8 +36,9 @@ public struct QueryEntitiesContext: Encodable {
     /**
      Initialize a `QueryEntitiesContext` with member variables.
 
-     - parameter text: Entity text to provide context for the queried entity and rank based on that association. For example, if you
-       wanted to query the city of London in England your query would look for `London` with the context of `England`.
+     - parameter text: Entity text to provide context for the queried entity and rank based on that association. For
+       example, if you wanted to query the city of London in England your query would look for `London` with the context
+       of `England`.
 
      - returns: An initialized `QueryEntitiesContext`.
     */

--- a/Source/DiscoveryV1/Models/QueryEntitiesEntity.swift
+++ b/Source/DiscoveryV1/Models/QueryEntitiesEntity.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A text string that appears within the entity text field. */
+/**
+ A text string that appears within the entity text field.
+ */
 public struct QueryEntitiesEntity: Codable {
 
     /**

--- a/Source/DiscoveryV1/Models/QueryEntitiesResponse.swift
+++ b/Source/DiscoveryV1/Models/QueryEntitiesResponse.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An array of entities resulting from the query. */
+/**
+ An array of entities resulting from the query.
+ */
 public struct QueryEntitiesResponse: Decodable {
 
     public var entities: [QueryEntitiesResponseItem]?

--- a/Source/DiscoveryV1/Models/QueryEntitiesResponseItem.swift
+++ b/Source/DiscoveryV1/Models/QueryEntitiesResponseItem.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Object containing Entity query response information. */
+/**
+ Object containing Entity query response information.
+ */
 public struct QueryEntitiesResponseItem: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/QueryEvidence.swift
+++ b/Source/DiscoveryV1/Models/QueryEvidence.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Description of evidence location supporting Knoweldge Graph query result. */
+/**
+ Description of evidence location supporting Knoweldge Graph query result.
+ */
 public struct QueryEvidence: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/QueryEvidenceEntity.swift
+++ b/Source/DiscoveryV1/Models/QueryEvidenceEntity.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Entity description and location within evidence field. */
+/**
+ Entity description and location within evidence field.
+ */
 public struct QueryEvidenceEntity: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/QueryRelations.swift
+++ b/Source/DiscoveryV1/Models/QueryRelations.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A respresentation of a relationship query. */
+/**
+ A respresentation of a relationship query.
+ */
 public struct QueryRelations: Encodable {
 
     /**
@@ -75,14 +77,15 @@ public struct QueryRelations: Encodable {
      Initialize a `QueryRelations` with member variables.
 
      - parameter entities: An array of entities to find relationships for.
-     - parameter context: Entity text to provide context for the queried entity and rank based on that association. For example, if you
-       wanted to query the city of London in England your query would look for `London` with the context of `England`.
-     - parameter sort: The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the number of unique
-       times each entity is identified. The default is `score`.
+     - parameter context: Entity text to provide context for the queried entity and rank based on that association.
+       For example, if you wanted to query the city of London in England your query would look for `London` with the
+       context of `England`.
+     - parameter sort: The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the
+       number of unique times each entity is identified. The default is `score`.
      - parameter filter: Filters to apply to the relationship query.
      - parameter count: The number of results to return. The default is `10`. The maximum is `1000`.
-     - parameter evidenceCount: The number of evidence items to return for each result. The default is `0`. The maximum number of evidence items
-       per query is 10,000.
+     - parameter evidenceCount: The number of evidence items to return for each result. The default is `0`. The
+       maximum number of evidence items per query is 10,000.
 
      - returns: An initialized `QueryRelations`.
     */

--- a/Source/DiscoveryV1/Models/QueryResponse.swift
+++ b/Source/DiscoveryV1/Models/QueryResponse.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A response containing the documents and aggregations for the query. */
+/**
+ A response containing the documents and aggregations for the query.
+ */
 public struct QueryResponse: Decodable {
 
     public var matchingResults: Int?

--- a/Source/DiscoveryV1/Models/QueryResultMetadata.swift
+++ b/Source/DiscoveryV1/Models/QueryResultMetadata.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Metadata of a query result. */
+/**
+ Metadata of a query result.
+ */
 public struct QueryResultMetadata: Decodable {
 
     /**

--- a/Source/DiscoveryV1/Models/SegmentSettings.swift
+++ b/Source/DiscoveryV1/Models/SegmentSettings.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A list of Document Segmentation settings. */
+/**
+ A list of Document Segmentation settings.
+ */
 public struct SegmentSettings: Codable {
 
     /**
@@ -39,7 +41,8 @@ public struct SegmentSettings: Codable {
      Initialize a `SegmentSettings` with member variables.
 
      - parameter enabled: Enables/disables the Document Segmentation feature.
-     - parameter selectorTags: Defines the heading level that splits into document segments. Valid values are h1, h2, h3, h4, h5, h6.
+     - parameter selectorTags: Defines the heading level that splits into document segments. Valid values are h1, h2,
+       h3, h4, h5, h6.
 
      - returns: An initialized `SegmentSettings`.
     */

--- a/Source/DiscoveryV1/Models/WordSettings.swift
+++ b/Source/DiscoveryV1/Models/WordSettings.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A list of Word conversion settings. */
+/**
+ A list of Word conversion settings.
+ */
 public struct WordSettings: Codable {
 
     public var heading: WordHeadingDetection?

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -88,9 +88,6 @@ public class LanguageTranslator {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error_message"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -102,7 +99,8 @@ public class LanguageTranslator {
 
      Translates the input text from the source language to the target language.
 
-     - parameter request: The translate request containing the text, and either a model ID or source and target language pair.
+     - parameter request: The translate request containing the text, and either a model ID or source and target
+       language pair.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -252,9 +250,9 @@ public class LanguageTranslator {
 
      - parameter source: Specify a language code to filter results by source language.
      - parameter target: Specify a language code to filter results by target language.
-     - parameter defaultModels: If the default parameter isn't specified, the service will return all models (default and non-default) for each
-       language pair. To return only default models, set this to `true`. To return only non-default models, set this to
-       `false`.
+     - parameter defaultModels: If the default parameter isn't specified, the service will return all models (default
+       and non-default) for each language pair. To return only default models, set this to `true`. To return only
+       non-default models, set this to `false`.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -318,15 +316,17 @@ public class LanguageTranslator {
      parallel corpus. Glossary files must be less than 10 MB. The cumulative file size of all uploaded glossary and
      corpus files is limited to 250 MB.
 
-     - parameter baseModelID: The model ID of the model to use as the base for customization. To see available models, use the `List models`
-       method.
-     - parameter name: An optional model name that you can use to identify the model. Valid characters are letters, numbers, dashes,
-       underscores, spaces and apostrophes. The maximum length is 32 characters.
-     - parameter forcedGlossary: A TMX file with your customizations. The customizations in the file completely overwrite the domain translaton
-       data, including high frequency or high confidence phrase translations. You can upload only one glossary with a
-       file size less than 10 MB per call.
-     - parameter parallelCorpus: A TMX file that contains entries that are treated as a parallel corpus instead of a glossary.
-     - parameter monolingualCorpus: A UTF-8 encoded plain text file that is used to customize the target language model.
+     - parameter baseModelID: The model ID of the model to use as the base for customization. To see available models,
+       use the `List models` method.
+     - parameter name: An optional model name that you can use to identify the model. Valid characters are letters,
+       numbers, dashes, underscores, spaces and apostrophes. The maximum length is 32 characters.
+     - parameter forcedGlossary: A TMX file with your customizations. The customizations in the file completely
+       overwrite the domain translaton data, including high frequency or high confidence phrase translations. You can
+       upload only one glossary with a file size less than 10 MB per call.
+     - parameter parallelCorpus: A TMX file that contains entries that are treated as a parallel corpus instead of a
+       glossary.
+     - parameter monolingualCorpus: A UTF-8 encoded plain text file that is used to customize the target language
+       model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -88,6 +88,9 @@ public class LanguageTranslator {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error_message"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)

--- a/Source/LanguageTranslatorV2/Models/TranslateRequest.swift
+++ b/Source/LanguageTranslatorV2/Models/TranslateRequest.swift
@@ -54,14 +54,16 @@ public struct TranslateRequest: Encodable {
     /**
      Initialize a `TranslateRequest` with member variables.
 
-     - parameter text: Input text in UTF-8 encoding. Multiple entries will result in multiple translations in the response.
-     - parameter modelID: Model ID of the translation model to use. If this is specified, the **source** and **target** parameters will be
-       ignored. The method requires either a model ID or both the **source** and **target** parameters.
-     - parameter source: Language code of the source text language. Use with `target` as an alternative way to select a translation model.
-       When `source` and `target` are set, and a model ID is not set, the system chooses a default model for the
-       language pair (usually the model based on the news domain).
-     - parameter target: Language code of the translation target language. Use with source as an alternative way to select a translation
-       model.
+     - parameter text: Input text in UTF-8 encoding. Multiple entries will result in multiple translations in the
+       response.
+     - parameter modelID: Model ID of the translation model to use. If this is specified, the **source** and
+       **target** parameters will be ignored. The method requires either a model ID or both the **source** and
+       **target** parameters.
+     - parameter source: Language code of the source text language. Use with `target` as an alternative way to select
+       a translation model. When `source` and `target` are set, and a model ID is not set, the system chooses a default
+       model for the language pair (usually the model based on the news domain).
+     - parameter target: Language code of the translation target language. Use with source as an alternative way to
+       select a translation model.
 
      - returns: An initialized `TranslateRequest`.
     */

--- a/Source/LanguageTranslatorV2/Models/TranslationModel.swift
+++ b/Source/LanguageTranslatorV2/Models/TranslationModel.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Response payload for models. */
+/**
+ Response payload for models.
+ */
 public struct TranslationModel: Decodable {
 
     /**

--- a/Source/LanguageTranslatorV2/Models/TranslationModels.swift
+++ b/Source/LanguageTranslatorV2/Models/TranslationModels.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The response type for listing existing translation models. */
+/**
+ The response type for listing existing translation models.
+ */
 public struct TranslationModels: Decodable {
 
     /**

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -93,9 +93,6 @@ public class LanguageTranslator {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -107,7 +104,8 @@ public class LanguageTranslator {
 
      Translates the input text from the source language to the target language.
 
-     - parameter request: The translate request containing the text, and either a model ID or source and target language pair.
+     - parameter request: The translate request containing the text, and either a model ID or source and target
+       language pair.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -272,9 +270,10 @@ public class LanguageTranslator {
 
      - parameter source: Specify a language code to filter results by source language.
      - parameter target: Specify a language code to filter results by target language.
-     - parameter defaultModels: If the default parameter isn't specified, the service will return all models (default and non-default) for each
-       language pair. To return only default models, set this to `true`. To return only non-default models, set this to
-       `false`. There is exactly one default model per language pair, the IBM provided base model.
+     - parameter defaultModels: If the default parameter isn't specified, the service will return all models (default
+       and non-default) for each language pair. To return only default models, set this to `true`. To return only
+       non-default models, set this to `false`. There is exactly one default model per language pair, the IBM provided
+       base model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -345,17 +344,18 @@ public class LanguageTranslator {
      parallel sentences</b> in your corpus.
      You can have a <b>maxium of 10 custom models per language pair</b>.
 
-     - parameter baseModelID: The model ID of the model to use as the base for customization. To see available models, use the `List models`
-       method. Usually all IBM provided models are customizable. In addition, all your models that have been created via
-       parallel corpus customization, can be further customized with a forced glossary.
-     - parameter name: An optional model name that you can use to identify the model. Valid characters are letters, numbers, dashes,
-       underscores, spaces and apostrophes. The maximum length is 32 characters.
-     - parameter forcedGlossary: A TMX file with your customizations. The customizations in the file completely overwrite the domain translaton
-       data, including high frequency or high confidence phrase translations. You can upload only one glossary with a
-       file size less than 10 MB per call. A forced glossary should contain single words or short phrases.
-     - parameter parallelCorpus: A TMX file with parallel sentences for source and target language. You can upload multiple parallel_corpus files
-       in one request. All uploaded parallel_corpus files combined, your parallel corpus must contain at least 5,000
-       parallel sentences to train successfully.
+     - parameter baseModelID: The model ID of the model to use as the base for customization. To see available models,
+       use the `List models` method. Usually all IBM provided models are customizable. In addition, all your models that
+       have been created via parallel corpus customization, can be further customized with a forced glossary.
+     - parameter name: An optional model name that you can use to identify the model. Valid characters are letters,
+       numbers, dashes, underscores, spaces and apostrophes. The maximum length is 32 characters.
+     - parameter forcedGlossary: A TMX file with your customizations. The customizations in the file completely
+       overwrite the domain translaton data, including high frequency or high confidence phrase translations. You can
+       upload only one glossary with a file size less than 10 MB per call. A forced glossary should contain single words
+       or short phrases.
+     - parameter parallelCorpus: A TMX file with parallel sentences for source and target language. You can upload
+       multiple parallel_corpus files in one request. All uploaded parallel_corpus files combined, your parallel corpus
+       must contain at least 5,000 parallel sentences to train successfully.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -93,6 +93,9 @@ public class LanguageTranslator {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)

--- a/Source/LanguageTranslatorV3/Models/TranslateRequest.swift
+++ b/Source/LanguageTranslatorV3/Models/TranslateRequest.swift
@@ -54,14 +54,16 @@ public struct TranslateRequest: Encodable {
     /**
      Initialize a `TranslateRequest` with member variables.
 
-     - parameter text: Input text in UTF-8 encoding. Multiple entries will result in multiple translations in the response.
-     - parameter modelID: Model ID of the translation model to use. If this is specified, the **source** and **target** parameters will be
-       ignored. The method requires either a model ID or both the **source** and **target** parameters.
-     - parameter source: Language code of the source text language. Use with `target` as an alternative way to select a translation model.
-       When `source` and `target` are set, and a model ID is not set, the system chooses a default model for the
-       language pair (usually the model based on the news domain).
-     - parameter target: Language code of the translation target language. Use with source as an alternative way to select a translation
-       model.
+     - parameter text: Input text in UTF-8 encoding. Multiple entries will result in multiple translations in the
+       response.
+     - parameter modelID: Model ID of the translation model to use. If this is specified, the **source** and
+       **target** parameters will be ignored. The method requires either a model ID or both the **source** and
+       **target** parameters.
+     - parameter source: Language code of the source text language. Use with `target` as an alternative way to select
+       a translation model. When `source` and `target` are set, and a model ID is not set, the system chooses a default
+       model for the language pair (usually the model based on the news domain).
+     - parameter target: Language code of the translation target language. Use with source as an alternative way to
+       select a translation model.
 
      - returns: An initialized `TranslateRequest`.
     */

--- a/Source/LanguageTranslatorV3/Models/TranslationModel.swift
+++ b/Source/LanguageTranslatorV3/Models/TranslationModel.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Response payload for models. */
+/**
+ Response payload for models.
+ */
 public struct TranslationModel: Decodable {
 
     /**

--- a/Source/LanguageTranslatorV3/Models/TranslationModels.swift
+++ b/Source/LanguageTranslatorV3/Models/TranslationModels.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The response type for listing existing translation models. */
+/**
+ The response type for listing existing translation models.
+ */
 public struct TranslationModels: Decodable {
 
     /**

--- a/Source/NaturalLanguageClassifierV1/Models/Classification.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/Classification.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Response from the classifier for a phrase. */
+/**
+ Response from the classifier for a phrase.
+ */
 public struct Classification: Decodable {
 
     /**

--- a/Source/NaturalLanguageClassifierV1/Models/ClassificationCollection.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassificationCollection.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Response from the classifier for multiple phrases. */
+/**
+ Response from the classifier for multiple phrases.
+ */
 public struct ClassificationCollection: Decodable {
 
     /**

--- a/Source/NaturalLanguageClassifierV1/Models/ClassifiedClass.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassifiedClass.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Class and confidence. */
+/**
+ Class and confidence.
+ */
 public struct ClassifiedClass: Decodable {
 
     /**

--- a/Source/NaturalLanguageClassifierV1/Models/Classifier.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/Classifier.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A classifier for natural language phrases. */
+/**
+ A classifier for natural language phrases.
+ */
 public struct Classifier: Decodable {
 
     /**

--- a/Source/NaturalLanguageClassifierV1/Models/ClassifierList.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassifierList.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** List of available classifiers. */
+/**
+ List of available classifiers.
+ */
 public struct ClassifierList: Decodable {
 
     /**

--- a/Source/NaturalLanguageClassifierV1/Models/ClassifyCollectionInput.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassifyCollectionInput.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Request payload to classify. */
+/**
+ Request payload to classify.
+ */
 internal struct ClassifyCollectionInput: Encodable {
 
     /**

--- a/Source/NaturalLanguageClassifierV1/Models/ClassifyInput.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassifyInput.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Request payload to classify. */
+/**
+ Request payload to classify.
+ */
 public struct ClassifyInput: Encodable {
 
     /**

--- a/Source/NaturalLanguageClassifierV1/Models/CollectionItem.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/CollectionItem.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Response from the classifier for a phrase in a collection. */
+/**
+ Response from the classifier for a phrase in a collection.
+ */
 public struct CollectionItem: Decodable {
 
     /**

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -82,12 +82,6 @@ public class NaturalLanguageClassifier {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
-            if case let .some(.string(description)) = json["description"] {
-                userInfo[NSLocalizedFailureReasonErrorKey] = description
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -220,12 +214,13 @@ public class NaturalLanguageClassifier {
 
      Sends data to create and train a classifier and returns information about the new classifier.
 
-     - parameter metadata: Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the
-       classifier. Specify the language with the 2-letter primary language code as assigned in ISO standard 639.
+     - parameter metadata: Metadata in JSON format. The metadata identifies the language of the data, and an optional
+       name to identify the classifier. Specify the language with the 2-letter primary language code as assigned in ISO
+       standard 639.
        Supported languages are English (`en`), Arabic (`ar`), French (`fr`), German, (`de`), Italian (`it`), Japanese
        (`ja`), Korean (`ko`), Brazilian Portuguese (`pt`), and Spanish (`es`).
-     - parameter trainingData: Training data in CSV format. Each text value must have at least one class. The data can include up to 20,000
-       records. For details, see [Data
+     - parameter trainingData: Training data in CSV format. Each text value must have at least one class. The data can
+       include up to 20,000 records. For details, see [Data
        preparation](https://console.bluemix.net/docs/services/natural-language-classifier/using-your-data.html).
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -82,6 +82,12 @@ public class NaturalLanguageClassifier {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
+            if case let .some(.string(description)) = json["description"] {
+                userInfo[NSLocalizedFailureReasonErrorKey] = description
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)

--- a/Source/NaturalLanguageUnderstandingV1/Models/AnalysisResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/AnalysisResults.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Results of the analysis, organized by feature. */
+/**
+ Results of the analysis, organized by feature.
+ */
 public struct AnalysisResults: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/Author.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Author.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The author of the analyzed content. */
+/**
+ The author of the analyzed content.
+ */
 public struct Author: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/CategoriesOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/CategoriesOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The hierarchical 5-level taxonomy the content is categorized into. */
+/**
+ The hierarchical 5-level taxonomy the content is categorized into.
+ */
 public struct CategoriesOptions: Encodable {
 
     /// Additional properties associated with this model.

--- a/Source/NaturalLanguageUnderstandingV1/Models/CategoriesResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/CategoriesResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The hierarchical 5-level taxonomy the content is categorized into. */
+/**
+ The hierarchical 5-level taxonomy the content is categorized into.
+ */
 public struct CategoriesResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/ConceptsOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/ConceptsOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Whether or not to analyze content for general concepts that are referenced or alluded to. */
+/**
+ Whether or not to analyze content for general concepts that are referenced or alluded to.
+ */
 public struct ConceptsOptions: Encodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/ConceptsResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/ConceptsResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The general concepts referenced or alluded to in the specified content. */
+/**
+ The general concepts referenced or alluded to in the specified content.
+ */
 public struct ConceptsResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/DisambiguationResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/DisambiguationResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Disambiguation information for the entity. */
+/**
+ Disambiguation information for the entity.
+ */
 public struct DisambiguationResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/DocumentEmotionResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/DocumentEmotionResults.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object containing the emotion results of a document. */
+/**
+ An object containing the emotion results of a document.
+ */
 public struct DocumentEmotionResults: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/EmotionOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EmotionOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Whether or not to return emotion analysis of the content. */
+/**
+ Whether or not to return emotion analysis of the content.
+ */
 public struct EmotionOptions: Encodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/EmotionResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EmotionResult.swift
@@ -16,7 +16,10 @@
 
 import Foundation
 
-/** The detected anger, disgust, fear, joy, or sadness that is conveyed by the content. Emotion information can be returned for detected entities, keywords, or user-specified target phrases found in the text. */
+/**
+ The detected anger, disgust, fear, joy, or sadness that is conveyed by the content. Emotion information can be returned
+ for detected entities, keywords, or user-specified target phrases found in the text.
+ */
 public struct EmotionResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/EntitiesOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EntitiesOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Whether or not to return important people, places, geopolitical, and other entities detected in the analyzed content. */
+/**
+ Whether or not to return important people, places, geopolitical, and other entities detected in the analyzed content.
+ */
 public struct EntitiesOptions: Encodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/EntitiesResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EntitiesResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The important people, places, geopolitical entities and other types of entities in your content. */
+/**
+ The important people, places, geopolitical entities and other types of entities in your content.
+ */
 public struct EntitiesResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/Features.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Features.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Analysis features and options. */
+/**
+ Analysis features and options.
+ */
 public struct Features: Encodable {
 
     /**
@@ -85,12 +87,14 @@ public struct Features: Encodable {
      - parameter emotion: Whether or not to extract the emotions implied in the analyzed text.
      - parameter entities: Whether or not to extract detected entity objects from the analyzed text.
      - parameter keywords: Whether or not to return the keywords in the analyzed text.
-     - parameter metadata: Whether or not the author, publication date, and title of the analyzed text should be returned. This parameter is
-       only available for URL and HTML input.
-     - parameter relations: Whether or not to return the relationships between detected entities in the analyzed text.
+     - parameter metadata: Whether or not the author, publication date, and title of the analyzed text should be
+       returned. This parameter is only available for URL and HTML input.
+     - parameter relations: Whether or not to return the relationships between detected entities in the analyzed
+       text.
      - parameter semanticRoles: Whether or not to return the subject-action-object relations from the analyzed text.
      - parameter sentiment: Whether or not to return the overall sentiment of the analyzed text.
-     - parameter categories: Whether or not to return the high level category the content is categorized as (i.e. news, art).
+     - parameter categories: Whether or not to return the high level category the content is categorized as (i.e.
+       news, art).
 
      - returns: An initialized `Features`.
     */

--- a/Source/NaturalLanguageUnderstandingV1/Models/Feed.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Feed.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** RSS or ATOM feed found on the webpage. */
+/**
+ RSS or ATOM feed found on the webpage.
+ */
 public struct Feed: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/KeywordsOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/KeywordsOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An option indicating whether or not important keywords from the analyzed content should be returned. */
+/**
+ An option indicating whether or not important keywords from the analyzed content should be returned.
+ */
 public struct KeywordsOptions: Encodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/KeywordsResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/KeywordsResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The most important keywords in the content, organized by relevance. */
+/**
+ The most important keywords in the content, organized by relevance.
+ */
 public struct KeywordsResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/ListModelsResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/ListModelsResults.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Models available for Relations and Entities features. */
+/**
+ Models available for Relations and Entities features.
+ */
 public struct ListModelsResults: Decodable {
 
     public var models: [Model]?

--- a/Source/NaturalLanguageUnderstandingV1/Models/MetadataOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/MetadataOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The Authors, Publication Date, and Title of the document. Supports URL and HTML input types. */
+/**
+ The Authors, Publication Date, and Title of the document. Supports URL and HTML input types.
+ */
 public struct MetadataOptions: Encodable {
 
     /// Additional properties associated with this model.

--- a/Source/NaturalLanguageUnderstandingV1/Models/MetadataResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/MetadataResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The Authors, Publication Date, and Title of the document. Supports URL and HTML input types. */
+/**
+ The Authors, Publication Date, and Title of the document. Supports URL and HTML input types.
+ */
 public struct MetadataResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/Parameters.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Parameters.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object containing request parameters. */
+/**
+ An object containing request parameters.
+ */
 public struct Parameters: Encodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/RelationEntity.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/RelationEntity.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An entity that corresponds with an argument in a relation. */
+/**
+ An entity that corresponds with an argument in a relation.
+ */
 public struct RelationEntity: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/RelationsOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/RelationsOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An option specifying if the relationships found between entities in the analyzed content should be returned. */
+/**
+ An option specifying if the relationships found between entities in the analyzed content should be returned.
+ */
 public struct RelationsOptions: Encodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/RelationsResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/RelationsResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The relations between entities found in the content. */
+/**
+ The relations between entities found in the content.
+ */
 public struct RelationsResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An option specifying whether or not to identify the subjects, actions, and verbs in the analyzed content. */
+/**
+ An option specifying whether or not to identify the subjects, actions, and verbs in the analyzed content.
+ */
 public struct SemanticRolesOptions: Encodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The object containing the actions and the objects the actions act upon. */
+/**
+ The object containing the actions and the objects the actions act upon.
+ */
 public struct SemanticRolesResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/SentimentOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SentimentOptions.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An option specifying if sentiment of detected entities, keywords, or phrases should be returned. */
+/**
+ An option specifying if sentiment of detected entities, keywords, or phrases should be returned.
+ */
 public struct SentimentOptions: Encodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/SentimentResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SentimentResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The sentiment of the content. */
+/**
+ The sentiment of the content.
+ */
 public struct SentimentResult: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/TargetedEmotionResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/TargetedEmotionResults.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** An object containing the emotion results for the target. */
+/**
+ An object containing the emotion results for the target.
+ */
 public struct TargetedEmotionResults: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/Models/Usage.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Usage.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Usage information. */
+/**
+ Usage information.
+ */
 public struct Usage: Decodable {
 
     /**

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -96,6 +96,12 @@ public class NaturalLanguageUnderstanding {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
+            if case let .some(.string(description)) = json["description"] {
+                userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -247,7 +253,7 @@ public class NaturalLanguageUnderstanding {
         modelID: String,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
-        success: @escaping (InlineResponse200) -> Void)
+        success: @escaping (DeleteModelResults) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -278,7 +284,7 @@ public class NaturalLanguageUnderstanding {
 
         // execute REST request
         request.responseObject {
-            (response: RestResponse<InlineResponse200>) in
+            (response: RestResponse<DeleteModelResults>) in
             switch response.result {
             case .success(let retval): success(retval)
             case .failure(let error): failure?(error)

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -96,12 +96,6 @@ public class NaturalLanguageUnderstanding {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
-            if case let .some(.string(description)) = json["description"] {
-                userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -140,8 +134,8 @@ public class NaturalLanguageUnderstanding {
      Categorize your content into a hierarchical 5-level taxonomy. For example, \"Leonardo DiCaprio won an Oscar\"
      returns \"/art and entertainment/movies and tv/movies\" as the most confident classification.
 
-     - parameter parameters: An object containing request parameters. The `features` object and one of the `text`, `html`, or `url` attributes
-       are required.
+     - parameter parameters: An object containing request parameters. The `features` object and one of the `text`,
+       `html`, or `url` attributes are required.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -253,7 +247,7 @@ public class NaturalLanguageUnderstanding {
         modelID: String,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
-        success: @escaping (DeleteModelResults) -> Void)
+        success: @escaping (InlineResponse200) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -284,7 +278,7 @@ public class NaturalLanguageUnderstanding {
 
         // execute REST request
         request.responseObject {
-            (response: RestResponse<DeleteModelResults>) in
+            (response: RestResponse<InlineResponse200>) in
             switch response.result {
             case .success(let retval): success(retval)
             case .failure(let error): failure?(error)

--- a/Source/PersonalityInsightsV3/Models/ContentItem.swift
+++ b/Source/PersonalityInsightsV3/Models/ContentItem.swift
@@ -115,23 +115,26 @@ public struct ContentItem: Encodable {
     /**
      Initialize a `ContentItem` with member variables.
 
-     - parameter content: The content that is to be analyzed. The service supports up to 20 MB of content for all `ContentItem` objects
-       combined.
+     - parameter content: The content that is to be analyzed. The service supports up to 20 MB of content for all
+       `ContentItem` objects combined.
      - parameter id: A unique identifier for this content item.
-     - parameter created: A timestamp that identifies when this content was created. Specify a value in milliseconds since the UNIX Epoch
-       (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
-     - parameter updated: A timestamp that identifies when this content was last updated. Specify a value in milliseconds since the UNIX
-       Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
-     - parameter contenttype: The MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is
-       analyzed; plain text is processed as submitted.
-     - parameter language: The language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is
-       `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as
-       `en`. A language specified with the **Content-Type** parameter overrides the value of this parameter; any content
-       items that specify a different language are ignored. Omit the **Content-Type** parameter to base the language on
-       the most prevalent specification among the content items; again, content items that specify a different language
-       are ignored. You can specify any combination of languages for the input and response content.
-     - parameter parentid: The unique ID of the parent content item for this item. Used to identify hierarchical relationships between
-       posts/replies, messages/replies, and so on.
+     - parameter created: A timestamp that identifies when this content was created. Specify a value in milliseconds
+       since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior
+       data.
+     - parameter updated: A timestamp that identifies when this content was last updated. Specify a value in
+       milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal
+       behavior data.
+     - parameter contenttype: The MIME type of the content. The default is plain text. The tags are stripped from
+       HTML content before it is analyzed; plain text is processed as submitted.
+     - parameter language: The language identifier (two-letter ISO 639-1 identifier) for the language of the content
+       item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US`
+       is interpreted as `en`. A language specified with the **Content-Type** parameter overrides the value of this
+       parameter; any content items that specify a different language are ignored. Omit the **Content-Type** parameter
+       to base the language on the most prevalent specification among the content items; again, content items that
+       specify a different language are ignored. You can specify any combination of languages for the input and response
+       content.
+     - parameter parentid: The unique ID of the parent content item for this item. Used to identify hierarchical
+       relationships between posts/replies, messages/replies, and so on.
      - parameter reply: Indicates whether this content item is a reply to another content item.
      - parameter forward: Indicates whether this content item is a forwarded/copied version of another content item.
 

--- a/Source/PersonalityInsightsV3/Models/ProfileContent.swift
+++ b/Source/PersonalityInsightsV3/Models/ProfileContent.swift
@@ -1,0 +1,46 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/**
+ A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
+ [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For
+ JSON input, provide an object of type `Content`.
+ */
+public enum ProfileContent {
+
+    case content(Content)
+    case html(String)
+    case text(String)
+
+    internal var contentType: String {
+        switch self {
+        case .content: return "application/json"
+        case .html: return "text/html"
+        case .text: return "text/plain"
+        }
+    }
+
+    internal var content: Data? {
+        switch self {
+        case .content(let content): return try? JSONEncoder().encode(content)
+        case .html(let html): return html.data(using: .utf8)
+        case .text(let text): return text.data(using: .utf8)
+        }
+    }
+
+}

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -102,12 +102,6 @@ public class PersonalityInsights {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
-            if case let .some(.string(help)) = json["help"] {
-                userInfo[NSLocalizedFailureReasonErrorKey] = help
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -133,41 +127,45 @@ public class PersonalityInsights {
      profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
      profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
 
-     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
-       [Providing sufficient
+     - parameter profileContent: A maximum of 20 MB of content to analyze, though the service requires much less text;
+       for more information, see [Providing sufficient
        input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For JSON input,
        provide an object of type `Content`.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
-       are treated as their parent language; for example, `en-US` is interpreted as `en`.
+     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean,
+       or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`.
        The effect of the **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type**
        is `text/plain` or `text/html`, **Content-Language** is the only way to specify the language. When
        **Content-Type** is `application/json`, **Content-Language** overrides a language specified with the `language`
        parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this
        parameter to base the language on the specification of the content items. You can specify any combination of
        languages for **Content-Language** and **Accept-Language**.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-       language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
-       and response content.
-     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
-       scores are not compared with a sample population. By default, only normalized percentiles are returned.
-     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences
-       are returned.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants
+       are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any
+       combination of languages for the input and response content.
+     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each
+       characteristic; raw scores are not compared with a sample population. By default, only normalized percentiles are
+       returned.
+     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column
+       labels are returned. Applies only when the **Accept** parameter is set to `text/csv`.
+     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By
+       default, no consumption preferences are returned.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
     public func profile(
-        content: Content,
+        profileContent: ProfileContent,
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         rawScores: Bool? = nil,
+        csvHeaders: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Profile) -> Void)
     {
         // construct body
-        guard let body = try? JSONEncoder().encode(content) else {
+        guard let body = profileContent.content else {
             failure?(RestError.serializationError)
             return
         }
@@ -178,7 +176,7 @@ public class PersonalityInsights {
             headerParameters.merge(headers) { (_, new) in new }
         }
         headerParameters["Accept"] = "application/json"
-        headerParameters["Content-Type"] = "application/json"
+        headerParameters["Content-Type"] = profileContent.contentType
         if let contentLanguage = contentLanguage {
             headerParameters["Content-Language"] = contentLanguage
         }
@@ -193,216 +191,8 @@ public class PersonalityInsights {
             let queryParameter = URLQueryItem(name: "raw_scores", value: "\(rawScores)")
             queryParameters.append(queryParameter)
         }
-        if let consumptionPreferences = consumptionPreferences {
-            let queryParameter = URLQueryItem(name: "consumption_preferences", value: "\(consumptionPreferences)")
-            queryParameters.append(queryParameter)
-        }
-
-        // construct REST request
-        let request = RestRequest(
-            session: session,
-            authMethod: authMethod,
-            errorResponseDecoder: errorResponseDecoder,
-            method: "POST",
-            url: serviceURL + "/v3/profile",
-            headerParameters: headerParameters,
-            queryItems: queryParameters,
-            messageBody: body
-        )
-
-        // execute REST request
-        request.responseObject {
-            (response: RestResponse<Profile>) in
-            switch response.result {
-            case .success(let retval): success(retval)
-            case .failure(let error): failure?(error)
-            }
-        }
-    }
-
-    /**
-     Get profile.
-
-     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
-     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
-     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
-     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
-     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
-     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
-     parameter; CSV output includes a fixed number of columns and optional headers.
-     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the
-     HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
-     set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
-     character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`.
-     For detailed information about calling the service and the responses it can generate, see [Requesting a
-     profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON
-     profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
-     profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
-
-     - parameter text: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
-     [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For JSON input,
-     provide an object of type `Content`.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
-     are treated as their parent language; for example, `en-US` is interpreted as `en`.
-     The effect of the **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type**
-     is `text/plain` or `text/html`, **Content-Language** is the only way to specify the language. When
-     **Content-Type** is `application/json`, **Content-Language** overrides a language specified with the `language`
-     parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this
-     parameter to base the language on the specification of the content items. You can specify any combination of
-     languages for **Content-Language** and **Accept-Language**.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
-     and response content.
-     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
-     scores are not compared with a sample population. By default, only normalized percentiles are returned.
-     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences
-     are returned.
-     - parameter headers: A dictionary of request headers to be sent with this request.
-     - parameter failure: A function executed if an error occurs.
-     - parameter success: A function executed with the successful result.
-     */
-    public func profile(
-        text: String,
-        contentLanguage: String? = nil,
-        acceptLanguage: String? = nil,
-        rawScores: Bool? = nil,
-        consumptionPreferences: Bool? = nil,
-        headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (Profile) -> Void)
-    {
-        // construct body
-        guard let body = text.data(using: .utf8) else {
-            failure?(RestError.serializationError)
-            return
-        }
-
-        // construct header parameters
-        var headerParameters = defaultHeaders
-        if let headers = headers {
-            headerParameters.merge(headers) { (_, new) in new }
-        }
-        headerParameters["Accept"] = "application/json"
-        headerParameters["Content-Type"] = "text/plain"
-        if let contentLanguage = contentLanguage {
-            headerParameters["Content-Language"] = contentLanguage
-        }
-        if let acceptLanguage = acceptLanguage {
-            headerParameters["Accept-Language"] = acceptLanguage
-        }
-
-        // construct query parameters
-        var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "version", value: version))
-        if let rawScores = rawScores {
-            let queryParameter = URLQueryItem(name: "raw_scores", value: "\(rawScores)")
-            queryParameters.append(queryParameter)
-        }
-        if let consumptionPreferences = consumptionPreferences {
-            let queryParameter = URLQueryItem(name: "consumption_preferences", value: "\(consumptionPreferences)")
-            queryParameters.append(queryParameter)
-        }
-
-        // construct REST request
-        let request = RestRequest(
-            session: session,
-            authMethod: authMethod,
-            errorResponseDecoder: errorResponseDecoder,
-            method: "POST",
-            url: serviceURL + "/v3/profile",
-            headerParameters: headerParameters,
-            queryItems: queryParameters,
-            messageBody: body
-        )
-
-        // execute REST request
-        request.responseObject {
-            (response: RestResponse<Profile>) in
-            switch response.result {
-            case .success(let retval): success(retval)
-            case .failure(let error): failure?(error)
-            }
-        }
-    }
-
-    /**
-     Get profile.
-
-     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
-     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
-     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
-     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
-     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
-     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
-     parameter; CSV output includes a fixed number of columns and optional headers.
-     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the
-     HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
-     set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
-     character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`.
-     For detailed information about calling the service and the responses it can generate, see [Requesting a
-     profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON
-     profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
-     profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
-
-     - parameter html: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
-     [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For JSON input,
-     provide an object of type `Content`.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
-     are treated as their parent language; for example, `en-US` is interpreted as `en`.
-     The effect of the **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type**
-     is `text/plain` or `text/html`, **Content-Language** is the only way to specify the language. When
-     **Content-Type** is `application/json`, **Content-Language** overrides a language specified with the `language`
-     parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this
-     parameter to base the language on the specification of the content items. You can specify any combination of
-     languages for **Content-Language** and **Accept-Language**.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
-     and response content.
-     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
-     scores are not compared with a sample population. By default, only normalized percentiles are returned.
-     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences
-     are returned.
-     - parameter headers: A dictionary of request headers to be sent with this request.
-     - parameter failure: A function executed if an error occurs.
-     - parameter success: A function executed with the successful result.
-     */
-    public func profile(
-        html: String,
-        contentLanguage: String? = nil,
-        acceptLanguage: String? = nil,
-        rawScores: Bool? = nil,
-        consumptionPreferences: Bool? = nil,
-        headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (Profile) -> Void)
-    {
-        // construct body
-        guard let body = html.data(using: .utf8) else {
-            failure?(RestError.serializationError)
-            return
-        }
-
-        // construct header parameters
-        var headerParameters = defaultHeaders
-        if let headers = headers {
-            headerParameters.merge(headers) { (_, new) in new }
-        }
-        headerParameters["Accept"] = "application/json"
-        headerParameters["Content-Type"] = "text/html"
-        if let contentLanguage = contentLanguage {
-            headerParameters["Content-Language"] = contentLanguage
-        }
-        if let acceptLanguage = acceptLanguage {
-            headerParameters["Accept-Language"] = acceptLanguage
-        }
-
-        // construct query parameters
-        var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "version", value: version))
-        if let rawScores = rawScores {
-            let queryParameter = URLQueryItem(name: "raw_scores", value: "\(rawScores)")
+        if let csvHeaders = csvHeaders {
+            let queryParameter = URLQueryItem(name: "csv_headers", value: "\(csvHeaders)")
             queryParameters.append(queryParameter)
         }
         if let consumptionPreferences = consumptionPreferences {
@@ -451,33 +241,34 @@ public class PersonalityInsights {
      profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
      profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
 
-     - parameter content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
-       [Providing sufficient
+     - parameter profileContent: A maximum of 20 MB of content to analyze, though the service requires much less text;
+       for more information, see [Providing sufficient
        input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For JSON input,
        provide an object of type `Content`.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
-       are treated as their parent language; for example, `en-US` is interpreted as `en`.
+     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean,
+       or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`.
        The effect of the **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type**
        is `text/plain` or `text/html`, **Content-Language** is the only way to specify the language. When
        **Content-Type** is `application/json`, **Content-Language** overrides a language specified with the `language`
        parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this
        parameter to base the language on the specification of the content items. You can specify any combination of
        languages for **Content-Language** and **Accept-Language**.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-       language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
-       and response content.
-     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
-       scores are not compared with a sample population. By default, only normalized percentiles are returned.
-     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column labels are returned.
-       Applies only when the **Accept** parameter is set to `text/csv`.
-     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences
-       are returned.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants
+       are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any
+       combination of languages for the input and response content.
+     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each
+       characteristic; raw scores are not compared with a sample population. By default, only normalized percentiles are
+       returned.
+     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column
+       labels are returned. Applies only when the **Accept** parameter is set to `text/csv`.
+     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By
+       default, no consumption preferences are returned.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
     public func profileAsCsv(
-        content: Content,
+        profileContent: ProfileContent,
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         rawScores: Bool? = nil,
@@ -485,10 +276,10 @@ public class PersonalityInsights {
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
-        success: @escaping (String) -> Void)
+        success: @escaping (URL) -> Void)
     {
         // construct body
-        guard let body = try? JSONEncoder().encode(content) else {
+        guard let body = profileContent.content else {
             failure?(RestError.serializationError)
             return
         }
@@ -499,7 +290,7 @@ public class PersonalityInsights {
             headerParameters.merge(headers) { (_, new) in new }
         }
         headerParameters["Accept"] = "text/csv"
-        headerParameters["Content-Type"] = "application/json"
+        headerParameters["Content-Type"] = profileContent.contentType
         if let contentLanguage = contentLanguage {
             headerParameters["Content-Language"] = contentLanguage
         }
@@ -536,234 +327,8 @@ public class PersonalityInsights {
         )
 
         // execute REST request
-        request.responseString {
-            (response: RestResponse<String>) in
-            switch response.result {
-            case .success(let retval): success(retval)
-            case .failure(let error): failure?(error)
-            }
-        }
-    }
-
-    /**
-     Get profile as csv.
-
-     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
-     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
-     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
-     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
-     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
-     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
-     parameter; CSV output includes a fixed number of columns and optional headers.
-     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the
-     HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
-     set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
-     character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`.
-     For detailed information about calling the service and the responses it can generate, see [Requesting a
-     profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON
-     profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
-     profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
-
-     - parameter text: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
-     [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For JSON input,
-     provide an object of type `Content`.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
-     are treated as their parent language; for example, `en-US` is interpreted as `en`.
-     The effect of the **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type**
-     is `text/plain` or `text/html`, **Content-Language** is the only way to specify the language. When
-     **Content-Type** is `application/json`, **Content-Language** overrides a language specified with the `language`
-     parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this
-     parameter to base the language on the specification of the content items. You can specify any combination of
-     languages for **Content-Language** and **Accept-Language**.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
-     and response content.
-     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
-     scores are not compared with a sample population. By default, only normalized percentiles are returned.
-     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column labels are returned.
-     Applies only when the **Accept** parameter is set to `text/csv`.
-     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences
-     are returned.
-     - parameter headers: A dictionary of request headers to be sent with this request.
-     - parameter failure: A function executed if an error occurs.
-     - parameter success: A function executed with the successful result.
-     */
-    public func profileAsCsv(
-        text: String,
-        contentLanguage: String? = nil,
-        acceptLanguage: String? = nil,
-        rawScores: Bool? = nil,
-        csvHeaders: Bool? = nil,
-        consumptionPreferences: Bool? = nil,
-        headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (String) -> Void)
-    {
-        // construct body
-        guard let body = text.data(using: .utf8) else {
-            failure?(RestError.serializationError)
-            return
-        }
-
-        // construct header parameters
-        var headerParameters = defaultHeaders
-        if let headers = headers {
-            headerParameters.merge(headers) { (_, new) in new }
-        }
-        headerParameters["Accept"] = "text/csv"
-        headerParameters["Content-Type"] = "text/plain"
-        if let contentLanguage = contentLanguage {
-            headerParameters["Content-Language"] = contentLanguage
-        }
-        if let acceptLanguage = acceptLanguage {
-            headerParameters["Accept-Language"] = acceptLanguage
-        }
-
-        // construct query parameters
-        var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "version", value: version))
-        if let rawScores = rawScores {
-            let queryParameter = URLQueryItem(name: "raw_scores", value: "\(rawScores)")
-            queryParameters.append(queryParameter)
-        }
-        if let csvHeaders = csvHeaders {
-            let queryParameter = URLQueryItem(name: "csv_headers", value: "\(csvHeaders)")
-            queryParameters.append(queryParameter)
-        }
-        if let consumptionPreferences = consumptionPreferences {
-            let queryParameter = URLQueryItem(name: "consumption_preferences", value: "\(consumptionPreferences)")
-            queryParameters.append(queryParameter)
-        }
-
-        // construct REST request
-        let request = RestRequest(
-            session: session,
-            authMethod: authMethod,
-            errorResponseDecoder: errorResponseDecoder,
-            method: "POST",
-            url: serviceURL + "/v3/profile",
-            headerParameters: headerParameters,
-            queryItems: queryParameters,
-            messageBody: body
-        )
-
-        // execute REST request
-        request.responseString {
-            (response: RestResponse<String>) in
-            switch response.result {
-            case .success(let retval): success(retval)
-            case .failure(let error): failure?(error)
-            }
-        }
-    }
-
-    /**
-     Get profile as csv.
-
-     Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input
-     content, but it requires much less text to produce an accurate profile; for more information, see [Providing
-     sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The
-     service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of
-     languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the
-     default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept**
-     parameter; CSV output includes a fixed number of columns and optional headers.
-     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the
-     HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
-     set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
-     character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`.
-     For detailed information about calling the service and the responses it can generate, see [Requesting a
-     profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON
-     profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
-     profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
-
-     - parameter html: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see
-     [Providing sufficient
-     input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For JSON input,
-     provide an object of type `Content`.
-     - parameter contentLanguage: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants
-     are treated as their parent language; for example, `en-US` is interpreted as `en`.
-     The effect of the **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type**
-     is `text/plain` or `text/html`, **Content-Language** is the only way to specify the language. When
-     **Content-Type** is `application/json`, **Content-Language** overrides a language specified with the `language`
-     parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this
-     parameter to base the language on the specification of the content items. You can specify any combination of
-     languages for **Content-Language** and **Accept-Language**.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-     language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input
-     and response content.
-     - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw
-     scores are not compared with a sample population. By default, only normalized percentiles are returned.
-     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column labels are returned.
-     Applies only when the **Accept** parameter is set to `text/csv`.
-     - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences
-     are returned.
-     - parameter headers: A dictionary of request headers to be sent with this request.
-     - parameter failure: A function executed if an error occurs.
-     - parameter success: A function executed with the successful result.
-     */
-    public func profileAsCsv(
-        html: String,
-        contentLanguage: String? = nil,
-        acceptLanguage: String? = nil,
-        rawScores: Bool? = nil,
-        csvHeaders: Bool? = nil,
-        consumptionPreferences: Bool? = nil,
-        headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (String) -> Void)
-    {
-        // construct body
-        guard let body = html.data(using: .utf8) else {
-            failure?(RestError.serializationError)
-            return
-        }
-
-        // construct header parameters
-        var headerParameters = defaultHeaders
-        if let headers = headers {
-            headerParameters.merge(headers) { (_, new) in new }
-        }
-        headerParameters["Accept"] = "text/csv"
-        headerParameters["Content-Type"] = "text/html"
-        if let contentLanguage = contentLanguage {
-            headerParameters["Content-Language"] = contentLanguage
-        }
-        if let acceptLanguage = acceptLanguage {
-            headerParameters["Accept-Language"] = acceptLanguage
-        }
-
-        // construct query parameters
-        var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "version", value: version))
-        if let rawScores = rawScores {
-            let queryParameter = URLQueryItem(name: "raw_scores", value: "\(rawScores)")
-            queryParameters.append(queryParameter)
-        }
-        if let csvHeaders = csvHeaders {
-            let queryParameter = URLQueryItem(name: "csv_headers", value: "\(csvHeaders)")
-            queryParameters.append(queryParameter)
-        }
-        if let consumptionPreferences = consumptionPreferences {
-            let queryParameter = URLQueryItem(name: "consumption_preferences", value: "\(consumptionPreferences)")
-            queryParameters.append(queryParameter)
-        }
-
-        // construct REST request
-        let request = RestRequest(
-            session: session,
-            authMethod: authMethod,
-            errorResponseDecoder: errorResponseDecoder,
-            method: "POST",
-            url: serviceURL + "/v3/profile",
-            headerParameters: headerParameters,
-            queryItems: queryParameters,
-            messageBody: body
-        )
-
-        // execute REST request
-        request.responseString {
-            (response: RestResponse<String>) in
+        request.responseObject {
+            (response: RestResponse<URL>) in
             switch response.result {
             case .success(let retval): success(retval)
             case .failure(let error): failure?(error)

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -102,6 +102,12 @@ public class PersonalityInsights {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
+            if case let .some(.string(help)) = json["help"] {
+                userInfo[NSLocalizedFailureReasonErrorKey] = help
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -145,8 +151,6 @@ public class PersonalityInsights {
      - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each
        characteristic; raw scores are not compared with a sample population. By default, only normalized percentiles are
        returned.
-     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column
-       labels are returned. Applies only when the **Accept** parameter is set to `text/csv`.
      - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By
        default, no consumption preferences are returned.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -158,7 +162,6 @@ public class PersonalityInsights {
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         rawScores: Bool? = nil,
-        csvHeaders: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -189,10 +192,6 @@ public class PersonalityInsights {
         queryParameters.append(URLQueryItem(name: "version", value: version))
         if let rawScores = rawScores {
             let queryParameter = URLQueryItem(name: "raw_scores", value: "\(rawScores)")
-            queryParameters.append(queryParameter)
-        }
-        if let csvHeaders = csvHeaders {
-            let queryParameter = URLQueryItem(name: "csv_headers", value: "\(csvHeaders)")
             queryParameters.append(queryParameter)
         }
         if let consumptionPreferences = consumptionPreferences {
@@ -276,7 +275,7 @@ public class PersonalityInsights {
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
-        success: @escaping (URL) -> Void)
+        success: @escaping (String) -> Void)
     {
         // construct body
         guard let body = profileContent.content else {
@@ -327,8 +326,8 @@ public class PersonalityInsights {
         )
 
         // execute REST request
-        request.responseObject {
-            (response: RestResponse<URL>) in
+        request.responseString {
+            (response: RestResponse<String>) in
             switch response.result {
             case .success(let retval): success(retval)
             case .failure(let error): failure?(error)
@@ -336,4 +335,106 @@ public class PersonalityInsights {
         }
     }
 
+}
+
+extension PersonalityInsights {
+
+    @available(*, deprecated, message: "This method has been deprecated in favor of the profile method that accepts a profileContent parameter.  This method will be removed in a future release.")
+    public func profile(
+        content: Content,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        rawScores: Bool? = nil,
+        consumptionPreferences: Bool? = nil,
+        headers: [String: String]? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (Profile) -> Void)
+    {
+        profile(profileContent: .content(content), contentLanguage: contentLanguage, acceptLanguage: acceptLanguage,
+                rawScores: rawScores, consumptionPreferences: consumptionPreferences, headers: headers,
+                failure: failure, success: success)
+    }
+
+    @available(*, deprecated, message: "This method has been deprecated in favor of the profile method that accepts a profileContent parameter.  This method will be removed in a future release.")
+    public func profile(
+        text: String,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        rawScores: Bool? = nil,
+        consumptionPreferences: Bool? = nil,
+        headers: [String: String]? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (Profile) -> Void)
+    {
+        profile(profileContent: .text(text), contentLanguage: contentLanguage, acceptLanguage: acceptLanguage,
+                rawScores: rawScores, consumptionPreferences: consumptionPreferences, headers: headers,
+                failure: failure, success: success)
+    }
+
+    @available(*, deprecated, message: "This method has been deprecated in favor of the profile method that accepts a profileContent parameter.  This method will be removed in a future release.")
+    public func profile(
+        html: String,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        rawScores: Bool? = nil,
+        consumptionPreferences: Bool? = nil,
+        headers: [String: String]? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (Profile) -> Void)
+    {
+        profile(profileContent: .html(html), contentLanguage: contentLanguage, acceptLanguage: acceptLanguage,
+                rawScores: rawScores, consumptionPreferences: consumptionPreferences, headers: headers,
+                failure: failure, success: success)
+    }
+
+    @available(*, deprecated, message: "This method has been deprecated in favor of the profileAsCsv method that accepts a profileContent parameter.  This method will be removed in a future release.")
+    public func profileAsCsv(
+        content: Content,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        rawScores: Bool? = nil,
+        csvHeaders: Bool? = nil,
+        consumptionPreferences: Bool? = nil,
+        headers: [String: String]? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (String) -> Void)
+    {
+        profileAsCsv(profileContent: .content(content), contentLanguage: contentLanguage, acceptLanguage: acceptLanguage,
+                     rawScores: rawScores, csvHeaders: csvHeaders, consumptionPreferences: consumptionPreferences, headers: headers,
+                     failure: failure, success: success)
+    }
+
+    @available(*, deprecated, message: "This method has been deprecated in favor of the profileAsCsv method that accepts a profileContent parameter.  This method will be removed in a future release.")
+    public func profileAsCsv(
+        text: String,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        rawScores: Bool? = nil,
+        csvHeaders: Bool? = nil,
+        consumptionPreferences: Bool? = nil,
+        headers: [String: String]? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (String) -> Void)
+    {
+        profileAsCsv(profileContent: .text(text), contentLanguage: contentLanguage, acceptLanguage: acceptLanguage,
+                     rawScores: rawScores, csvHeaders: csvHeaders, consumptionPreferences: consumptionPreferences, headers: headers,
+                     failure: failure, success: success)
+    }
+
+    @available(*, deprecated, message: "This method has been deprecated in favor of the profileAsCsv method that accepts a profileContent parameter.  This method will be removed in a future release.")
+    public func profileAsCsv(
+        html: String,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        rawScores: Bool? = nil,
+        csvHeaders: Bool? = nil,
+        consumptionPreferences: Bool? = nil,
+        headers: [String: String]? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (String) -> Void)
+    {
+        profileAsCsv(profileContent: .html(html), contentLanguage: contentLanguage, acceptLanguage: acceptLanguage,
+                     rawScores: rawScores, csvHeaders: csvHeaders, consumptionPreferences: consumptionPreferences, headers: headers,
+                     failure: failure, success: success)
+    }
 }

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -40,6 +40,7 @@ internal struct RestRequest {
             #endif
         }()
         let operatingSystemVersion: String = {
+            // swiftlint:disable:next identifier_name
             let os = ProcessInfo.processInfo.operatingSystemVersion
             return "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
         }()

--- a/Source/SpeechToTextV1/Models/CreateAcousticModel.swift
+++ b/Source/SpeechToTextV1/Models/CreateAcousticModel.swift
@@ -75,15 +75,16 @@ internal struct CreateAcousticModel: Encodable {
     /**
      Initialize a `CreateAcousticModel` with member variables.
 
-     - parameter name: A user-defined name for the new custom acoustic model. Use a name that is unique among all custom acoustic models
-       that you own. Use a localized name that matches the language of the custom model. Use a name that describes the
-       acoustic environment of the custom model, such as `Mobile custom model` or `Noisy car custom model`.
-     - parameter baseModelName: The name of the base language model that is to be customized by the new custom acoustic model. The new custom
-       model can be used only with the base model that it customizes. To determine whether a base model supports
-       acoustic model customization, refer to [Language support for
+     - parameter name: A user-defined name for the new custom acoustic model. Use a name that is unique among all
+       custom acoustic models that you own. Use a localized name that matches the language of the custom model. Use a
+       name that describes the acoustic environment of the custom model, such as `Mobile custom model` or `Noisy car
+       custom model`.
+     - parameter baseModelName: The name of the base language model that is to be customized by the new custom
+       acoustic model. The new custom model can be used only with the base model that it customizes. To determine
+       whether a base model supports acoustic model customization, refer to [Language support for
        customization](https://console.bluemix.net/docs/services/speech-to-text/custom.html#languageSupport).
-     - parameter description: A description of the new custom acoustic model. Use a localized description that matches the language of the
-       custom model.
+     - parameter description: A description of the new custom acoustic model. Use a localized description that
+       matches the language of the custom model.
 
      - returns: An initialized `CreateAcousticModel`.
     */

--- a/Source/SpeechToTextV1/Models/CreateLanguageModel.swift
+++ b/Source/SpeechToTextV1/Models/CreateLanguageModel.swift
@@ -85,24 +85,24 @@ public struct CreateLanguageModel: Encodable {
     /**
      Initialize a `CreateLanguageModel` with member variables.
 
-     - parameter name: A user-defined name for the new custom language model. Use a name that is unique among all custom language models
-       that you own. Use a localized name that matches the language of the custom model. Use a name that describes the
-       domain of the custom model, such as `Medical custom model` or `Legal custom model`.
-     - parameter baseModelName: The name of the base language model that is to be customized by the new custom language model. The new custom
-       model can be used only with the base model that it customizes. To determine whether a base model supports
-       language model customization, request information about the base model and check that the attribute
-       `custom_language_model` is set to `true`, or refer to [Language support for
+     - parameter name: A user-defined name for the new custom language model. Use a name that is unique among all
+       custom language models that you own. Use a localized name that matches the language of the custom model. Use a
+       name that describes the domain of the custom model, such as `Medical custom model` or `Legal custom model`.
+     - parameter baseModelName: The name of the base language model that is to be customized by the new custom
+       language model. The new custom model can be used only with the base model that it customizes. To determine
+       whether a base model supports language model customization, request information about the base model and check
+       that the attribute `custom_language_model` is set to `true`, or refer to [Language support for
        customization](https://console.bluemix.net/docs/services/speech-to-text/custom.html#languageSupport).
-     - parameter dialect: The dialect of the specified language that is to be used with the custom language model. The parameter is
-       meaningful only for Spanish models, for which the service creates a custom language model that is suited for
-       speech in one of the following dialects:
+     - parameter dialect: The dialect of the specified language that is to be used with the custom language model.
+       The parameter is meaningful only for Spanish models, for which the service creates a custom language model that
+       is suited for speech in one of the following dialects:
        * `es-ES` for Castilian Spanish (the default)
        * `es-LA` for Latin American Spanish
        * `es-US` for North American (Mexican) Spanish
        A specified dialect must be valid for the base model. By default, the dialect matches the language of the base
        model; for example, `en-US` for either of the US English language models.
-     - parameter description: A description of the new custom language model. Use a localized description that matches the language of the
-       custom model.
+     - parameter description: A description of the new custom language model. Use a localized description that
+       matches the language of the custom model.
 
      - returns: An initialized `CreateLanguageModel`.
     */

--- a/Source/SpeechToTextV1/Models/CustomWord.swift
+++ b/Source/SpeechToTextV1/Models/CustomWord.swift
@@ -55,20 +55,20 @@ public struct CustomWord: Encodable {
     /**
      Initialize a `CustomWord` with member variables.
 
-     - parameter word: For the **Add custom words** method, you must specify the custom word that is to be added to or updated in the
-       custom model. Do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
-       compound words.
+     - parameter word: For the **Add custom words** method, you must specify the custom word that is to be added to
+       or updated in the custom model. Do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to
+       connect the tokens of compound words.
        Omit this field for the **Add a custom word** method.
-     - parameter soundsLike: An array of sounds-like pronunciations for the custom word. Specify how words that are difficult to pronounce,
-       foreign words, acronyms, and so on can be pronounced by users. For a word that is not in the service's base
-       vocabulary, omit the parameter to have the service automatically generate a sounds-like pronunciation for the
-       word. For a word that is in the service's base vocabulary, use the parameter to specify additional pronunciations
-       for the word. You cannot override the default pronunciation of a word; pronunciations you add augment the
-       pronunciation from the base vocabulary. A word can have at most five sounds-like pronunciations, and a
-       pronunciation can include at most 40 characters not including spaces.
-     - parameter displayAs: An alternative spelling for the custom word when it appears in a transcript. Use the parameter when you want the
-       word to have a spelling that is different from its usual representation or from its spelling in corpora training
-       data.
+     - parameter soundsLike: An array of sounds-like pronunciations for the custom word. Specify how words that are
+       difficult to pronounce, foreign words, acronyms, and so on can be pronounced by users. For a word that is not in
+       the service's base vocabulary, omit the parameter to have the service automatically generate a sounds-like
+       pronunciation for the word. For a word that is in the service's base vocabulary, use the parameter to specify
+       additional pronunciations for the word. You cannot override the default pronunciation of a word; pronunciations
+       you add augment the pronunciation from the base vocabulary. A word can have at most five sounds-like
+       pronunciations, and a pronunciation can include at most 40 characters not including spaces.
+     - parameter displayAs: An alternative spelling for the custom word when it appears in a transcript. Use the
+       parameter when you want the word to have a spelling that is different from its usual representation or from its
+       spelling in corpora training data.
 
      - returns: An initialized `CustomWord`.
     */

--- a/Source/SpeechToTextV1/Models/CustomWords.swift
+++ b/Source/SpeechToTextV1/Models/CustomWords.swift
@@ -33,8 +33,8 @@ internal struct CustomWords: Encodable {
     /**
      Initialize a `CustomWords` with member variables.
 
-     - parameter words: An array of objects that provides information about each custom word that is to be added to or updated in the
-       custom language model.
+     - parameter words: An array of objects that provides information about each custom word that is to be added to
+       or updated in the custom language model.
 
      - returns: An initialized `CustomWords`.
     */

--- a/Source/SpeechToTextV1/Models/KeywordResult.swift
+++ b/Source/SpeechToTextV1/Models/KeywordResult.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** KeywordResult. */
-public struct KeywordResult: Decodable {
+public struct KeywordResult: {
 
     /**
      A specified keyword normalized to the spoken phrase that matched in the audio input.

--- a/Source/SpeechToTextV1/Models/KeywordResult.swift
+++ b/Source/SpeechToTextV1/Models/KeywordResult.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** KeywordResult. */
-public struct KeywordResult: {
+public struct KeywordResult: Decodable {
 
     /**
      A specified keyword normalized to the spoken phrase that matched in the audio input.

--- a/Source/SpeechToTextV1/Models/SpeechRecognitionAlternative.swift
+++ b/Source/SpeechToTextV1/Models/SpeechRecognitionAlternative.swift
@@ -35,14 +35,14 @@ public struct SpeechRecognitionAlternative: Decodable {
      the word followed by its start and end time in seconds. Example: `[["hello",0.0,1.2],["world",1.2,2.5]]`. Returned
      only for the best alternative.
      */
-    public var timestamps: [WordTimestamp]?
+    public var timestamps: [String]?
 
     /**
      A confidence score for each word of the transcript as a list of lists. Each inner list consists of two elements:
      the word and its confidence score in the range of 0 to 1. Example: `[["hello",0.95],["world",0.866]]`. Returned
      only for the best alternative and only with results marked as final.
      */
-    public var wordConfidence: [WordConfidence]?
+    public var wordConfidence: [String]?
 
     // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {

--- a/Source/SpeechToTextV1/Models/SpeechRecognitionAlternative.swift
+++ b/Source/SpeechToTextV1/Models/SpeechRecognitionAlternative.swift
@@ -35,14 +35,14 @@ public struct SpeechRecognitionAlternative: Decodable {
      the word followed by its start and end time in seconds. Example: `[["hello",0.0,1.2],["world",1.2,2.5]]`. Returned
      only for the best alternative.
      */
-    public var timestamps: [String]?
+    public var timestamps: [WordTimestamp]?
 
     /**
      A confidence score for each word of the transcript as a list of lists. Each inner list consists of two elements:
      the word and its confidence score in the range of 0 to 1. Example: `[["hello",0.95],["world",0.866]]`. Returned
      only for the best alternative and only with results marked as final.
      */
-    public var wordConfidence: [String]?
+    public var wordConfidence: [WordConfidence]?
 
     // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -62,12 +62,18 @@ public class SpeechToText {
     /// The base URL to use when contacting the service.
     public var serviceURL = "https://stream.watsonplatform.net/speech-to-text/api"
 
+    /// The URL that shall be used to obtain a token.
+    public var tokenURL = "https://stream.watsonplatform.net/authorization/api/v1/token"
+
+    /// The URL that shall be used to stream audio for transcription.
+    public var websocketsURL = "wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize"
+
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
-    private let session = URLSession(configuration: URLSessionConfiguration.default)
-    private var authMethod: AuthenticationMethod
-    private let domain = "com.ibm.watson.developer-cloud.SpeechToTextV1"
+    internal let session = URLSession(configuration: URLSessionConfiguration.default)
+    internal var authMethod: AuthenticationMethod
+    internal let domain = "com.ibm.watson.developer-cloud.SpeechToTextV1"
 
     /**
      Create a `SpeechToText` object.
@@ -117,6 +123,12 @@ public class SpeechToText {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
+            if case let .some(.string(description)) = json["code_description"] {
+                userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -329,13 +341,13 @@ public class SpeechToText {
      - parameter success: A function executed with the successful result.
      */
     public func recognizeSessionless(
-        audio: Data,
-        contentType: String,
         model: String? = nil,
         customizationID: String? = nil,
         acousticCustomizationID: String? = nil,
         baseModelVersion: String? = nil,
         customizationWeight: Double? = nil,
+        audio: Data? = nil,
+        contentType: String? = nil,
         inactivityTimeout: Int? = nil,
         keywords: [String]? = nil,
         keywordsThreshold: Double? = nil,
@@ -1515,6 +1527,7 @@ public class SpeechToText {
        audio resource with the same name. If `false` (the default), the request fails if a corpus or audio resource with
        the same name already exists. The parameter has no effect if a corpus or audio resource with the same name does
        not already exist.
+     - parameter corpusFileContentType: The content type of corpusFile.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1524,6 +1537,7 @@ public class SpeechToText {
         corpusName: String,
         corpusFile: URL,
         allowOverwrite: Bool? = nil,
+        corpusFileContentType: String? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping () -> Void)
@@ -2646,7 +2660,7 @@ public class SpeechToText {
     public func addAudio(
         customizationID: String,
         audioName: String,
-        audioResource: [Data],
+        audioResource: Data,
         contentType: String,
         containedContentType: String? = nil,
         allowOverwrite: Bool? = nil,
@@ -2655,10 +2669,7 @@ public class SpeechToText {
         success: @escaping () -> Void)
     {
         // construct body
-        guard let body = try? JSONEncoder().encode(audioResource) else {
-            failure?(RestError.serializationError)
-            return
-        }
+        let body = audioResource
 
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/TextToSpeechV1/Models/CreateVoiceModel.swift
+++ b/Source/TextToSpeechV1/Models/CreateVoiceModel.swift
@@ -61,7 +61,8 @@ internal struct CreateVoiceModel: Encodable {
      Initialize a `CreateVoiceModel` with member variables.
 
      - parameter name: The name of the new custom voice model.
-     - parameter language: The language of the new custom voice model. Omit the parameter to use the the default language, `en-US`.
+     - parameter language: The language of the new custom voice model. Omit the parameter to use the the default
+       language, `en-US`.
      - parameter description: A description of the new custom voice model. Specifying a description is recommended.
 
      - returns: An initialized `CreateVoiceModel`.

--- a/Source/TextToSpeechV1/Models/Translation.swift
+++ b/Source/TextToSpeechV1/Models/Translation.swift
@@ -69,13 +69,13 @@ public struct Translation: Codable {
     /**
      Initialize a `Translation` with member variables.
 
-     - parameter translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on the SSML format for
-       representing the phonetic string of a word either as an IPA translation or as an IBM SPR translation. A
-       sounds-like is one or more words that, when combined, sound like the word.
-     - parameter partOfSpeech: **Japanese only.** The part of speech for the word. The service uses the value to produce the correct intonation
-       for the word. You can create only a single entry, with or without a single part of speech, for any word; you
-       cannot create multiple entries with different parts of speech for the same word. For more information, see
-       [Working with Japanese
+     - parameter translation: The phonetic or sounds-like translation for the word. A phonetic translation is based
+       on the SSML format for representing the phonetic string of a word either as an IPA translation or as an IBM SPR
+       translation. A sounds-like is one or more words that, when combined, sound like the word.
+     - parameter partOfSpeech: **Japanese only.** The part of speech for the word. The service uses the value to
+       produce the correct intonation for the word. You can create only a single entry, with or without a single part of
+       speech, for any word; you cannot create multiple entries with different parts of speech for the same word. For
+       more information, see [Working with Japanese
        entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
 
      - returns: An initialized `Translation`.

--- a/Source/TextToSpeechV1/Models/UpdateVoiceModel.swift
+++ b/Source/TextToSpeechV1/Models/UpdateVoiceModel.swift
@@ -47,8 +47,8 @@ internal struct UpdateVoiceModel: Encodable {
 
      - parameter name: A new name for the custom voice model.
      - parameter description: A new description for the custom voice model.
-     - parameter words: An array of `Word` objects that provides the words and their translations that are to be added or updated for the
-       custom voice model. Pass an empty array to make no additions or updates.
+     - parameter words: An array of `Word` objects that provides the words and their translations that are to be
+       added or updated for the custom voice model. Pass an empty array to make no additions or updates.
 
      - returns: An initialized `UpdateVoiceModel`.
     */

--- a/Source/TextToSpeechV1/Models/Word.swift
+++ b/Source/TextToSpeechV1/Models/Word.swift
@@ -76,13 +76,13 @@ public struct Word: Codable {
      Initialize a `Word` with member variables.
 
      - parameter word: A word from the custom voice model.
-     - parameter translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on the SSML format for
-       representing the phonetic string of a word either as an IPA or IBM SPR translation. A sounds-like translation
-       consists of one or more words that, when combined, sound like the word.
-     - parameter partOfSpeech: **Japanese only.** The part of speech for the word. The service uses the value to produce the correct intonation
-       for the word. You can create only a single entry, with or without a single part of speech, for any word; you
-       cannot create multiple entries with different parts of speech for the same word. For more information, see
-       [Working with Japanese
+     - parameter translation: The phonetic or sounds-like translation for the word. A phonetic translation is based
+       on the SSML format for representing the phonetic string of a word either as an IPA or IBM SPR translation. A
+       sounds-like translation consists of one or more words that, when combined, sound like the word.
+     - parameter partOfSpeech: **Japanese only.** The part of speech for the word. The service uses the value to
+       produce the correct intonation for the word. You can create only a single entry, with or without a single part of
+       speech, for any word; you cannot create multiple entries with different parts of speech for the same word. For
+       more information, see [Working with Japanese
        entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
 
      - returns: An initialized `Word`.

--- a/Source/TextToSpeechV1/Models/Words.swift
+++ b/Source/TextToSpeechV1/Models/Words.swift
@@ -36,8 +36,8 @@ public struct Words: Codable {
     /**
      Initialize a `Words` with member variables.
 
-     - parameter words: The **Add custom words** method accepts an array of `Word` objects. Each object provides a word that is to be
-       added or updated for the custom voice model and the word's translation.
+     - parameter words: The **Add custom words** method accepts an array of `Word` objects. Each object provides a
+       word that is to be added or updated for the custom voice model and the word's translation.
        The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation
        from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before
        lowercase letters. The array is empty if the custom model contains no words.

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -115,12 +115,6 @@ public class TextToSpeech {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
-            if case let .some(.string(description)) = json["code_description"] {
-                userInfo[NSLocalizedFailureReasonErrorKey] = description
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -177,9 +171,9 @@ public class TextToSpeech {
      voice. To list information about all available voices, use the **List voices** method.
 
      - parameter voice: The voice for which information is to be returned.
-     - parameter customizationID: The customization ID (GUID) of a custom voice model for which information is to be returned. You must make the
-       request with service credentials created for the instance of the service that owns the custom model. Omit the
-       parameter to see information about the specified voice with no customization.
+     - parameter customizationID: The customization ID (GUID) of a custom voice model for which information is to be
+       returned. You must make the request with service credentials created for the instance of the service that owns
+       the custom model. Omit the parameter to see information about the specified voice with no customization.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -245,16 +239,16 @@ public class TextToSpeech {
      a list of the form `\"invalid_arg_1, invalid_arg_2.\"` The request succeeds despite the warnings.
 
      - parameter text: The text to synthesize.
-     - parameter accept: The requested audio format (MIME type) of the audio. You can use the `Accept` header or the `accept` query
-       parameter to specify the audio format. (For the `audio/l16` format, you can optionally specify
+     - parameter accept: The requested audio format (MIME type) of the audio. You can use the `Accept` header or the
+       `accept` query parameter to specify the audio format. (For the `audio/l16` format, you can optionally specify
        `endianness=big-endian` or `endianness=little-endian`; the default is little endian.) For detailed information
        about the supported audio formats and sampling rates, see [Specifying an audio
        format](https://console.bluemix.net/docs/services/text-to-speech/http.html#format).
      - parameter voice: The voice to use for synthesis.
-     - parameter customizationID: The customization ID (GUID) of a custom voice model to use for the synthesis. If a custom voice model is
-       specified, it is guaranteed to work only if it matches the language of the indicated voice. You must make the
-       request with service credentials created for the instance of the service that owns the custom model. Omit the
-       parameter to use the specified voice with no customization.
+     - parameter customizationID: The customization ID (GUID) of a custom voice model to use for the synthesis. If a
+       custom voice model is specified, it is guaranteed to work only if it matches the language of the indicated voice.
+       You must make the request with service credentials created for the instance of the service that owns the custom
+       model. Omit the parameter to use the specified voice with no customization.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -266,7 +260,7 @@ public class TextToSpeech {
         customizationID: String? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
-        success: @escaping (Data) -> Void)
+        success: @escaping (URL) -> Void)
     {
         // construct body
         let synthesizeRequest = Text(text: text)
@@ -309,38 +303,11 @@ public class TextToSpeech {
         )
 
         // execute REST request
-        request.responseData {
-            (response: RestResponse<Data>) in
+        request.responseObject {
+            (response: RestResponse<URL>) in
             switch response.result {
-            case .success(let data):
-                if accept?.lowercased().contains("audio/wav") == true {
-                    // repair the WAV header
-                    var wav = data
-                    guard WAVRepair.isWAVFile(data: wav) else {
-                        let failureReason = "Returned audio is in an unexpected format."
-                        let userInfo = [NSLocalizedDescriptionKey: failureReason]
-                        let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
-                        failure?(error)
-                        return
-                    }
-                    WAVRepair.repairWAVHeader(data: &wav)
-                    success(wav)
-                } else if accept?.lowercased().contains("ogg") == true && accept?.lowercased().contains("opus") == true {
-                    do {
-                        let decodedAudio = try TextToSpeechDecoder(audioData: data)
-                        success(decodedAudio.pcmDataWithHeaders)
-                    } catch {
-                        let failureReason = "Returned audio is in an unexpected format."
-                        let userInfo = [NSLocalizedDescriptionKey: failureReason]
-                        let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
-                        failure?(error)
-                        return
-                    }
-                } else {
-                    success(data)
-                }
-            case .failure(let error):
-                failure?(error)
+            case .success(let retval): success(retval)
+            case .failure(let error): failure?(error)
             }
         }
     }
@@ -354,15 +321,15 @@ public class TextToSpeech {
      **Note:** This method is currently a beta release.
 
      - parameter text: The word for which the pronunciation is requested.
-     - parameter voice: A voice that specifies the language in which the pronunciation is to be returned. All voices for the same
-       language (for example, `en-US`) return the same translation.
-     - parameter format: The phoneme format in which to return the pronunciation. Omit the parameter to obtain the pronunciation in the
-       default format.
-     - parameter customizationID: The customization ID (GUID) of a custom voice model for which the pronunciation is to be returned. The language
-       of a specified custom model must match the language of the specified voice. If the word is not defined in the
-       specified custom model, the service returns the default translation for the custom model's language. You must
-       make the request with service credentials created for the instance of the service that owns the custom model.
-       Omit the parameter to see the translation for the specified voice with no customization.
+     - parameter voice: A voice that specifies the language in which the pronunciation is to be returned. All voices
+       for the same language (for example, `en-US`) return the same translation.
+     - parameter format: The phoneme format in which to return the pronunciation. Omit the parameter to obtain the
+       pronunciation in the default format.
+     - parameter customizationID: The customization ID (GUID) of a custom voice model for which the pronunciation is
+       to be returned. The language of a specified custom model must match the language of the specified voice. If the
+       word is not defined in the specified custom model, the service returns the default translation for the custom
+       model's language. You must make the request with service credentials created for the instance of the service that
+       owns the custom model. Omit the parameter to see the translation for the specified voice with no customization.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -429,7 +396,8 @@ public class TextToSpeech {
      **Note:** This method is currently a beta release.
 
      - parameter name: The name of the new custom voice model.
-     - parameter language: The language of the new custom voice model. Omit the parameter to use the the default language, `en-US`.
+     - parameter language: The language of the new custom voice model. Omit the parameter to use the the default
+       language, `en-US`.
      - parameter description: A description of the new custom voice model. Specifying a description is recommended.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -488,8 +456,9 @@ public class TextToSpeech {
      instance of the service that owns a model to list information about it.
      **Note:** This method is currently a beta release.
 
-     - parameter language: The language for which custom voice models that are owned by the requesting service credentials are to be
-       returned. Omit the parameter to see all custom voice models that are owned by the requester.
+     - parameter language: The language for which custom voice models that are owned by the requesting service
+       credentials are to be returned. Omit the parameter to see all custom voice models that are owned by the
+       requester.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -545,12 +514,12 @@ public class TextToSpeech {
      it.
      **Note:** This method is currently a beta release.
 
-     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-       for the instance of the service that owns the custom model.
+     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
+       with service credentials created for the instance of the service that owns the custom model.
      - parameter name: A new name for the custom voice model.
      - parameter description: A new description for the custom voice model.
-     - parameter words: An array of `Word` objects that provides the words and their translations that are to be added or updated for the
-       custom voice model. Pass an empty array to make no additions or updates.
+     - parameter words: An array of `Word` objects that provides the words and their translations that are to be added
+       or updated for the custom voice model. Pass an empty array to make no additions or updates.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -613,8 +582,8 @@ public class TextToSpeech {
      metadata for a voice model, use the **List custom models** method.
      **Note:** This method is currently a beta release.
 
-     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-       for the instance of the service that owns the custom model.
+     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
+       with service credentials created for the instance of the service that owns the custom model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -664,8 +633,8 @@ public class TextToSpeech {
      model to delete it.
      **Note:** This method is currently a beta release.
 
-     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-       for the instance of the service that owns the custom model.
+     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
+       with service credentials created for the instance of the service that owns the custom model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -716,10 +685,10 @@ public class TextToSpeech {
      words to it.
      **Note:** This method is currently a beta release.
 
-     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-       for the instance of the service that owns the custom model.
-     - parameter words: The **Add custom words** method accepts an array of `Word` objects. Each object provides a word that is to be
-       added or updated for the custom voice model and the word's translation.
+     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
+       with service credentials created for the instance of the service that owns the custom model.
+     - parameter words: The **Add custom words** method accepts an array of `Word` objects. Each object provides a
+       word that is to be added or updated for the custom voice model and the word's translation.
        The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation
        from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before
        lowercase letters. The array is empty if the custom model contains no words.
@@ -783,8 +752,8 @@ public class TextToSpeech {
      model to list its words.
      **Note:** This method is currently a beta release.
 
-     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-       for the instance of the service that owns the custom model.
+     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
+       with service credentials created for the instance of the service that owns the custom model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -836,16 +805,16 @@ public class TextToSpeech {
      to it.
      **Note:** This method is currently a beta release.
 
-     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-       for the instance of the service that owns the custom model.
+     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
+       with service credentials created for the instance of the service that owns the custom model.
      - parameter word: The word that is to be added or updated for the custom voice model.
-     - parameter translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on the SSML format for
-       representing the phonetic string of a word either as an IPA translation or as an IBM SPR translation. A
-       sounds-like is one or more words that, when combined, sound like the word.
-     - parameter partOfSpeech: **Japanese only.** The part of speech for the word. The service uses the value to produce the correct intonation
-       for the word. You can create only a single entry, with or without a single part of speech, for any word; you
-       cannot create multiple entries with different parts of speech for the same word. For more information, see
-       [Working with Japanese
+     - parameter translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on
+       the SSML format for representing the phonetic string of a word either as an IPA translation or as an IBM SPR
+       translation. A sounds-like is one or more words that, when combined, sound like the word.
+     - parameter partOfSpeech: **Japanese only.** The part of speech for the word. The service uses the value to
+       produce the correct intonation for the word. You can create only a single entry, with or without a single part of
+       speech, for any word; you cannot create multiple entries with different parts of speech for the same word. For
+       more information, see [Working with Japanese
        entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -907,8 +876,8 @@ public class TextToSpeech {
      defined in the model. You must use credentials for the instance of the service that owns a model to list its words.
      **Note:** This method is currently a beta release.
 
-     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-       for the instance of the service that owns the custom model.
+     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
+       with service credentials created for the instance of the service that owns the custom model.
      - parameter word: The word that is to be queried from the custom voice model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -960,8 +929,8 @@ public class TextToSpeech {
      service that owns a model to delete its words.
      **Note:** This method is currently a beta release.
 
-     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-       for the instance of the service that owns the custom model.
+     - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
+       with service credentials created for the instance of the service that owns the custom model.
      - parameter word: The word that is to be deleted from the custom voice model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.

--- a/Source/ToneAnalyzerV3/Models/ToneChatInput.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneChatInput.swift
@@ -32,7 +32,8 @@ internal struct ToneChatInput: Encodable {
     /**
      Initialize a `ToneChatInput` with member variables.
 
-     - parameter utterances: An array of `Utterance` objects that provides the input content that the service is to analyze.
+     - parameter utterances: An array of `Utterance` objects that provides the input content that the service is to
+       analyze.
 
      - returns: An initialized `ToneChatInput`.
     */

--- a/Source/ToneAnalyzerV3/Models/ToneContent.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneContent.swift
@@ -1,0 +1,45 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/**
+ JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type
+ `ToneInput`.
+ */
+public enum ToneContent {
+
+    case toneInput(ToneInput)
+    case text(String)
+    case html(String)
+
+    internal var contentType: String {
+        switch self {
+        case .toneInput: return "application/json"
+        case .text: return "text/plain"
+        case .html: return "text/html"
+        }
+    }
+
+    internal var content: Data? {
+        switch self {
+        case .toneInput(let toneInput): return try? JSONEncoder().encode(toneInput)
+        case .text(let text): return text.data(using: .utf8)
+        case .html(let html): return html.data(using: .utf8)
+        }
+    }
+
+}

--- a/Source/ToneAnalyzerV3/Models/Utterance.swift
+++ b/Source/ToneAnalyzerV3/Models/Utterance.swift
@@ -39,9 +39,10 @@ public struct Utterance: Encodable {
     /**
      Initialize a `Utterance` with member variables.
 
-     - parameter text: An utterance contributed by a user in the conversation that is to be analyzed. The utterance can contain multiple
-       sentences.
-     - parameter user: A string that identifies the user who contributed the utterance specified by the `text` parameter.
+     - parameter text: An utterance contributed by a user in the conversation that is to be analyzed. The utterance
+       can contain multiple sentences.
+     - parameter user: A string that identifies the user who contributed the utterance specified by the `text`
+       parameter.
 
      - returns: An initialized `Utterance`.
     */

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -96,6 +96,9 @@ public class ToneAnalyzer {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -284,6 +287,55 @@ public class ToneAnalyzer {
             case .failure(let error): failure?(error)
             }
         }
+    }
+
+}
+
+extension ToneAnalyzer {
+
+    @available(*, deprecated, message: "This method has been deprecated in favor of the tone method that accepts a toneContent parameter.  This method will be removed in a future release.")
+    public func tone(
+        toneInput: ToneInput,
+        sentences: Bool? = nil,
+        tones: [String]? = nil,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        headers: [String: String]? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (ToneAnalysis) -> Void)
+    {
+        tone(toneContent: .toneInput(toneInput), sentences: sentences, tones: tones, contentLanguage: contentLanguage,
+             acceptLanguage: acceptLanguage, headers: headers, failure: failure, success: success)
+    }
+
+    @available(*, deprecated, message: "This method has been deprecated in favor of the tone method that accepts a toneContent parameter.  This method will be removed in a future release.")
+    public func tone(
+        text: String,
+        sentences: Bool? = nil,
+        tones: [String]? = nil,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        headers: [String: String]? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (ToneAnalysis) -> Void)
+    {
+        tone(toneContent: .text(text), sentences: sentences, tones: tones, contentLanguage: contentLanguage,
+             acceptLanguage: acceptLanguage, headers: headers, failure: failure, success: success)
+    }
+
+    @available(*, deprecated, message: "This method has been deprecated in favor of the tone method that accepts a toneContent parameter.  This method will be removed in a future release.")
+    public func tone(
+        html: String,
+        sentences: Bool? = nil,
+        tones: [String]? = nil,
+        contentLanguage: String? = nil,
+        acceptLanguage: String? = nil,
+        headers: [String: String]? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (ToneAnalysis) -> Void)
+    {
+        tone(toneContent: .html(html), sentences: sentences, tones: tones, contentLanguage: contentLanguage,
+             acceptLanguage: acceptLanguage, headers: headers, failure: failure, success: success)
     }
 
 }

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -96,9 +96,6 @@ public class ToneAnalyzer {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -120,29 +117,31 @@ public class ToneAnalyzer {
      character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the
      service removes HTML tags and analyzes only the textual content.
 
-     - parameter toneInput: A `ToneInput` object that contains the content to be analyzed.
-     - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of
-       the full document. If `true` (the default), the service returns results for each sentence.
-     - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the
-       parameter no longer affects the response.
+     - parameter toneContent: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON
+       input, provide an object of type `ToneInput`.
+     - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in
+       addition to its analysis of the full document. If `true` (the default), the service returns results for each
+       sentence.
+     - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for
+       backward-compatibility, but the parameter no longer affects the response.
        **`2016-05-19`:** A comma-separated list of tones for which the service is to return its analysis of the input;
        the indicated tones apply both to the full document and to individual sentences of the document. You can specify
        one or more of the valid values. Omit the parameter to request results for all three tones.
-     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent
-       language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do
-       not submit content that contains both languages. You can use different languages for **Content-Language** and
-       **Accept-Language**.
+     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants
+       are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match
+       the specified language. Do not submit content that contains both languages. You can use different languages for
+       **Content-Language** and **Accept-Language**.
        * **`2017-09-21`:** Accepts `en` or `fr`.
        * **`2016-05-19`:** Accepts only `en`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-       language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language**
-       and **Accept-Language**.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants
+       are treated as their parent language; for example, `en-US` is interpreted as `en`. You can use different
+       languages for **Content-Language** and **Accept-Language**.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
     public func tone(
-        toneInput: ToneInput,
+        toneContent: ToneContent,
         sentences: Bool? = nil,
         tones: [String]? = nil,
         contentLanguage: String? = nil,
@@ -152,7 +151,7 @@ public class ToneAnalyzer {
         success: @escaping (ToneAnalysis) -> Void)
     {
         // construct body
-        guard let body = try? JSONEncoder().encode(toneInput) else {
+        guard let body = toneContent.content else {
             failure?(RestError.serializationError)
             return
         }
@@ -163,207 +162,7 @@ public class ToneAnalyzer {
             headerParameters.merge(headers) { (_, new) in new }
         }
         headerParameters["Accept"] = "application/json"
-        headerParameters["Content-Type"] = "application/json"
-        if let contentLanguage = contentLanguage {
-            headerParameters["Content-Language"] = contentLanguage
-        }
-        if let acceptLanguage = acceptLanguage {
-            headerParameters["Accept-Language"] = acceptLanguage
-        }
-
-        // construct query parameters
-        var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "version", value: version))
-        if let sentences = sentences {
-            let queryParameter = URLQueryItem(name: "sentences", value: "\(sentences)")
-            queryParameters.append(queryParameter)
-        }
-        if let tones = tones {
-            let queryParameter = URLQueryItem(name: "tones", value: tones.joined(separator: ","))
-            queryParameters.append(queryParameter)
-        }
-
-        // construct REST request
-        let request = RestRequest(
-            session: session,
-            authMethod: authMethod,
-            errorResponseDecoder: errorResponseDecoder,
-            method: "POST",
-            url: serviceURL + "/v3/tone",
-            headerParameters: headerParameters,
-            queryItems: queryParameters,
-            messageBody: body
-        )
-
-        // execute REST request
-        request.responseObject {
-            (response: RestResponse<ToneAnalysis>) in
-            switch response.result {
-            case .success(let retval): success(retval)
-            case .failure(let error): failure?(error)
-            }
-        }
-    }
-
-    /**
-     Analyze general tone.
-
-     Use the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for
-     emotional and language tones. The method always analyzes the tone of the full document; by default, it also
-     analyzes the tone of each individual sentence of the content.
-     You can submit no more than 128 KB of total input content and no more than 1000 individual sentences in JSON, plain
-     text, or HTML format. The service analyzes the first 1000 sentences for document-level analysis and only the first
-     100 sentences for sentence-level analysis.
-     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the
-     HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
-     set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
-     character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the
-     service removes HTML tags and analyzes only the textual content.
-
-     - parameter text: plain text input that contains the content to be analyzed.
-     - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of
-     the full document. If `true` (the default), the service returns results for each sentence.
-     - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the
-     parameter no longer affects the response.
-     **`2016-05-19`:** A comma-separated list of tones for which the service is to return its analysis of the input;
-     the indicated tones apply both to the full document and to individual sentences of the document. You can specify
-     one or more of the valid values. Omit the parameter to request results for all three tones.
-     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent
-     language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do
-     not submit content that contains both languages. You can use different languages for **Content-Language** and
-     **Accept-Language**.
-     * **`2017-09-21`:** Accepts `en` or `fr`.
-     * **`2016-05-19`:** Accepts only `en`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-     language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language**
-     and **Accept-Language**.
-     - parameter headers: A dictionary of request headers to be sent with this request.
-     - parameter failure: A function executed if an error occurs.
-     - parameter success: A function executed with the successful result.
-     */
-    public func tone(
-        text: String,
-        sentences: Bool? = nil,
-        tones: [String]? = nil,
-        contentLanguage: String? = nil,
-        acceptLanguage: String? = nil,
-        headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (ToneAnalysis) -> Void)
-    {
-        // construct body
-        guard let body = text.data(using: .utf8) else {
-            failure?(RestError.serializationError)
-            return
-        }
-
-        // construct header parameters
-        var headerParameters = defaultHeaders
-        if let headers = headers {
-            headerParameters.merge(headers) { (_, new) in new }
-        }
-        headerParameters["Accept"] = "application/json"
-        headerParameters["Content-Type"] = "text/plain"
-        if let contentLanguage = contentLanguage {
-            headerParameters["Content-Language"] = contentLanguage
-        }
-        if let acceptLanguage = acceptLanguage {
-            headerParameters["Accept-Language"] = acceptLanguage
-        }
-
-        // construct query parameters
-        var queryParameters = [URLQueryItem]()
-        queryParameters.append(URLQueryItem(name: "version", value: version))
-        if let sentences = sentences {
-            let queryParameter = URLQueryItem(name: "sentences", value: "\(sentences)")
-            queryParameters.append(queryParameter)
-        }
-        if let tones = tones {
-            let queryParameter = URLQueryItem(name: "tones", value: tones.joined(separator: ","))
-            queryParameters.append(queryParameter)
-        }
-
-        // construct REST request
-        let request = RestRequest(
-            session: session,
-            authMethod: authMethod,
-            errorResponseDecoder: errorResponseDecoder,
-            method: "POST",
-            url: serviceURL + "/v3/tone",
-            headerParameters: headerParameters,
-            queryItems: queryParameters,
-            messageBody: body
-        )
-
-        // execute REST request
-        request.responseObject {
-            (response: RestResponse<ToneAnalysis>) in
-            switch response.result {
-            case .success(let retval): success(retval)
-            case .failure(let error): failure?(error)
-            }
-        }
-    }
-
-    /**
-     Analyze general tone.
-
-     Use the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for
-     emotional and language tones. The method always analyzes the tone of the full document; by default, it also
-     analyzes the tone of each individual sentence of the content.
-     You can submit no more than 128 KB of total input content and no more than 1000 individual sentences in JSON, plain
-     text, or HTML format. The service analyzes the first 1000 sentences for document-level analysis and only the first
-     100 sentences for sentence-level analysis.
-     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the
-     HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
-     set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
-     character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the
-     service removes HTML tags and analyzes only the textual content.
-
-     - parameter html: HTML input that contains the content to be analyzed.
-     - parameter sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of
-     the full document. If `true` (the default), the service returns results for each sentence.
-     - parameter tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the
-     parameter no longer affects the response.
-     **`2016-05-19`:** A comma-separated list of tones for which the service is to return its analysis of the input;
-     the indicated tones apply both to the full document and to individual sentences of the document. You can specify
-     one or more of the valid values. Omit the parameter to request results for all three tones.
-     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent
-     language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do
-     not submit content that contains both languages. You can use different languages for **Content-Language** and
-     **Accept-Language**.
-     * **`2017-09-21`:** Accepts `en` or `fr`.
-     * **`2016-05-19`:** Accepts only `en`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-     language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language**
-     and **Accept-Language**.
-     - parameter headers: A dictionary of request headers to be sent with this request.
-     - parameter failure: A function executed if an error occurs.
-     - parameter success: A function executed with the successful result.
-     */
-    public func tone(
-        html: String,
-        sentences: Bool? = nil,
-        tones: [String]? = nil,
-        contentLanguage: String? = nil,
-        acceptLanguage: String? = nil,
-        headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (ToneAnalysis) -> Void)
-    {
-        // construct body
-        guard let body = html.data(using: .utf8) else {
-            failure?(RestError.serializationError)
-            return
-        }
-
-        // construct header parameters
-        var headerParameters = defaultHeaders
-        if let headers = headers {
-            headerParameters.merge(headers) { (_, new) in new }
-        }
-        headerParameters["Accept"] = "application/json"
-        headerParameters["Content-Type"] = "text/html"
+        headerParameters["Content-Type"] = toneContent.contentType
         if let contentLanguage = contentLanguage {
             headerParameters["Content-Language"] = contentLanguage
         }
@@ -417,16 +216,17 @@ public class ToneAnalyzer {
      500 characters.
      Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8.
 
-     - parameter utterances: An array of `Utterance` objects that provides the input content that the service is to analyze.
-     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants are treated as their parent
-       language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do
-       not submit content that contains both languages. You can use different languages for **Content-Language** and
-       **Accept-Language**.
+     - parameter utterances: An array of `Utterance` objects that provides the input content that the service is to
+       analyze.
+     - parameter contentLanguage: The language of the input text for the request: English or French. Regional variants
+       are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match
+       the specified language. Do not submit content that contains both languages. You can use different languages for
+       **Content-Language** and **Accept-Language**.
        * **`2017-09-21`:** Accepts `en` or `fr`.
        * **`2016-05-19`:** Accepts only `en`.
-     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants are treated as their parent
-       language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language**
-       and **Accept-Language**.
+     - parameter acceptLanguage: The desired language of the response. For two-character arguments, regional variants
+       are treated as their parent language; for example, `en-US` is interpreted as `en`. You can use different
+       languages for **Content-Language** and **Accept-Language**.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.

--- a/Source/VisualRecognitionV3/Models/Class.swift
+++ b/Source/VisualRecognitionV3/Models/Class.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A category within a classifier. */
+/**
+ A category within a classifier.
+ */
 public struct Class: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/ClassResult.swift
+++ b/Source/VisualRecognitionV3/Models/ClassResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Result of a class within a classifier. */
+/**
+ Result of a class within a classifier.
+ */
 public struct ClassResult: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/ClassifiedImage.swift
+++ b/Source/VisualRecognitionV3/Models/ClassifiedImage.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Results for one image. */
+/**
+ Results for one image.
+ */
 public struct ClassifiedImage: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/ClassifiedImages.swift
+++ b/Source/VisualRecognitionV3/Models/ClassifiedImages.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Results for all images. */
+/**
+ Results for all images.
+ */
 public struct ClassifiedImages: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/Classifier.swift
+++ b/Source/VisualRecognitionV3/Models/Classifier.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Information about a classifier. */
+/**
+ Information about a classifier.
+ */
 public struct Classifier: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/ClassifierResult.swift
+++ b/Source/VisualRecognitionV3/Models/ClassifierResult.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Classifier and score combination. */
+/**
+ Classifier and score combination.
+ */
 public struct ClassifierResult: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/Classifiers.swift
+++ b/Source/VisualRecognitionV3/Models/Classifiers.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** A container for the list of classifiers. */
+/**
+ A container for the list of classifiers.
+ */
 public struct Classifiers: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/DetectedFaces.swift
+++ b/Source/VisualRecognitionV3/Models/DetectedFaces.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Results for all faces. */
+/**
+ Results for all faces.
+ */
 public struct DetectedFaces: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/ErrorInfo.swift
+++ b/Source/VisualRecognitionV3/Models/ErrorInfo.swift
@@ -16,7 +16,10 @@
 
 import Foundation
 
-/** Information about what might have caused a failure, such as an image that is too large. Not returned when there is no error. */
+/**
+ Information about what might have caused a failure, such as an image that is too large. Not returned when there is no
+ error.
+ */
 public struct ErrorInfo: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/Face.swift
+++ b/Source/VisualRecognitionV3/Models/Face.swift
@@ -36,6 +36,9 @@ public struct Face: Decodable {
      */
     public var faceLocation: FaceLocation?
 
+    /** deprecated */
+    public var identity: FaceIdentity?
+
     // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case age = "age"

--- a/Source/VisualRecognitionV3/Models/Face.swift
+++ b/Source/VisualRecognitionV3/Models/Face.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Information about the face. */
+/**
+ Information about the face.
+ */
 public struct Face: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/FaceAge.swift
+++ b/Source/VisualRecognitionV3/Models/FaceAge.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Age information about a face. */
+/**
+ Age information about a face.
+ */
 public struct FaceAge: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/FaceGender.swift
+++ b/Source/VisualRecognitionV3/Models/FaceGender.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Information about the gender of the face. */
+/**
+ Information about the gender of the face.
+ */
 public struct FaceGender: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/FaceIdentity.swift
+++ b/Source/VisualRecognitionV3/Models/FaceIdentity.swift
@@ -22,7 +22,8 @@ public struct FaceIdentity {
     /// Name of the person.
     public var name: String
 
-    /// Confidence score for the property in the range of 0 to 1. A higher score indicates greater likelihood that the class is depicted in the image. The default threshold for returning scores from a classifier is 0.5.
+    /// Confidence score for the property in the range of 0 to 1. A higher score indicates greater likelihood that the
+    /// class is depicted in the image. The default threshold for returning scores from a classifier is 0.5.
     public var score: Double?
 
     /// Knowledge graph of the property. For example, `People/Leaders/Presidents/USA/Barack Obama`. Included only if identified.
@@ -32,8 +33,10 @@ public struct FaceIdentity {
      Initialize a `FaceIdentity` with member variables.
 
      - parameter name: Name of the person.
-     - parameter score: Confidence score for the property in the range of 0 to 1. A higher score indicates greater likelihood that the class is depicted in the image. The default threshold for returning scores from a classifier is 0.5.
-     - parameter typeHierarchy: Knowledge graph of the property. For example, `People/Leaders/Presidents/USA/Barack Obama`. Included only if identified.
+     - parameter score: Confidence score for the property in the range of 0 to 1. A higher score indicates greater likelihood
+       that the class is depicted in the image. The default threshold for returning scores from a classifier is 0.5.
+     - parameter typeHierarchy: Knowledge graph of the property. For example, `People/Leaders/Presidents/USA/Barack Obama`.
+       Included only if identified.
 
      - returns: An initialized `FaceIdentity`.
     */

--- a/Source/VisualRecognitionV3/Models/FaceLocation.swift
+++ b/Source/VisualRecognitionV3/Models/FaceLocation.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** The location of the bounding box around the face. */
+/**
+ The location of the bounding box around the face.
+ */
 public struct FaceLocation: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/ImageWithFaces.swift
+++ b/Source/VisualRecognitionV3/Models/ImageWithFaces.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Information about faces in the image. */
+/**
+ Information about faces in the image.
+ */
 public struct ImageWithFaces: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/Models/WarningInfo.swift
+++ b/Source/VisualRecognitionV3/Models/WarningInfo.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-/** Information about something that went wrong. */
+/**
+ Information about something that went wrong.
+ */
 public struct WarningInfo: Decodable {
 
     /**

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -30,10 +30,10 @@ public class VisualRecognition {
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
-    internal let session = URLSession(configuration: URLSessionConfiguration.default)
-    internal var authMethod: AuthenticationMethod
-    internal let domain = "com.ibm.watson.developer-cloud.VisualRecognitionV3"
-    internal let version: String
+    private let session = URLSession(configuration: URLSessionConfiguration.default)
+    private var authMethod: AuthenticationMethod
+    private let domain = "com.ibm.watson.developer-cloud.VisualRecognitionV3"
+    private let version: String
 
     /**
      Create a `VisualRecognition` object.
@@ -45,7 +45,6 @@ public class VisualRecognition {
     public init(apiKey: String, version: String) {
         self.authMethod = APIKeyAuthentication(name: "api_key", key: apiKey, location: .query)
         self.version = version
-        self.serviceURL = "https://gateway-a.watsonplatform.net/visual-recognition/api"
     }
 
     /**
@@ -86,36 +85,12 @@ public class VisualRecognition {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    internal func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if code == 403 {
-                // ErrorAuthentication
-                if case let .some(.string(status)) = json["status"],
-                    case let .some(.string(statusInfo)) = json["statusInfo"] {
-                    userInfo[NSLocalizedDescriptionKey] = "\(status): \(statusInfo)"
-                }
-            } else if code == 404 {
-                // "error": ErrorInfo
-                if case let .some(.object(errorObj)) = json["error"],
-                    case let .some(.string(message)) = errorObj["description"],
-                    case let .some(.string(errorID)) = errorObj["error_id"] {
-                    userInfo[NSLocalizedDescriptionKey] = "\(message) (error_id = \(errorID))"
-                }
-            } else if code == 413 {
-                // ErrorHTML
-                if case let .some(.string(message)) = json["Error"] {
-                    userInfo[NSLocalizedDescriptionKey] = message
-                }
-            } else {
-                // ErrorResponse
-                if case let .some(.string(message)) = json["error"] {
-                    userInfo[NSLocalizedDescriptionKey] = message
-                }
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -127,27 +102,27 @@ public class VisualRecognition {
 
      Classify images with built-in or custom classifiers.
 
-     - parameter imagesFile: An image file (.jpg, .png) or .zip file with images. Maximum image size is 10 MB. Include no more than 20 images
-       and limit the .zip file to 100 MB. Encode the image and .zip file names in UTF-8 if they contain non-ASCII
-       characters. The service assumes UTF-8 encoding if it encounters non-ASCII characters.
+     - parameter imagesFile: An image file (.jpg, .png) or .zip file with images. Maximum image size is 10 MB. Include
+       no more than 20 images and limit the .zip file to 100 MB. Encode the image and .zip file names in UTF-8 if they
+       contain non-ASCII characters. The service assumes UTF-8 encoding if it encounters non-ASCII characters.
        You can also include an image with the **url** parameter.
-     - parameter acceptLanguage: The language of the output class names. The full set of languages is supported only for the built-in `default`
-       classifier ID. The class names of custom classifiers are not translated.
+     - parameter acceptLanguage: The language of the output class names. The full set of languages is supported only
+       for the built-in `default` classifier ID. The class names of custom classifiers are not translated.
        The response might not be in the specified language when the requested language is not supported or when there is
        no translation for the class name.
-     - parameter url: The URL of an image to analyze. Must be in .jpg, or .png format. The minimum recommended pixel density is 32X32
-       pixels per inch, and the maximum image size is 10 MB.
+     - parameter url: The URL of an image to analyze. Must be in .jpg, or .png format. The minimum recommended pixel
+       density is 32X32 pixels per inch, and the maximum image size is 10 MB.
        You can also include images with the **images_file** parameter.
-     - parameter threshold: The minimum score a class must have to be displayed in the response. Set the threshold to `0.0` to ignore the
-       classification score and return all values.
-     - parameter owners: The categories of classifiers to apply. Use `IBM` to classify against the `default` general classifier, and use
-       `me` to classify against your custom classifiers. To analyze the image against both classifier categories, set
-       the value to both `IBM` and `me`.
+     - parameter threshold: The minimum score a class must have to be displayed in the response. Set the threshold to
+       `0.0` to ignore the classification score and return all values.
+     - parameter owners: The categories of classifiers to apply. Use `IBM` to classify against the `default` general
+       classifier, and use `me` to classify against your custom classifiers. To analyze the image against both
+       classifier categories, set the value to both `IBM` and `me`.
        The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.
        The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty.
-     - parameter classifierIDs: Which classifiers to apply. Overrides the **owners** parameter. You can specify both custom and built-in
-       classifier IDs. The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters
-       are empty.
+     - parameter classifierIds: Which classifiers to apply. Overrides the **owners** parameter. You can specify both
+       custom and built-in classifier IDs. The built-in `default` classifier is used if both **classifier_ids** and
+       **owners** parameters are empty.
        The following built-in classifier IDs require no training:
        - `default`: Returns classes from thousands of general tags.
        - `food`: (Beta) Enhances specificity and accuracy for images of food items.
@@ -159,11 +134,12 @@ public class VisualRecognition {
      */
     public func classify(
         imagesFile: URL? = nil,
+        acceptLanguage: String? = nil,
         url: String? = nil,
         threshold: Double? = nil,
         owners: [String]? = nil,
-        classifierIDs: [String]? = nil,
-        acceptLanguage: String? = nil,
+        classifierIds: [String]? = nil,
+        imagesFileContentType: String? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ClassifiedImages) -> Void)
@@ -194,12 +170,12 @@ public class VisualRecognition {
             }
             multipartFormData.append(ownersData, withName: "owners")
         }
-        if let classifierIDs = classifierIDs {
-            guard let classifierIDsData = classifierIDs.joined(separator: ",").data(using: .utf8) else {
+        if let classifierIds = classifierIds {
+            guard let classifierIdsData = classifierIds.joined(separator: ",").data(using: .utf8) else {
                 failure?(RestError.serializationError)
                 return
             }
-            multipartFormData.append(classifierIDsData, withName: "classifier_ids")
+            multipartFormData.append(classifierIdsData, withName: "classifier_ids")
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)
@@ -256,14 +232,14 @@ public class VisualRecognition {
      Supported image formats include .gif, .jpg, .png, and .tif. The maximum image size is 10 MB. The minimum
      recommended pixel density is 32X32 pixels per inch.
 
-     - parameter imagesFile: An image file (gif, .jpg, .png, .tif.) or .zip file with images. Limit the .zip file to 100 MB. You can include a
-       maximum of 15 images in a request.
+     - parameter imagesFile: An image file (gif, .jpg, .png, .tif.) or .zip file with images. Limit the .zip file to
+       100 MB. You can include a maximum of 15 images in a request.
        Encode the image and .zip file names in UTF-8 if they contain non-ASCII characters. The service assumes UTF-8
        encoding if it encounters non-ASCII characters.
        You can also include an image with the **url** parameter.
-     - parameter url: The URL of an image to analyze. Must be in .gif, .jpg, .png, or .tif format. The minimum recommended pixel
-       density is 32X32 pixels per inch, and the maximum image size is 10 MB. Redirects are followed, so you can use a
-       shortened URL.
+     - parameter url: The URL of an image to analyze. Must be in .gif, .jpg, .png, or .tif format. The minimum
+       recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. Redirects are followed,
+       so you can use a shortened URL.
        You can also include images with the **images_file** parameter.
      - parameter imagesFileContentType: The content type of imagesFile.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -273,6 +249,7 @@ public class VisualRecognition {
     public func detectFaces(
         imagesFile: URL? = nil,
         url: String? = nil,
+        imagesFileContentType: String? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (DetectedFaces) -> Void)
@@ -280,7 +257,7 @@ public class VisualRecognition {
         // construct body
         let multipartFormData = MultipartFormData()
         if let imagesFile = imagesFile {
-            multipartFormData.append(imagesFile, withName: "images_file", mimeType: "application/octet-stream")
+            multipartFormData.append(imagesFile, withName: "images_file")
         }
         if let url = url {
             guard let urlData = url.data(using: .utf8) else {
@@ -338,14 +315,15 @@ public class VisualRecognition {
      names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.
 
      - parameter name: The name of the new classifier. Encode special characters in UTF-8.
-     - parameter positiveExamples: An array of of positive examples, each with a name and a compressed
-     (.zip) file of images that depict the visual subject of a class in the new classifier. You can include more than
-       one positive example file in a call.
+     - parameter classnamePositiveExamples: A .zip file of images that depict the visual subject of a class in the new
+       classifier. You can include more than one positive example file in a call.
+       Specify the parameter name by appending `_positive_examples` to the class name. For example,
+       `goldenretriever_positive_examples` creates the class **goldenretriever**.
        Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels. The
        maximum number of images is 10,000 images or 100 MB per .zip file.
        Encode special characters in the file name in UTF-8.
-     - parameter negativeExamples: A .zip file of images that do not depict the visual subject of any of the classes of the new classifier. Must
-       contain a minimum of 10 images.
+     - parameter negativeExamples: A .zip file of images that do not depict the visual subject of any of the classes
+       of the new classifier. Must contain a minimum of 10 images.
        Encode special characters in the file name in UTF-8.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -353,7 +331,7 @@ public class VisualRecognition {
      */
     public func createClassifier(
         name: String,
-        positiveExamples: [PositiveExample],
+        classnamePositiveExamples: URL,
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -366,9 +344,7 @@ public class VisualRecognition {
             return
         }
         multipartFormData.append(nameData, withName: "name")
-        positiveExamples.forEach { example in
-            multipartFormData.append(example.examples, withName: example.name + "_positive_examples")
-        }
+        multipartFormData.append(classnamePositiveExamples, withName: "classname_positive_examples")
         if let negativeExamples = negativeExamples {
             multipartFormData.append(negativeExamples, withName: "negative_examples")
         }
@@ -414,15 +390,13 @@ public class VisualRecognition {
     /**
      Retrieve a list of classifiers.
 
-     - parameter owners: Unused. This parameter will be removed in a future release.
-     - parameter verbose: Specify `true` to return details about the classifiers. Omit this parameter to return a brief list of
-       classifiers.
+     - parameter verbose: Specify `true` to return details about the classifiers. Omit this parameter to return a
+       brief list of classifiers.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
      */
     public func listClassifiers(
-        owners: [String]? = nil,
         verbose: Bool? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -531,14 +505,16 @@ public class VisualRecognition {
      classifier retraining finished.
 
      - parameter classifierID: The ID of the classifier.
-     - parameter positiveExamples: An array of positive examples, each with a name and a compressed
-     (.zip) file of images that depict the visual subject of a class in the classifier. The positive examples create
-       or update classes in the classifier. You can include more than one positive example file in a call.
+     - parameter classnamePositiveExamples: A .zip file of images that depict the visual subject of a class in the
+       classifier. The positive examples create or update classes in the classifier. You can include more than one
+       positive example file in a call.
+       Specify the parameter name by appending `_positive_examples` to the class name. For example,
+       `goldenretriever_positive_examples` creates the class `goldenretriever`.
        Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels. The
        maximum number of images is 10,000 images or 100 MB per .zip file.
        Encode special characters in the file name in UTF-8.
-     - parameter negativeExamples: A .zip file of images that do not depict the visual subject of any of the classes of the new classifier. Must
-       contain a minimum of 10 images.
+     - parameter negativeExamples: A .zip file of images that do not depict the visual subject of any of the classes
+       of the new classifier. Must contain a minimum of 10 images.
        Encode special characters in the file name in UTF-8.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -546,7 +522,7 @@ public class VisualRecognition {
      */
     public func updateClassifier(
         classifierID: String,
-        positiveExamples: [PositiveExample]? = nil,
+        classnamePositiveExamples: URL? = nil,
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -554,10 +530,8 @@ public class VisualRecognition {
     {
         // construct body
         let multipartFormData = MultipartFormData()
-        if let positiveExamples = positiveExamples {
-            positiveExamples.forEach { example in
-                multipartFormData.append(example.examples, withName: example.name + "_positive_examples")
-            }
+        if let classnamePositiveExamples = classnamePositiveExamples {
+            multipartFormData.append(classnamePositiveExamples, withName: "classname_positive_examples")
         }
         if let negativeExamples = negativeExamples {
             multipartFormData.append(negativeExamples, withName: "negative_examples")

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -30,10 +30,10 @@ public class VisualRecognition {
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
-    private let session = URLSession(configuration: URLSessionConfiguration.default)
-    private var authMethod: AuthenticationMethod
-    private let domain = "com.ibm.watson.developer-cloud.VisualRecognitionV3"
-    private let version: String
+    internal let session = URLSession(configuration: URLSessionConfiguration.default)
+    internal var authMethod: AuthenticationMethod
+    internal let domain = "com.ibm.watson.developer-cloud.VisualRecognitionV3"
+    internal let version: String
 
     /**
      Create a `VisualRecognition` object.
@@ -45,6 +45,7 @@ public class VisualRecognition {
     public init(apiKey: String, version: String) {
         self.authMethod = APIKeyAuthentication(name: "api_key", key: apiKey, location: .query)
         self.version = version
+        self.serviceURL = "https://gateway-a.watsonplatform.net/visual-recognition/api"
     }
 
     /**
@@ -85,12 +86,36 @@ public class VisualRecognition {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    internal func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if code == 403 {
+                // ErrorAuthentication
+                if case let .some(.string(status)) = json["status"],
+                    case let .some(.string(statusInfo)) = json["statusInfo"] {
+                    userInfo[NSLocalizedDescriptionKey] = "\(status): \(statusInfo)"
+                }
+            } else if code == 404 {
+                // "error": ErrorInfo
+                if case let .some(.object(errorObj)) = json["error"],
+                    case let .some(.string(message)) = errorObj["description"],
+                    case let .some(.string(errorID)) = errorObj["error_id"] {
+                    userInfo[NSLocalizedDescriptionKey] = "\(message) (error_id = \(errorID))"
+                }
+            } else if code == 413 {
+                // ErrorHTML
+                if case let .some(.string(message)) = json["Error"] {
+                    userInfo[NSLocalizedDescriptionKey] = message
+                }
+            } else {
+                // ErrorResponse
+                if case let .some(.string(message)) = json["error"] {
+                    userInfo[NSLocalizedDescriptionKey] = message
+                }
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -120,7 +145,7 @@ public class VisualRecognition {
        classifier categories, set the value to both `IBM` and `me`.
        The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.
        The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty.
-     - parameter classifierIds: Which classifiers to apply. Overrides the **owners** parameter. You can specify both
+     - parameter classifierIDs: Which classifiers to apply. Overrides the **owners** parameter. You can specify both
        custom and built-in classifier IDs. The built-in `default` classifier is used if both **classifier_ids** and
        **owners** parameters are empty.
        The following built-in classifier IDs require no training:
@@ -134,12 +159,11 @@ public class VisualRecognition {
      */
     public func classify(
         imagesFile: URL? = nil,
-        acceptLanguage: String? = nil,
         url: String? = nil,
         threshold: Double? = nil,
         owners: [String]? = nil,
-        classifierIds: [String]? = nil,
-        imagesFileContentType: String? = nil,
+        classifierIDs: [String]? = nil,
+        acceptLanguage: String? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ClassifiedImages) -> Void)
@@ -170,12 +194,12 @@ public class VisualRecognition {
             }
             multipartFormData.append(ownersData, withName: "owners")
         }
-        if let classifierIds = classifierIds {
-            guard let classifierIdsData = classifierIds.joined(separator: ",").data(using: .utf8) else {
+        if let classifierIDs = classifierIDs {
+            guard let classifierIDsData = classifierIDs.joined(separator: ",").data(using: .utf8) else {
                 failure?(RestError.serializationError)
                 return
             }
-            multipartFormData.append(classifierIdsData, withName: "classifier_ids")
+            multipartFormData.append(classifierIDsData, withName: "classifier_ids")
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)
@@ -249,7 +273,6 @@ public class VisualRecognition {
     public func detectFaces(
         imagesFile: URL? = nil,
         url: String? = nil,
-        imagesFileContentType: String? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (DetectedFaces) -> Void)
@@ -257,7 +280,7 @@ public class VisualRecognition {
         // construct body
         let multipartFormData = MultipartFormData()
         if let imagesFile = imagesFile {
-            multipartFormData.append(imagesFile, withName: "images_file")
+            multipartFormData.append(imagesFile, withName: "images_file", mimeType: "application/octet-stream")
         }
         if let url = url {
             guard let urlData = url.data(using: .utf8) else {
@@ -315,12 +338,11 @@ public class VisualRecognition {
      names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.
 
      - parameter name: The name of the new classifier. Encode special characters in UTF-8.
-     - parameter classnamePositiveExamples: A .zip file of images that depict the visual subject of a class in the new
-       classifier. You can include more than one positive example file in a call.
-       Specify the parameter name by appending `_positive_examples` to the class name. For example,
-       `goldenretriever_positive_examples` creates the class **goldenretriever**.
-       Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels. The
-       maximum number of images is 10,000 images or 100 MB per .zip file.
+     - parameter positiveExamples: An array of of positive examples, each with a name and a compressed (.zip) file
+       of images that depict the visual subject of a class in the new classifier. You can include more than one
+       positive example file in a call.
+       Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels.
+       The maximum number of images is 10,000 images or 100 MB per .zip file.
        Encode special characters in the file name in UTF-8.
      - parameter negativeExamples: A .zip file of images that do not depict the visual subject of any of the classes
        of the new classifier. Must contain a minimum of 10 images.
@@ -331,7 +353,7 @@ public class VisualRecognition {
      */
     public func createClassifier(
         name: String,
-        classnamePositiveExamples: URL,
+        positiveExamples: [PositiveExample],
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -344,7 +366,9 @@ public class VisualRecognition {
             return
         }
         multipartFormData.append(nameData, withName: "name")
-        multipartFormData.append(classnamePositiveExamples, withName: "classname_positive_examples")
+        positiveExamples.forEach { example in
+            multipartFormData.append(example.examples, withName: example.name + "_positive_examples")
+        }
         if let negativeExamples = negativeExamples {
             multipartFormData.append(negativeExamples, withName: "negative_examples")
         }
@@ -390,6 +414,7 @@ public class VisualRecognition {
     /**
      Retrieve a list of classifiers.
 
+     - parameter owners: Unused. This parameter will be removed in a future release.
      - parameter verbose: Specify `true` to return details about the classifiers. Omit this parameter to return a
        brief list of classifiers.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -397,6 +422,7 @@ public class VisualRecognition {
      - parameter success: A function executed with the successful result.
      */
     public func listClassifiers(
+        owners: [String]? = nil,
         verbose: Bool? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -505,13 +531,11 @@ public class VisualRecognition {
      classifier retraining finished.
 
      - parameter classifierID: The ID of the classifier.
-     - parameter classnamePositiveExamples: A .zip file of images that depict the visual subject of a class in the
-       classifier. The positive examples create or update classes in the classifier. You can include more than one
-       positive example file in a call.
-       Specify the parameter name by appending `_positive_examples` to the class name. For example,
-       `goldenretriever_positive_examples` creates the class `goldenretriever`.
-       Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels. The
-       maximum number of images is 10,000 images or 100 MB per .zip file.
+     - parameter positiveExamples: An array of positive examples, each with a name and a compressed (.zip) file
+       of images that depict the visual subject of a class in the classifier. The positive examples create
+       or update classes in the classifier. You can include more than one positive example file in a call.
+       Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels.
+       The maximum number of images is 10,000 images or 100 MB per .zip file.
        Encode special characters in the file name in UTF-8.
      - parameter negativeExamples: A .zip file of images that do not depict the visual subject of any of the classes
        of the new classifier. Must contain a minimum of 10 images.
@@ -522,7 +546,7 @@ public class VisualRecognition {
      */
     public func updateClassifier(
         classifierID: String,
-        classnamePositiveExamples: URL? = nil,
+        positiveExamples: [PositiveExample]? = nil,
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -530,8 +554,10 @@ public class VisualRecognition {
     {
         // construct body
         let multipartFormData = MultipartFormData()
-        if let classnamePositiveExamples = classnamePositiveExamples {
-            multipartFormData.append(classnamePositiveExamples, withName: "classname_positive_examples")
+        if let positiveExamples = positiveExamples {
+            positiveExamples.forEach { example in
+                multipartFormData.append(example.examples, withName: example.name + "_positive_examples")
+            }
         }
         if let negativeExamples = negativeExamples {
             multipartFormData.append(negativeExamples, withName: "negative_examples")

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation
@@ -444,7 +444,9 @@ class AssistantTests: XCTestCase {
         let workspaceDialogNode = CreateDialogNode(dialogNode: "DialogNode1", description: "description of DialogNode1")
         let workspaceCounterexample = CreateCounterexample(text: "This is a counterexample")
 
-        let createWorkspaceBody = CreateWorkspace(name: workspaceName, description: workspaceDescription, language: workspaceLanguage, intents: [workspaceIntent], entities: [workspaceEntity], dialogNodes: [workspaceDialogNode], counterexamples: [workspaceCounterexample], metadata: workspaceMetadata)
+        let createWorkspaceBody = CreateWorkspace(name: workspaceName, description: workspaceDescription, language: workspaceLanguage, intents: [workspaceIntent],
+                                                  entities: [workspaceEntity], dialogNodes: [workspaceDialogNode], counterexamples: [workspaceCounterexample],
+                                                  metadata: workspaceMetadata)
         assistant.createWorkspace(properties: createWorkspaceBody, failure: failWithError) { workspace in
             XCTAssertEqual(workspace.name, workspaceName)
             XCTAssertEqual(workspace.description, workspaceDescription)
@@ -732,7 +734,8 @@ class AssistantTests: XCTestCase {
         let updatedIntentName = "updated-name-for-\(newIntentName)"
         let updatedIntentDescription = "updated-description-for-\(newIntentName)"
         let updatedExample1 = CreateExample(text: "updated example for \(newIntentName)")
-        assistant.updateIntent(workspaceID: workspaceID, intent: newIntentName, newIntent: updatedIntentName, newDescription: updatedIntentDescription, newExamples: [updatedExample1], failure: failWithError) { intent in
+        assistant.updateIntent(workspaceID: workspaceID, intent: newIntentName, newIntent: updatedIntentName, newDescription: updatedIntentDescription,
+                               newExamples: [updatedExample1], failure: failWithError) { intent in
             XCTAssertEqual(intent.intentName, updatedIntentName)
             XCTAssertEqual(intent.description, updatedIntentDescription)
             expectation2.fulfill()

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation
@@ -444,7 +444,9 @@ class ConversationTests: XCTestCase {
         let workspaceDialogNode = CreateDialogNode(dialogNode: "DialogNode1", description: "description of DialogNode1")
         let workspaceCounterexample = CreateCounterexample(text: "This is a counterexample")
 
-        let createWorkspaceBody = CreateWorkspace(name: workspaceName, description: workspaceDescription, language: workspaceLanguage, intents: [workspaceIntent], entities: [workspaceEntity], dialogNodes: [workspaceDialogNode], counterexamples: [workspaceCounterexample], metadata: workspaceMetadata)
+        let createWorkspaceBody = CreateWorkspace(name: workspaceName, description: workspaceDescription, language: workspaceLanguage, intents: [workspaceIntent],
+                                                  entities: [workspaceEntity], dialogNodes: [workspaceDialogNode], counterexamples: [workspaceCounterexample],
+                                                  metadata: workspaceMetadata)
         conversation.createWorkspace(properties: createWorkspaceBody, failure: failWithError) { workspace in
             XCTAssertEqual(workspace.name, workspaceName)
             XCTAssertEqual(workspace.description, workspaceDescription)
@@ -732,7 +734,8 @@ class ConversationTests: XCTestCase {
         let updatedIntentName = "updated-name-for-\(newIntentName)"
         let updatedIntentDescription = "updated-description-for-\(newIntentName)"
         let updatedExample1 = CreateExample(text: "updated example for \(newIntentName)")
-        conversation.updateIntent(workspaceID: workspaceID, intent: newIntentName, newIntent: updatedIntentName, newDescription: updatedIntentDescription, newExamples: [updatedExample1], failure: failWithError) { intent in
+        conversation.updateIntent(workspaceID: workspaceID, intent: newIntentName, newIntent: updatedIntentName, newDescription: updatedIntentDescription,
+                                  newExamples: [updatedExample1], failure: failWithError) { intent in
             XCTAssertEqual(intent.intentName, updatedIntentName)
             XCTAssertEqual(intent.description, updatedIntentDescription)
             expectation2.fulfill()

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation

--- a/Tests/LanguageTranslatorV2Tests/LanguageTranslatorTests.swift
+++ b/Tests/LanguageTranslatorV2Tests/LanguageTranslatorTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation

--- a/Tests/LanguageTranslatorV3Tests/LanguageTranslatorTests.swift
+++ b/Tests/LanguageTranslatorV3Tests/LanguageTranslatorTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation

--- a/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
+++ b/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation

--- a/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
+++ b/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation
@@ -206,7 +206,10 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
     func testAnalyzeTextForEmotions() {
         let description = "Analyze text for emotions."
         let expectation = self.expectation(description: description)
-        let text = "But I believe this thinking is wrong. I believe the road of true democracy remains the better path. I believe that in the 21st century, economies can only grow to a certain point until they need to open up -- because entrepreneurs need to access information in order to invent; young people need a global education in order to thrive; independent media needs to check the abuses of power."
+        let text = "But I believe this thinking is wrong. I believe the road of true democracy remains the better path. "
+                 + "I believe that in the 21st century, economies can only grow to a certain point until they need to open up -- "
+                 + "because entrepreneurs need to access information in order to invent; young people need a global education "
+                 + "in order to thrive; independent media needs to check the abuses of power."
         let emotion = EmotionOptions(targets: ["democracy", "entrepreneurs", "media", "economies"])
         let features = Features(emotion: emotion)
         let parameters = Parameters(features: features, text: text, returnAnalyzedText: true)
@@ -244,7 +247,10 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
     func testAnalyzeTextForEmotionsWithoutTargets() {
         let description = "Analyze text for emotions without targets."
         let expectation = self.expectation(description: description)
-        let text = "But I believe this thinking is wrong. I believe the road of true democracy remains the better path. I believe that in the 21st century, economies can only grow to a certain point until they need to open up -- because entrepreneurs need to access information in order to invent; young people need a global education in order to thrive; independent media needs to check the abuses of power."
+        let text = "But I believe this thinking is wrong. I believe the road of true democracy remains the better path. "
+                 + "I believe that in the 21st century, economies can only grow to a certain point until they need to open up -- "
+                 + "because entrepreneurs need to access information in order to invent; young people need a global education "
+                 + "in order to thrive; independent media needs to check the abuses of power."
         let features = Features(emotion: EmotionOptions())
         let parameters = Parameters(features: features, text: text, returnAnalyzedText: true)
         naturalLanguageUnderstanding.analyze(parameters: parameters, failure: failWithError) {

--- a/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import PersonalityInsightsV3

--- a/Tests/RestKitTests/AuthenticationTests.swift
+++ b/Tests/RestKitTests/AuthenticationTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 

--- a/Tests/RestKitTests/CodableExtensionsTests.swift
+++ b/Tests/RestKitTests/CodableExtensionsTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 

--- a/Tests/RestKitTests/JSONValueTests.swift
+++ b/Tests/RestKitTests/JSONValueTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 #if os(Linux)
 #else

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation

--- a/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 #if !os(Linux)
 import XCTest

--- a/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 #if os(iOS) || os(tvOS) || os(watchOS)
 

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-// swiftlint:disable function_body_length force_try force_unwrapping superfluous_disable_command
+// swiftlint:disable function_body_length force_try force_unwrapping file_length
 
 import XCTest
 import Foundation

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -574,6 +574,8 @@
 		CA28818020CB099D00FC992C /* TranslationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA28816620CB090700FC992C /* TranslationModels.swift */; };
 		CA28818120CB099D00FC992C /* TranslateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA28816720CB090700FC992C /* TranslateRequest.swift */; };
 		CA28818220CB099D00FC992C /* IdentifiableLanguages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA28816820CB090700FC992C /* IdentifiableLanguages.swift */; };
+		CA35CD4720E3234900FACB2B /* ToneContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4620E3234800FACB2B /* ToneContent.swift */; };
+		CA35CD4920E3237400FACB2B /* ProfileContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4820E3237400FACB2B /* ProfileContent.swift */; };
 		CAD2685B20CAF28B002BA2C4 /* LanguageTranslatorV3.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CAD2685220CAF28A002BA2C4 /* LanguageTranslatorV3.framework */; };
 		CAD2686E20CAF919002BA2C4 /* LanguageTranslator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD2686A20CAF919002BA2C4 /* LanguageTranslator.swift */; };
 		CAD2687320CB00F2002BA2C4 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
@@ -1241,6 +1243,8 @@
 		CA28816820CB090700FC992C /* IdentifiableLanguages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifiableLanguages.swift; sourceTree = "<group>"; };
 		CA28817420CB095100FC992C /* glossary.tmx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = glossary.tmx; path = Tests/LanguageTranslatorV3Tests/glossary.tmx; sourceTree = SOURCE_ROOT; };
 		CA28817520CB095100FC992C /* LanguageTranslatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LanguageTranslatorTests.swift; path = Tests/LanguageTranslatorV3Tests/LanguageTranslatorTests.swift; sourceTree = SOURCE_ROOT; };
+		CA35CD4620E3234800FACB2B /* ToneContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneContent.swift; sourceTree = "<group>"; };
+		CA35CD4820E3237400FACB2B /* ProfileContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileContent.swift; sourceTree = "<group>"; };
 		CA45954820A62FBE0060BF9B /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		CA45954920A630080060BF9B /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CONTRIBUTING.md; path = .github/CONTRIBUTING.md; sourceTree = "<group>"; };
 		CAD2685220CAF28A002BA2C4 /* LanguageTranslatorV3.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LanguageTranslatorV3.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2001,6 +2005,7 @@
 				689A16AA203C9946002CFC66 /* Content.swift */,
 				689A16A6203C9945002CFC66 /* ContentItem.swift */,
 				689A16A9203C9945002CFC66 /* Profile.swift */,
+				CA35CD4820E3237400FACB2B /* ProfileContent.swift */,
 				689A16AB203C9946002CFC66 /* Trait.swift */,
 				689A16A8203C9945002CFC66 /* Warning.swift */,
 			);
@@ -2306,6 +2311,7 @@
 				B1F21DF41CE2461800393146 /* ToneCategory.swift */,
 				68D09C18200D61870087ADE5 /* ToneChatInput.swift */,
 				68D09C1A200D61870087ADE5 /* ToneChatScore.swift */,
+				CA35CD4620E3234800FACB2B /* ToneContent.swift */,
 				68D09C1C200D61870087ADE5 /* ToneInput.swift */,
 				B1F21DF51CE2461800393146 /* ToneScore.swift */,
 				68D09C1D200D61870087ADE5 /* Utterance.swift */,
@@ -3973,6 +3979,7 @@
 				68BC28C21F8C35050042810E /* RestError.swift in Sources */,
 				689A16B4203C9946002CFC66 /* ConsumptionPreferences.swift in Sources */,
 				68BC28C51F8C35050042810E /* RestUtilities.swift in Sources */,
+				CA35CD4920E3237400FACB2B /* ProfileContent.swift in Sources */,
 				689A16AF203C9946002CFC66 /* ConsumptionPreferencesCategory.swift in Sources */,
 				689A16B2203C9946002CFC66 /* Content.swift in Sources */,
 				68BC28C31F8C35050042810E /* RestRequest.swift in Sources */,
@@ -4066,6 +4073,7 @@
 				68D09C21200D61870087ADE5 /* ToneChatScore.swift in Sources */,
 				7AAAF4101CEE9D5300B74848 /* SentenceAnalysis.swift in Sources */,
 				68BC28E81F8C35080042810E /* JSON.swift in Sources */,
+				CA35CD4720E3234900FACB2B /* ToneContent.swift in Sources */,
 				68D09C25200D61870087ADE5 /* DocumentAnalysis.swift in Sources */,
 				7AAAF4131CEE9D5300B74848 /* ToneScore.swift in Sources */,
 				68BC28E61F8C35080042810E /* CodableExtensions.swift in Sources */,


### PR DESCRIPTION
This PR implements a new design for multi-consumes operations in Swift. Where appropriate, the body is represented by an enum type with associated values that capture both the type of the content and its value. The bodyEnum has computed properties that will return the content-type and the content value.

I also squeezed in a few code style improvements and tightened up the swiftlint config accordingly.

The generated files use:
api-definitions git hash: 9b9df9e
sdk generator git hash: 11aa521