### PR TITLE
Single completion handler

### DIFF
--- a/Source/AssistantV1/RestKit/WatsonResponse.swift
+++ b/Source/AssistantV1/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/ConversationV1/RestKit/WatsonResponse.swift
+++ b/Source/ConversationV1/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/DiscoveryV1/RestKit/WatsonResponse.swift
+++ b/Source/DiscoveryV1/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/LanguageTranslatorV2/RestKit/WatsonResponse.swift
+++ b/Source/LanguageTranslatorV2/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/LanguageTranslatorV3/RestKit/WatsonResponse.swift
+++ b/Source/LanguageTranslatorV3/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/NaturalLanguageClassifierV1/RestKit/WatsonResponse.swift
+++ b/Source/NaturalLanguageClassifierV1/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/NaturalLanguageUnderstandingV1/RestKit/WatsonResponse.swift
+++ b/Source/NaturalLanguageUnderstandingV1/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/PersonalityInsightsV3/RestKit/WatsonResponse.swift
+++ b/Source/PersonalityInsightsV3/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/RestKit/Authentication.swift
+++ b/Source/RestKit/Authentication.swift
@@ -119,14 +119,17 @@ internal class BasicAuthentication: AuthenticationMethod {
             url: tokenURL,
             headerParameters: [:])
 
-         request.responseString { response in
-            switch response.result {
-            case .success(let token):
-                self.token = token
-                completionHandler(token, nil)
-            case .failure(let error):
+        request.response { (response: WatsonResponse<String>?, error) in
+            guard error == nil else {
                 completionHandler(nil, error)
+                return
             }
+            guard let token = response?.result else {
+                completionHandler(nil, RestError.noData)
+                return
+            }
+            self.token = token
+            completionHandler(token, nil)
         }
     }
 
@@ -284,14 +287,12 @@ internal class IAMAuthentication: AuthenticationMethod {
             headerParameters: headerParameters,
             messageBody: form.joined(separator: "&").data(using: .utf8)
         )
-        request.responseObject { (response: RestResponse<IAMToken>) in
-            switch response.result {
-            case .success(let token):
-                self.token = token
-                completionHandler(token, nil)
-            case .failure(let error):
+        request.responseObject { (response: WatsonResponse<IAMToken>?, error) in
+            guard let token = response?.result, error == nil else {
                 completionHandler(nil, error)
+                return
             }
+            completionHandler(token, nil)
         }
     }
 
@@ -308,14 +309,12 @@ internal class IAMAuthentication: AuthenticationMethod {
             headerParameters: headerParameters,
             messageBody: form.joined(separator: "&").data(using: .utf8)
         )
-        request.responseObject { (response: RestResponse<IAMToken>) in
-            switch response.result {
-            case .success(let token):
-                self.token = token
-                completionHandler(token, nil)
-            case .failure(let error):
+        request.responseObject { (response: WatsonResponse<IAMToken>?, error) in
+            guard let token = response?.result, error == nil else {
                 completionHandler(nil, error)
+                return
             }
+            completionHandler(token, nil)
         }
     }
 }

--- a/Source/RestKit/WatsonResponse.swift
+++ b/Source/RestKit/WatsonResponse.swift
@@ -18,6 +18,10 @@ import Foundation
 
 // MARK: - WatsonResponse
 
+/**
+ Common response type for all service methods that encapsulates the response status,
+ response headers if any, and the result of the service call of the parameterized type T.
+ */
 public struct WatsonResponse<T> {
 
     /**

--- a/Source/RestKit/WatsonResponse.swift
+++ b/Source/RestKit/WatsonResponse.swift
@@ -1,0 +1,49 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+// MARK: - WatsonResponse
+
+public struct WatsonResponse<T> {
+
+    /**
+     The HTTP status code.
+     */
+    public var statusCode: Int
+
+    /**
+     A dictionary containing the HTTP response headers.
+     */
+    public var headers: [String: String]
+
+    /**
+     The result.
+     */
+    public var result: T?
+
+    internal init(response: HTTPURLResponse) {
+        self.statusCode = response.statusCode
+        self.headers = [:]
+        for (key, value) in response.allHeaderFields {
+            if let key = key as? String,
+                let value = value as? String {
+                self.headers[key] = value
+            }
+        }
+    }
+
+}

--- a/Source/SpeechToTextV1/RestKit/WatsonResponse.swift
+++ b/Source/SpeechToTextV1/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/TextToSpeechV1/RestKit/WatsonResponse.swift
+++ b/Source/TextToSpeechV1/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/ToneAnalyzerV3/RestKit/WatsonResponse.swift
+++ b/Source/ToneAnalyzerV3/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -96,9 +96,6 @@ public class ToneAnalyzer {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
-            if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
-            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)
@@ -140,8 +137,7 @@ public class ToneAnalyzer {
        are treated as their parent language; for example, `en-US` is interpreted as `en`. You can use different
        languages for **Content-Language** and **Accept-Language**.
      - parameter headers: A dictionary of request headers to be sent with this request.
-     - parameter failure: A function executed if an error occurs.
-     - parameter success: A function executed with the successful result.
+     - parameter completionHandler: A function executed when the request completes with a successful result or error
      */
     public func tone(
         toneContent: ToneContent,
@@ -150,12 +146,11 @@ public class ToneAnalyzer {
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (ToneAnalysis) -> Void)
+        completionHandler: @escaping (WatsonResponse<ToneAnalysis>?, Error?) -> Void)
     {
         // construct body
         guard let body = toneContent.content else {
-            failure?(RestError.serializationError)
+            completionHandler(nil, RestError.serializationError)
             return
         }
 
@@ -198,13 +193,7 @@ public class ToneAnalyzer {
         )
 
         // execute REST request
-        request.responseObject {
-            (response: RestResponse<ToneAnalysis>) in
-            switch response.result {
-            case .success(let retval): success(retval)
-            case .failure(let error): failure?(error)
-            }
-        }
+        request.responseObject(completionHandler: completionHandler)
     }
 
     /**
@@ -231,21 +220,19 @@ public class ToneAnalyzer {
        are treated as their parent language; for example, `en-US` is interpreted as `en`. You can use different
        languages for **Content-Language** and **Accept-Language**.
      - parameter headers: A dictionary of request headers to be sent with this request.
-     - parameter failure: A function executed if an error occurs.
-     - parameter success: A function executed with the successful result.
+     - parameter completionHandler: A function executed when the request completes with a successful result or error
      */
     public func toneChat(
         utterances: [Utterance],
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (UtteranceAnalyses) -> Void)
+        completionHandler: @escaping (WatsonResponse<UtteranceAnalyses>?, Error?) -> Void)
     {
         // construct body
         let toneChatRequest = ToneChatInput(utterances: utterances)
         guard let body = try? JSONEncoder().encode(toneChatRequest) else {
-            failure?(RestError.serializationError)
+            completionHandler(nil, RestError.serializationError)
             return
         }
 
@@ -280,62 +267,7 @@ public class ToneAnalyzer {
         )
 
         // execute REST request
-        request.responseObject {
-            (response: RestResponse<UtteranceAnalyses>) in
-            switch response.result {
-            case .success(let retval): success(retval)
-            case .failure(let error): failure?(error)
-            }
-        }
-    }
-
-}
-
-extension ToneAnalyzer {
-
-    @available(*, deprecated, message: "This method has been deprecated in favor of the tone method that accepts a toneContent parameter.  This method will be removed in a future release.")
-    public func tone(
-        toneInput: ToneInput,
-        sentences: Bool? = nil,
-        tones: [String]? = nil,
-        contentLanguage: String? = nil,
-        acceptLanguage: String? = nil,
-        headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (ToneAnalysis) -> Void)
-    {
-        tone(toneContent: .toneInput(toneInput), sentences: sentences, tones: tones, contentLanguage: contentLanguage,
-             acceptLanguage: acceptLanguage, headers: headers, failure: failure, success: success)
-    }
-
-    @available(*, deprecated, message: "This method has been deprecated in favor of the tone method that accepts a toneContent parameter.  This method will be removed in a future release.")
-    public func tone(
-        text: String,
-        sentences: Bool? = nil,
-        tones: [String]? = nil,
-        contentLanguage: String? = nil,
-        acceptLanguage: String? = nil,
-        headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (ToneAnalysis) -> Void)
-    {
-        tone(toneContent: .text(text), sentences: sentences, tones: tones, contentLanguage: contentLanguage,
-             acceptLanguage: acceptLanguage, headers: headers, failure: failure, success: success)
-    }
-
-    @available(*, deprecated, message: "This method has been deprecated in favor of the tone method that accepts a toneContent parameter.  This method will be removed in a future release.")
-    public func tone(
-        html: String,
-        sentences: Bool? = nil,
-        tones: [String]? = nil,
-        contentLanguage: String? = nil,
-        acceptLanguage: String? = nil,
-        headers: [String: String]? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (ToneAnalysis) -> Void)
-    {
-        tone(toneContent: .html(html), sentences: sentences, tones: tones, contentLanguage: contentLanguage,
-             acceptLanguage: acceptLanguage, headers: headers, failure: failure, success: success)
+        request.responseObject(completionHandler: completionHandler)
     }
 
 }

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -96,6 +96,9 @@ public class ToneAnalyzer {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             var userInfo: [String: Any] = [:]
+            if case let .some(.string(message)) = json["error"] {
+                userInfo[NSLocalizedDescriptionKey] = message
+            }
             return NSError(domain: domain, code: code, userInfo: userInfo)
         } catch {
             return NSError(domain: domain, code: code, userInfo: nil)

--- a/Source/VisualRecognitionV3/RestKit/WatsonResponse.swift
+++ b/Source/VisualRecognitionV3/RestKit/WatsonResponse.swift
@@ -1,0 +1,1 @@
+../../RestKit/WatsonResponse.swift

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -76,21 +76,6 @@ class ToneAnalyzerTests: XCTestCase {
         toneAnalyzer.defaultHeaders["X-Watson-Test"] = "true"
     }
 
-    /** Fail false negatives. */
-    func failWithError(error: Error) {
-        XCTFail("Positive test failed with error: \(error)")
-    }
-
-    /** Fail false positives. */
-    func failWithResult<T>(result: T) {
-        XCTFail("Negative test returned a result.")
-    }
-
-    /** Fail false positives. */
-    func failWithResult() {
-        XCTFail("Negative test returned a result.")
-    }
-
     /** Wait for expectations. */
     func waitForExpectations(timeout: TimeInterval = 5.0) {
         waitForExpectations(timeout: timeout) { error in
@@ -102,8 +87,12 @@ class ToneAnalyzerTests: XCTestCase {
 
     func testGetToneJSON() {
         let expectation = self.expectation(description: "Get tone.")
-        toneAnalyzer.tone(toneInput: ToneInput(text: text), failure: failWithError) {
-            toneAnalysis in
+        toneAnalyzer.tone(toneContent: .toneInput(ToneInput(text: text))) {
+            response, error in
+            guard let toneAnalysis = response?.result else {
+                XCTFail("Positive test failed with error: \(error!)")
+                return
+            }
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
             XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
             XCTAssertNotNil(toneAnalysis.sentencesTone)
@@ -122,8 +111,12 @@ class ToneAnalyzerTests: XCTestCase {
 
     func testGetTonePlainText() {
         let expectation = self.expectation(description: "Get tone.")
-        toneAnalyzer.tone(text: text, failure: failWithError) {
-            toneAnalysis in
+        toneAnalyzer.tone(toneContent: .text(text)) {
+            response, error in
+            guard let toneAnalysis = response?.result else {
+                XCTFail("Positive test failed with error: \(error!)")
+                return
+            }
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
             XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
             XCTAssertNotNil(toneAnalysis.sentencesTone)
@@ -143,8 +136,12 @@ class ToneAnalyzerTests: XCTestCase {
     func testGetToneHTML() {
         let expectation = self.expectation(description: "Get tone.")
         let html = "<!DOCTYPE html><html><body><p>\(text)</p></body></html>"
-        toneAnalyzer.tone(html: html, failure: failWithError) {
-            toneAnalysis in
+        toneAnalyzer.tone(toneContent: .html(html)) {
+            response, error in
+            guard let toneAnalysis = response?.result else {
+                XCTFail("Positive test failed with error: \(error!)")
+                return
+            }
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
             XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
             XCTAssertNotNil(toneAnalysis.sentencesTone)
@@ -163,13 +160,16 @@ class ToneAnalyzerTests: XCTestCase {
     func testGetToneCustom() {
         let expectation = self.expectation(description: "Get tone with custom parameters.")
         toneAnalyzer.tone(
-            toneInput: ToneInput(text: text),
+            toneContent: .toneInput(ToneInput(text: text)),
             sentences: false,
             contentLanguage: "en",
-            acceptLanguage: "en",
-            failure: failWithError)
+            acceptLanguage: "en")
         {
-            toneAnalysis in
+            response, error in
+            guard let toneAnalysis = response?.result else {
+                XCTFail("Positive test failed with error: \(error!)")
+                return
+            }
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
             XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
             XCTAssertNil(toneAnalysis.sentencesTone)
@@ -180,7 +180,12 @@ class ToneAnalyzerTests: XCTestCase {
 
     func testToneChat() {
         let expectation = self.expectation(description: "Tone chat.")
-        toneAnalyzer.toneChat(utterances: utterances, acceptLanguage: "en", failure: failWithError) { analyses in
+        toneAnalyzer.toneChat(utterances: utterances, acceptLanguage: "en") {
+            response, error in
+            guard let analyses = response?.result else {
+                XCTFail("Positive test failed with error: \(error!)")
+                return
+            }
             XCTAssert(!analyses.utterancesTone.isEmpty)
             expectation.fulfill()
         }
@@ -191,15 +196,25 @@ class ToneAnalyzerTests: XCTestCase {
 
     func testGetToneEmptyString() {
         let expectation = self.expectation(description: "Get tone with an empty string.")
-        let failure = { (error: Error) in expectation.fulfill() }
-        toneAnalyzer.tone(toneInput: ToneInput(text: ""), failure: failure, success: failWithResult)
+        toneAnalyzer.tone(toneContent: .toneInput(ToneInput(text: ""))) {
+            _, error in
+            if error == nil {
+                XCTFail("Negative test did not return error.")
+            }
+            expectation.fulfill()
+        }
         waitForExpectations()
     }
 
     func testToneChatEmptyArray() {
         let expectation = self.expectation(description: "Tone chat with an empty array.")
-        let failure = { (error: Error) in expectation.fulfill() }
-        toneAnalyzer.toneChat(utterances: [], acceptLanguage: "en", failure: failure, success: failWithResult)
+        toneAnalyzer.toneChat(utterances: [], acceptLanguage: "en") {
+            _, error in
+            if error == nil {
+                XCTFail("Negative test did not return error.")
+            }
+            expectation.fulfill()
+        }
         waitForExpectations()
     }
 }

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -565,6 +565,18 @@
 		CA35CD4720E3234900FACB2B /* ToneContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4620E3234800FACB2B /* ToneContent.swift */; };
 		CA35CD4920E3237400FACB2B /* ProfileContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4820E3237400FACB2B /* ProfileContent.swift */; };
 		CA35CD4C20EF11EF00FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD4D20F010E700FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD4E20F010E900FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD4F20F010EA00FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD5020F010EB00FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD5120F010EC00FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD5220F010ED00FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD5320F010EE00FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD5420F010EF00FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD5520F010F000FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD5620F010F100FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD5720F010F200FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
+		CA35CD5820F010F300FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
 		CAD2685B20CAF28B002BA2C4 /* LanguageTranslatorV3.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CAD2685220CAF28A002BA2C4 /* LanguageTranslatorV3.framework */; };
 		CAD2686E20CAF919002BA2C4 /* LanguageTranslator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD2686A20CAF919002BA2C4 /* LanguageTranslator.swift */; };
 		CAD2687320CB00F2002BA2C4 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
@@ -3692,6 +3704,7 @@
 				683947E9202CF4F7007E3CF3 /* CategoriesResult.swift in Sources */,
 				6836B9042091D23B006DF944 /* Authentication.swift in Sources */,
 				683947F0202CF4F7007E3CF3 /* KeywordsResult.swift in Sources */,
+				CA35CD5320F010EE00FACB2B /* WatsonResponse.swift in Sources */,
 				683947FF202CF4F7007E3CF3 /* EntitiesOptions.swift in Sources */,
 				683947EC202CF4F7007E3CF3 /* SemanticRolesAction.swift in Sources */,
 				683947FC202CF4F7007E3CF3 /* FeatureSentimentResults.swift in Sources */,
@@ -3726,6 +3739,7 @@
 				126DF90B1EB25A45001FF980 /* opus_header.c in Sources */,
 				689A1710203CCDA9002CFC66 /* Pronunciation.swift in Sources */,
 				68BC28DE1F8C35080042810E /* CodableExtensions.swift in Sources */,
+				CA35CD5620F010F100FACB2B /* WatsonResponse.swift in Sources */,
 				68BC28E21F8C35080042810E /* RestError.swift in Sources */,
 				68BC28E11F8C35080042810E /* MultipartFormData.swift in Sources */,
 				689A1711203CCDA9002CFC66 /* VoiceModels.swift in Sources */,
@@ -3790,6 +3804,7 @@
 				68AF8F862069690300D552E3 /* Expansion.swift in Sources */,
 				68AF8F5E2069690300D552E3 /* Collection.swift in Sources */,
 				68AF8F562069690300D552E3 /* EnrichmentOptions.swift in Sources */,
+				CA35CD4F20F010EA00FACB2B /* WatsonResponse.swift in Sources */,
 				68AF8F722069690300D552E3 /* QueryResponse.swift in Sources */,
 				68AF8F792069690300D552E3 /* Calculation.swift in Sources */,
 				68AF8F882069690300D552E3 /* QueryFilterType.swift in Sources */,
@@ -3933,6 +3948,7 @@
 				6800FCBA2056D8D50078788A /* LogCollection.swift in Sources */,
 				6800FCA62056D8D50078788A /* CreateEntity.swift in Sources */,
 				6800FCA42056D8D50078788A /* CreateCounterexample.swift in Sources */,
+				CA35CD4D20F010E700FACB2B /* WatsonResponse.swift in Sources */,
 				6800FCCE2056D8D50078788A /* UpdateValue.swift in Sources */,
 				6800FCC02056D8D50078788A /* MessageResponse.swift in Sources */,
 				6800FCD02056D8D50078788A /* Value.swift in Sources */,
@@ -3969,6 +3985,7 @@
 				68BC28C11F8C35050042810E /* MultipartFormData.swift in Sources */,
 				7A6711A01DD0F1790070CA9D /* PersonalityInsights.swift in Sources */,
 				68BC28BE1F8C35050042810E /* CodableExtensions.swift in Sources */,
+				CA35CD5420F010EF00FACB2B /* WatsonResponse.swift in Sources */,
 				689A16B5203C9946002CFC66 /* Behavior.swift in Sources */,
 				6836B9052091D23C006DF944 /* Authentication.swift in Sources */,
 			);
@@ -4029,6 +4046,7 @@
 				6836B9092091D240006DF944 /* Authentication.swift in Sources */,
 				689A1692203C88C7002CFC66 /* ClassResult.swift in Sources */,
 				689A1691203C88C7002CFC66 /* ImageWithFaces.swift in Sources */,
+				CA35CD5820F010F300FACB2B /* WatsonResponse.swift in Sources */,
 				689A1698203C88C7002CFC66 /* WarningInfo.swift in Sources */,
 				689A169D203C88C7002CFC66 /* ClassifiedImages.swift in Sources */,
 				7AAAF3DA1CEE9A4700B74848 /* VisualRecognition.swift in Sources */,
@@ -4058,6 +4076,7 @@
 				CA35CD4720E3234900FACB2B /* ToneContent.swift in Sources */,
 				68D09C25200D61870087ADE5 /* DocumentAnalysis.swift in Sources */,
 				7AAAF4131CEE9D5300B74848 /* ToneScore.swift in Sources */,
+				CA35CD5720F010F200FACB2B /* WatsonResponse.swift in Sources */,
 				68BC28E61F8C35080042810E /* CodableExtensions.swift in Sources */,
 				68D09C22200D61870087ADE5 /* UtteranceAnalyses.swift in Sources */,
 				68BC28EB1F8C35080042810E /* RestRequest.swift in Sources */,
@@ -4114,6 +4133,7 @@
 				68F7FF0C207D458900E84DBF /* WordAlternativeResult.swift in Sources */,
 				68F7FF0D207D458900E84DBF /* WordError.swift in Sources */,
 				68F7FF15207D458900E84DBF /* Corpus.swift in Sources */,
+				CA35CD5520F010F000FACB2B /* WatsonResponse.swift in Sources */,
 				68F7FF11207D458900E84DBF /* CustomWords.swift in Sources */,
 				68F7FF10207D458900E84DBF /* LanguageModels.swift in Sources */,
 				68F7FF18207D458900E84DBF /* SupportedFeatures.swift in Sources */,
@@ -4165,6 +4185,7 @@
 				68A6A9AE202A38490069585F /* Classifier.swift in Sources */,
 				68A6A9AC202A38490069585F /* ClassifiedClass.swift in Sources */,
 				68438EA1208A987400FD7DB9 /* CollectionItem.swift in Sources */,
+				CA35CD5220F010ED00FACB2B /* WatsonResponse.swift in Sources */,
 				68BC28A91F8C35030042810E /* MultipartFormData.swift in Sources */,
 				68BC28AA1F8C35030042810E /* RestError.swift in Sources */,
 				68A6A9B0202A38490069585F /* Classification.swift in Sources */,
@@ -4204,6 +4225,7 @@
 				7AAAF4FA1CEEA17600B74848 /* LanguageTranslator.swift in Sources */,
 				68BC289E1F8C35020042810E /* CodableExtensions.swift in Sources */,
 				68A6A99E202A0EE90069585F /* DeleteModelResult.swift in Sources */,
+				CA35CD5020F010EB00FACB2B /* WatsonResponse.swift in Sources */,
 				68A6A99D202A0EE90069585F /* TranslationModels.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4278,6 +4300,7 @@
 				68BC28851F8C35000042810E /* RestUtilities.swift in Sources */,
 				6823CEE91F8EA0F700A388EC /* UpdateExample.swift in Sources */,
 				6823CEEE1F8EA0F700A388EC /* Value.swift in Sources */,
+				CA35CD4E20F010E900FACB2B /* WatsonResponse.swift in Sources */,
 				6823CEF21F8EA0F700A388EC /* WorkspaceCollection.swift in Sources */,
 				6823CEE71F8EA0F700A388EC /* UpdateDialogNode.swift in Sources */,
 				6823CECC1F8EA0F700A388EC /* DialogNodeAction.swift in Sources */,
@@ -4316,6 +4339,7 @@
 				CA28818120CB099D00FC992C /* TranslateRequest.swift in Sources */,
 				CAD2687620CB00F2002BA2C4 /* MultipartFormData.swift in Sources */,
 				CA28817C20CB099D00FC992C /* TranslationResult.swift in Sources */,
+				CA35CD5120F010EC00FACB2B /* WatsonResponse.swift in Sources */,
 				CA28817B20CB099D00FC992C /* Translation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		CA28818220CB099D00FC992C /* IdentifiableLanguages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA28816820CB090700FC992C /* IdentifiableLanguages.swift */; };
 		CA35CD4720E3234900FACB2B /* ToneContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4620E3234800FACB2B /* ToneContent.swift */; };
 		CA35CD4920E3237400FACB2B /* ProfileContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4820E3237400FACB2B /* ProfileContent.swift */; };
+		CA35CD4C20EF11EF00FACB2B /* WatsonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */; };
 		CAD2685B20CAF28B002BA2C4 /* LanguageTranslatorV3.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CAD2685220CAF28A002BA2C4 /* LanguageTranslatorV3.framework */; };
 		CAD2686E20CAF919002BA2C4 /* LanguageTranslator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD2686A20CAF919002BA2C4 /* LanguageTranslator.swift */; };
 		CAD2687320CB00F2002BA2C4 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6836B8FD2091D1AF006DF944 /* Authentication.swift */; };
@@ -1231,6 +1232,7 @@
 		CA28817520CB095100FC992C /* LanguageTranslatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LanguageTranslatorTests.swift; path = Tests/LanguageTranslatorV3Tests/LanguageTranslatorTests.swift; sourceTree = SOURCE_ROOT; };
 		CA35CD4620E3234800FACB2B /* ToneContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneContent.swift; sourceTree = "<group>"; };
 		CA35CD4820E3237400FACB2B /* ProfileContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileContent.swift; sourceTree = "<group>"; };
+		CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatsonResponse.swift; sourceTree = "<group>"; };
 		CA45954820A62FBE0060BF9B /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		CA45954920A630080060BF9B /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CONTRIBUTING.md; path = .github/CONTRIBUTING.md; sourceTree = "<group>"; };
 		CAD2685220CAF28A002BA2C4 /* LanguageTranslatorV3.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LanguageTranslatorV3.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1926,6 +1928,7 @@
 				681BA1B41F7DCB1E006633A3 /* RestError.swift */,
 				7A61174F1CB5988B009A4DA1 /* RestRequest.swift */,
 				7AAA9A3C1CEE3059002C9564 /* RestUtilities.swift */,
+				CA35CD4A20EF0A1100FACB2B /* WatsonResponse.swift */,
 				682D30681F7D3BFD005562F9 /* Tests */,
 			);
 			name = RestKit;
@@ -3984,6 +3987,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA35CD4C20EF11EF00FACB2B /* WatsonResponse.swift in Sources */,
 				68BC29011F8C38700042810E /* MultipartFormData.swift in Sources */,
 				68B213EF1F84298B0052DC00 /* CodableExtensionsTests.swift in Sources */,
 				68B213F01F84298B0052DC00 /* JSONValueTests.swift in Sources */,


### PR DESCRIPTION
This PR contains the RestKit changes to support service methods with a single completion handler.

The single completion handler is more consistent with the style of Apple APIs.

The signature for the completion handler is:
```
(WatsonResponse<T>?, Error?) -> Void
```

The `WatsonResponse` is a new `struct` (class) that contains the service response code, the method result (a `T`), and a `headers` dictionary containing response headers.

This PR includes a generated ToneAnalyzer service with updated tests to use the single completion handler.  This shows some concrete examples of the new API design.

The other services have not been regenerated or updated, so these will fail to build -- that is expected.


