### PR TITLE
Manual fix for generator bug in shared params with alternate name

### DIFF
--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -2030,7 +2030,7 @@ public class Discovery {
             queryParameters.append(queryParameter)
         }
         if let returnFields = returnFields {
-            let queryParameter = URLQueryItem(name: "return_fields", value: returnFields.joined(separator: ","))
+            let queryParameter = URLQueryItem(name: "return", value: returnFields.joined(separator: ","))
             queryParameters.append(queryParameter)
         }
         if let offset = offset {
@@ -2212,7 +2212,7 @@ public class Discovery {
             queryParameters.append(queryParameter)
         }
         if let returnFields = returnFields {
-            let queryParameter = URLQueryItem(name: "return_fields", value: returnFields.joined(separator: ","))
+            let queryParameter = URLQueryItem(name: "return", value: returnFields.joined(separator: ","))
             queryParameters.append(queryParameter)
         }
         if let offset = offset {
@@ -2389,7 +2389,7 @@ public class Discovery {
             queryParameters.append(queryParameter)
         }
         if let returnFields = returnFields {
-            let queryParameter = URLQueryItem(name: "return_fields", value: returnFields.joined(separator: ","))
+            let queryParameter = URLQueryItem(name: "return", value: returnFields.joined(separator: ","))
             queryParameters.append(queryParameter)
         }
         if let offset = offset {


### PR DESCRIPTION
This PR fixes the `baseName` of `return` parameter, which was incorrectly set to the parameter "alternate name" by a generator bug.

The generator bug has been fixed, but I've patched this by hand this time around so that we don't have to wait for the next regen to get this corrected.