### PR TITLE
Handle malformed URLs when constructing URL requests

### DIFF
--- a/Source/RestKit/RestError.swift
+++ b/Source/RestKit/RestError.swift
@@ -39,6 +39,9 @@ public enum RestError: Error {
     /// Failed to load the given file.
     case invalidFile
 
+    /// The request failed because the URL was malformed.
+    case badURL
+
     /// An HTTP error with a status code and description.
     case failure(Int, String)
 

--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -81,6 +81,8 @@ internal struct RestRequest {
             return nil
         }
         if !queryItems.isEmpty { components.queryItems = queryItems }
+        // we must explicitly encode "+" as "%2B" since URLComponents does not
+        components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
         guard let urlWithQuery = components.url else {
             return nil
         }

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -31,7 +31,7 @@ class AssistantTests: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        instantiateAssistant()
+        assistant = instantiateAssistant()
     }
 
     static var allTests: [(String, (AssistantTests) -> () throws -> Void)] {
@@ -93,13 +93,14 @@ class AssistantTests: XCTestCase {
     }
 
     /** Instantiate Assistant. */
-    func instantiateAssistant() {
+    func instantiateAssistant() -> Assistant {
         let username = Credentials.AssistantUsername
         let password = Credentials.AssistantPassword
         let version = "2018-02-16"
-        assistant = Assistant(username: username, password: password, version: version)
+        let assistant = Assistant(username: username, password: password, version: version)
         assistant.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         assistant.defaultHeaders["X-Watson-Test"] = "true"
+        return assistant
     }
 
     /** Fail false negatives. */
@@ -1519,6 +1520,24 @@ class AssistantTests: XCTestCase {
         let workspaceID = "this id is invalid"
         let failure = { (error: Error) in expectation.fulfill() }
         assistant.message(workspaceID: workspaceID, failure: failure, success: failWithResult)
+        waitForExpectations()
+    }
+
+    func testInvalidServiceURL() {
+        let description = "Start a conversation with an invalid workspace."
+        let expectation = self.expectation(description: description)
+        let assistant = instantiateAssistant()
+        assistant.serviceURL = "this is broken"
+        let failure = { (error: Error) in
+            switch error {
+            case RestError.badURL:
+                break
+            default:
+                XCTFail("Unexpected error response")
+            }
+            expectation.fulfill()
+        }
+        assistant.listWorkspaces(failure: failure, success: failWithResult)
         waitForExpectations()
     }
 }


### PR DESCRIPTION
This PR replaces force unwraps with guard statements when constructing the URL for a request.  The force unwraps will cause an app crash if the URL is malformed, which could happen if the user provided an incorrect value for the serviceURL.  The new logic will call the `failure` completion handler with a `badURL` error.