### PR TITLE
Change VR classifyWithLocalModel to accept an imageFile

### DIFF
--- a/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
@@ -128,7 +128,7 @@ extension VisualRecognition {
     /**
      Classify an image using a Core ML model from the local filesystem.
 
-     - parameter image: The image to classify.
+     - parameter imagesFile: The image to classify.
      - parameter classifierIDs: A list of the classifier ids to use. "default" is the id of the
        built-in classifier.
      - parameter threshold: The minimum score a class must have to be displayed in the response.
@@ -136,17 +136,17 @@ extension VisualRecognition {
      - parameter success: A function executed with the image classifications.
      */
     public func classifyWithLocalModel(
-        image: UIImage,
+        imagesFile: URL,
         classifierIDs: [String] = ["default"],
         threshold: Double? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ClassifiedImages) -> Void)
     {
-        // convert UIImage to Data
-        guard let image = UIImagePNGRepresentation(image) else {
-            let description = "Failed to convert image from UIImage to Data."
-            let userInfo = [NSLocalizedDescriptionKey: description]
-            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+        // convert imagesFile to Data
+        var imagesData: Data
+        do {
+            imagesData = try Data(contentsOf: imagesFile)
+        } catch {
             failure?(error)
             return
         }
@@ -222,7 +222,7 @@ extension VisualRecognition {
 
                 // execute classification request
                 do {
-                    let requestHandler = VNImageRequestHandler(data: image)
+                    let requestHandler = VNImageRequestHandler(data: imagesData)
                     try requestHandler.perform([request])
                 } catch {
                     dispatchGroup.leave()

--- a/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
@@ -128,7 +128,7 @@ extension VisualRecognition {
     /**
      Classify an image using a Core ML model from the local filesystem.
 
-     - parameter imagesFile: The image to classify.
+     - parameter imageFile: The image to classify.
      - parameter classifierIDs: A list of the classifier ids to use. "default" is the id of the
        built-in classifier.
      - parameter threshold: The minimum score a class must have to be displayed in the response.
@@ -136,21 +136,32 @@ extension VisualRecognition {
      - parameter success: A function executed with the image classifications.
      */
     public func classifyWithLocalModel(
-        imagesFile: URL,
+        imageFile: URL,
         classifierIDs: [String] = ["default"],
         threshold: Double? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ClassifiedImages) -> Void)
     {
-        // convert imagesFile to Data
-        var imagesData: Data
+        // convert imageFile to Data
+        var imageData: Data
         do {
-            imagesData = try Data(contentsOf: imagesFile)
+            imageData = try Data(contentsOf: imageFile)
         } catch {
             failure?(error)
             return
         }
 
+        classifyWithLocalModel(imageData: imageData, classifierIDs: classifierIDs, threshold: threshold,
+                               failure: failure, success: success)
+    }
+
+    internal func classifyWithLocalModel(
+        imageData: Data,
+        classifierIDs: [String] = ["default"],
+        threshold: Double? = nil,
+        failure: ((Error) -> Void)? = nil,
+        success: @escaping (ClassifiedImages) -> Void)
+    {
         // ensure a classifier id was provided
         guard !classifierIDs.isEmpty else {
             let description = "Please provide at least one classifierID."
@@ -222,7 +233,7 @@ extension VisualRecognition {
 
                 // execute classification request
                 do {
-                    let requestHandler = VNImageRequestHandler(data: imagesData)
+                    let requestHandler = VNImageRequestHandler(data: imageData)
                     try requestHandler.perform([request])
                 } catch {
                     dispatchGroup.leave()

--- a/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
@@ -128,7 +128,7 @@ extension VisualRecognition {
     /**
      Classify an image using a Core ML model from the local filesystem.
 
-     - parameter imageFile: The image to classify.
+     - parameter imageData: The image to classify.
      - parameter classifierIDs: A list of the classifier ids to use. "default" is the id of the
        built-in classifier.
      - parameter threshold: The minimum score a class must have to be displayed in the response.
@@ -136,26 +136,6 @@ extension VisualRecognition {
      - parameter success: A function executed with the image classifications.
      */
     public func classifyWithLocalModel(
-        imageFile: URL,
-        classifierIDs: [String] = ["default"],
-        threshold: Double? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (ClassifiedImages) -> Void)
-    {
-        // convert imageFile to Data
-        var imageData: Data
-        do {
-            imageData = try Data(contentsOf: imageFile)
-        } catch {
-            failure?(error)
-            return
-        }
-
-        classifyWithLocalModel(imageData: imageData, classifierIDs: classifierIDs, threshold: threshold,
-                               failure: failure, success: success)
-    }
-
-    internal func classifyWithLocalModel(
         imageData: Data,
         classifierIDs: [String] = ["default"],
         threshold: Double? = nil,

--- a/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
@@ -152,22 +152,17 @@ extension VisualRecognition {
         failure: ((Error) -> Void)? = nil,
         success: @escaping (ClassifiedImages) -> Void)
     {
-        // save image to disk
-        let file: URL
-        do {
-            file = try saveToDisk(image: image)
-        } catch {
+        // convert UIImage to Data
+        guard let imageData = UIImagePNGRepresentation(image) else {
+            let description = "Failed to convert image from UIImage to Data."
+            let userInfo = [NSLocalizedDescriptionKey: description]
+            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
             failure?(error)
             return
         }
 
-        // delete image after service call
-        let deleteFile = { try? FileManager.default.removeItem(at: file) }
-        let failureWithDelete = { (error: Error) in deleteFile(); failure?(error) }
-        let successWithDelete = { (classifiedImages: ClassifiedImages) in deleteFile(); success(classifiedImages) }
-
-        self.classifyWithLocalModel(imagesFile: file, classifierIDs: classifierIDs, threshold: threshold,
-                                    failure: failureWithDelete, success: successWithDelete)
+        self.classifyWithLocalModel(imageData: imageData, classifierIDs: classifierIDs, threshold: threshold,
+                                    failure: failure, success: success)
     }
 
     /**

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
@@ -111,7 +111,7 @@ class VisualRecognitionCoreMLTests: XCTestCase {
         }
     }
 
-    func testClassifyWithLocalModel() {
+    func testClassifyWithLocalModel() throws {
         if #available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
 
             // update the local model
@@ -121,11 +121,14 @@ class VisualRecognitionCoreMLTests: XCTestCase {
             }
             waitForExpectations()
 
+            // convert imageFile to Data
+            let bundle = Bundle(for: type(of: self))
+            let imageFile = bundle.url(forResource: "car", withExtension: "png")!
+            let imageData = try Data(contentsOf: imageFile)
+
             // classify using the local model
             let expectation2 = self.expectation(description: "classifyWithLocalModel")
-            let bundle = Bundle(for: type(of: self))
-            let image = bundle.url(forResource: "car", withExtension: "png")!
-            visualRecognition.classifyWithLocalModel(imageFile: image, classifierIDs: [classifierID], threshold: 0.1, failure: failWithError) {
+            visualRecognition.classifyWithLocalModel(imageData: imageData, classifierIDs: [classifierID], threshold: 0.1, failure: failWithError) {
                 classifiedImages in
                 print(classifiedImages)
                 expectation2.fulfill()

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
@@ -112,7 +112,7 @@ class VisualRecognitionCoreMLTests: XCTestCase {
     }
 
     func testClassifyWithLocalModel() {
-        if #available(iOS 11.0, *) {
+        if #available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
 
             // update the local model
             let expectation1 = self.expectation(description: "updateLocalModel")
@@ -123,8 +123,9 @@ class VisualRecognitionCoreMLTests: XCTestCase {
 
             // classify using the local model
             let expectation2 = self.expectation(description: "classifyWithLocalModel")
-            let image = UIImage(named: "car", in: Bundle(for: type(of: self)), compatibleWith: nil)!
-            visualRecognition.classifyWithLocalModel(image: image, classifierIDs: [classifierID], threshold: 0.1, failure: failWithError) {
+            let bundle = Bundle(for: type(of: self))
+            let image = bundle.url(forResource: "car", withExtension: "png")!
+            visualRecognition.classifyWithLocalModel(imagesFile: image, classifierIDs: [classifierID], threshold: 0.1, failure: failWithError) {
                 classifiedImages in
                 print(classifiedImages)
                 expectation2.fulfill()

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
@@ -125,7 +125,7 @@ class VisualRecognitionCoreMLTests: XCTestCase {
             let expectation2 = self.expectation(description: "classifyWithLocalModel")
             let bundle = Bundle(for: type(of: self))
             let image = bundle.url(forResource: "car", withExtension: "png")!
-            visualRecognition.classifyWithLocalModel(imagesFile: image, classifierIDs: [classifierID], threshold: 0.1, failure: failWithError) {
+            visualRecognition.classifyWithLocalModel(imageFile: image, classifierIDs: [classifierID], threshold: 0.1, failure: failWithError) {
                 classifiedImages in
                 print(classifiedImages)
                 expectation2.fulfill()

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
@@ -26,6 +26,7 @@ import VisualRecognitionV3
 class VisualRecognitionUIImageTests: XCTestCase {
 
     private var visualRecognition: VisualRecognition!
+    private let classifierID = Credentials.VisualRecognitionClassifierID
 
     private var car: UIImage {
         let bundle = Bundle(for: type(of: self))

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
@@ -26,7 +26,7 @@ import VisualRecognitionV3
 class VisualRecognitionUIImageTests: XCTestCase {
 
     private var visualRecognition: VisualRecognition!
-    private let classifierID = Credentials.VisualRecognitionClassifierID
+    private let classifierID = WatsonCredentials.VisualRecognitionClassifierID
 
     private var car: UIImage {
         let bundle = Bundle(for: type(of: self))

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
@@ -151,6 +151,37 @@ class VisualRecognitionUIImageTests: XCTestCase {
         }
         waitForExpectations()
     }
+
+    func testClassifyWithLocalModel() {
+        if #available(iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+            // update the local model
+            let expectation1 = self.expectation(description: "updateLocalModel")
+            visualRecognition.updateLocalModel(classifierID: classifierID, failure: failWithError) {
+                expectation1.fulfill()
+            }
+            waitForExpectations()
+
+            // classify using the local model
+            let expectation2 = self.expectation(description: "classifyWithLocalModel")
+            let image = UIImage(named: "car", in: Bundle(for: type(of: self)), compatibleWith: nil)!
+            visualRecognition.classifyWithLocalModel(image: image, classifierIDs: [classifierID], threshold: 0.1, failure: failWithError) {
+                classifiedImages in
+                print(classifiedImages)
+                expectation2.fulfill()
+            }
+            waitForExpectations()
+
+            // delete the local model
+            do {
+                try visualRecognition.deleteLocalModel(classifierID: classifierID)
+            } catch {
+                XCTFail("Failed to delete the local model: \(error)")
+            }
+
+        } else {
+            XCTFail("Core ML required iOS 11+")
+        }
+    }
 }
 
 #endif


### PR DESCRIPTION
This PR changes the `classifyWithLocalModel` method of VisualRecognition+CoreML to take an imagesFile of type URL rather than an image of type UIImage.  This change fixes a build problem for this file on macOS -- which isn't technically supported but is explicitly allowed by the ifdef enclosing the file.

The PR also adds a method to VisualRecognition+UIImage that conforms to the original `classifyWithLocalModel` signature, for backward-compatiblity.  The new method simply wraps the CoreML method in a manner similar to the other methods in this file.