### PR TITLE
Update Speech-to-Text tests for single completion handler

### DIFF
--- a/Source/RestKit/RestRequest.swift
+++ b/Source/RestKit/RestRequest.swift
@@ -185,18 +185,17 @@ extension RestRequest {
                 return
             }
 
-            switch watsonResponse.result {
-            case is Data?:
+            if T.self == Data.self {
                 // pass thru the raw data
                 watsonResponse.result = data as? T
-            case is String?:
+            } else if T.self == String.self {
                 // parse data as a string
                 guard let string = String(data: data, encoding: .utf8) else {
                     completionHandler(watsonResponse, RestError.serializationError)
                     return
                 }
                 watsonResponse.result = string as? T
-            default:
+            } else {
                 // no other supported types
                 watsonResponse.result = nil
             }

--- a/Source/RestKit/WatsonResponse.swift
+++ b/Source/RestKit/WatsonResponse.swift
@@ -39,15 +39,19 @@ public struct WatsonResponse<T> {
      */
     public var result: T?
 
+    internal init(statusCode: Int, headers: [String: String] = [:]) {
+        self.statusCode = statusCode
+        self.headers = headers
+    }
+
     internal init(response: HTTPURLResponse) {
-        self.statusCode = response.statusCode
-        self.headers = [:]
+        var headers: [String: String] = [:]
         for (key, value) in response.allHeaderFields {
             if let key = key as? String,
                 let value = value as? String {
-                self.headers[key] = value
+                headers[key] = value
             }
         }
+        self.init(statusCode: response.statusCode, headers: headers)
     }
-
 }

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -45,8 +45,7 @@ extension SpeechToText {
         model: String? = nil,
         customizationID: String? = nil,
         learningOptOut: Bool? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (SpeechRecognitionResults) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, Error?) -> Void)
     {
         do {
             let data = try Data(contentsOf: audio)
@@ -56,14 +55,13 @@ extension SpeechToText {
                 model: model,
                 customizationID: customizationID,
                 learningOptOut: learningOptOut,
-                failure: failure,
-                success: success
+                completionHandler: completionHandler
             )
         } catch {
             let failureReason = "Could not load audio data from \(audio)."
             let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
-            failure?(error)
+            completionHandler(nil, error)
             return
         }
     }
@@ -89,8 +87,7 @@ extension SpeechToText {
         model: String? = nil,
         customizationID: String? = nil,
         learningOptOut: Bool? = nil,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (SpeechRecognitionResults) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, Error?) -> Void)
     {
         // create SpeechToTextSession
         let session = SpeechToTextSession(
@@ -109,8 +106,14 @@ extension SpeechToText {
         session.defaultHeaders = defaultHeaders
 
         // set callbacks
-        session.onResults = success
-        session.onError = failure
+        session.onResults = { result in
+            var response = WatsonResponse<SpeechRecognitionResults>(statusCode: 0)
+            response.result = result
+            completionHandler(response, nil)
+        }
+        session.onError = { error in
+            completionHandler(nil, error)
+        }
 
         // execute recognition request
         session.connect()
@@ -152,8 +155,7 @@ extension SpeechToText {
         customizationID: String? = nil,
         learningOptOut: Bool? = nil,
         compress: Bool = true,
-        failure: ((Error) -> Void)? = nil,
-        success: @escaping (SpeechRecognitionResults) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, Error?) -> Void)
     {
         // make sure the AVAudioSession shared instance is properly configured
         do {
@@ -164,7 +166,7 @@ extension SpeechToText {
             let failureReason = "Failed to setup the AVAudioSession sharedInstance properly."
             let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
-            failure?(error)
+            completionHandler(nil, error)
             return
         }
 
@@ -177,7 +179,7 @@ extension SpeechToText {
             let failureReason = "Invalid authenticaion method format."
             let userInfo = [NSLocalizedDescriptionKey: failureReason]
             let error = NSError(domain: domain, code: 0, userInfo: userInfo)
-            failure?(error)
+            completionHandler(nil, error)
             return
         }
 
@@ -199,8 +201,14 @@ extension SpeechToText {
         session.defaultHeaders = defaultHeaders
 
         // set callbacks
-        session.onResults = success
-        session.onError = failure
+        session.onResults = { result in
+            var response = WatsonResponse<SpeechRecognitionResults>(statusCode: 0)
+            response.result = result
+            completionHandler(response, nil)
+        }
+        session.onError = { error in
+            completionHandler(nil, error)
+        }
 
         // start recognition request
         session.connect()

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -202,7 +202,7 @@ extension SpeechToText {
 
         // set callbacks
         session.onResults = { result in
-            var response = WatsonResponse<SpeechRecognitionResults>(statusCode: 0)
+            var response = WatsonResponse<SpeechRecognitionResults>(statusCode: 200)
             response.result = result
             completionHandler(response, nil)
         }

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -106,11 +106,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         speechToText.recognize(audio: file, settings: settings) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             self.validateSTTResults(results: results, settings: settings)
@@ -164,11 +164,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         speechToText.recognize(audio: file, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             self.validateSTTResults(results: results, settings: settings)
@@ -214,11 +214,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
             speechToText.recognize(audio: audio, settings: settings) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail("Received an unexpected error: \(error)")
                     return
                 }
                 guard let results = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail("Missing result from response")
                     return
                 }
                 self.validateSTTResults(results: results, settings: settings)
@@ -279,11 +279,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
             speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail("Received an unexpected error: \(error)")
                     return
                 }
                 guard let results = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail("Missing result from response")
                     return
                 }
                 self.validateSTTResults(results: results, settings: settings)
@@ -333,11 +333,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             self.validateSTTResults(results: results, settings: settings)
@@ -390,11 +390,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
             speechToText.recognize(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail("Received an unexpected error: \(error)")
                     return
                 }
                 guard let results = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail("Missing result from response")
                     return
                 }
                 XCTAssertNotNil(results.speakerLabels)

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -78,20 +78,6 @@ class SpeechToTextRecognizeTests: XCTestCase {
         ]
     }
 
-    // MARK: - Helper Functions
-
-    func failWithError(error: Error) {
-        XCTFail("Positive test failed with error: \(error)")
-    }
-
-    func failWithResult<T>(result: T) {
-        XCTFail("Negative test returned a result.")
-    }
-
-    func failWithResult() {
-        XCTFail("Negative test returned a result.")
-    }
-
     // MARK: - Transcribe File, Default Settings
 
     func testTranscribeFileDefaultWAV() {
@@ -117,7 +103,16 @@ class SpeechToTextRecognizeTests: XCTestCase {
         }
 
         let settings = RecognitionSettings(contentType: format)
-        speechToText.recognize(audio: file, settings: settings, failure: failWithError) { results in
+        speechToText.recognize(audio: file, settings: settings) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let results = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             self.validateSTTResults(results: results, settings: settings)
             XCTAssertNotNil(results.results)
             XCTAssertEqual(results.results!.count, 1)
@@ -166,7 +161,16 @@ class SpeechToTextRecognizeTests: XCTestCase {
         settings.filterProfanity = false
         settings.smartFormatting = true
 
-        speechToText.recognize(audio: file, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true, failure: failWithError) { results in
+        speechToText.recognize(audio: file, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let results = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             self.validateSTTResults(results: results, settings: settings)
             XCTAssertNotNil(results.results)
             if results.results!.last?.finalResults == true {
@@ -207,7 +211,16 @@ class SpeechToTextRecognizeTests: XCTestCase {
             let audio = try Data(contentsOf: file)
 
             let settings = RecognitionSettings(contentType: format)
-            speechToText.recognize(audio: audio, settings: settings, failure: failWithError) { results in
+            speechToText.recognize(audio: audio, settings: settings) {
+                response, error in
+                if let error = error {
+                    XCTFail("Unexpected error response from service: \(error)")
+                    return
+                }
+                guard let results = response?.result else {
+                    XCTFail("Missing result value")
+                    return
+                }
                 self.validateSTTResults(results: results, settings: settings)
                 XCTAssertNotNil(results.results)
                 XCTAssertEqual(results.results!.count, 1)
@@ -263,7 +276,16 @@ class SpeechToTextRecognizeTests: XCTestCase {
             settings.filterProfanity = false
             settings.smartFormatting = true
 
-            speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true, failure: failWithError) { results in
+            speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
+                response, error in
+                if let error = error {
+                    XCTFail("Unexpected error response from service: \(error)")
+                    return
+                }
+                guard let results = response?.result else {
+                    XCTFail("Missing result value")
+                    return
+                }
                 self.validateSTTResults(results: results, settings: settings)
                 if results.results?.last?.finalResults == true {
                     let transcript = results.results!.last?.alternatives.last?.transcript
@@ -308,7 +330,16 @@ class SpeechToTextRecognizeTests: XCTestCase {
         var settings = RecognitionSettings(contentType: format)
         settings.smartFormatting = true
 
-        speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true, failure: failWithError) { results in
+        speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let results = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             self.validateSTTResults(results: results, settings: settings)
             XCTAssertNotNil(results.results)
             if results.results!.last?.finalResults == true {
@@ -356,7 +387,16 @@ class SpeechToTextRecognizeTests: XCTestCase {
             settings.filterProfanity = false
             settings.speakerLabels = true
 
-            speechToText.recognize(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true, failure: failWithError) { results in
+            speechToText.recognize(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true) {
+                response, error in
+                if let error = error {
+                    XCTFail("Unexpected error response from service: \(error)")
+                    return
+                }
+                guard let results = response?.result else {
+                    XCTFail("Missing result value")
+                    return
+                }
                 XCTAssertNotNil(results.speakerLabels)
                 if !expectationFulfilled && results.speakerLabels!.count > 0 {
                     self.validateSTTSpeakerLabels(speakerLabels: results.speakerLabels!)

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -70,10 +70,20 @@ class SpeechToTextTests: XCTestCase {
     func lookupOrCreateTestLanguageModel() -> LanguageModel? {
         var languageModel: LanguageModel?
         let expectation = self.expectation(description: "listLanguageModels")
-        let failure = failureExceptLitePlan(expectation: expectation, message: "Failed to lookup languageModel")
-        speechToText.listLanguageModels(failure: failure) {
-            response in
-            languageModel = response.customizations.first { $0.name == "swift-test-model" }
+        speechToText.listLanguageModels {
+            response, error in
+            if let error = error {
+                if !error.localizedDescription.contains(self.litePlanMessage) {
+                    XCTFail("Lookup for languageModel failed: \(error)")
+                }
+                expectation.fulfill()
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
+            languageModel = result.customizations.first { $0.name == "swift-test-model" }
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
@@ -84,9 +94,19 @@ class SpeechToTextTests: XCTestCase {
         var languageModel: LanguageModel?
         let expectation = self.expectation(description: "createLanguageModel")
         let options = CreateLanguageModel(name: "swift-test-model", baseModelName: "en-US_BroadbandModel")
-        let failure = failureExceptLitePlan(expectation: expectation)
-        speechToText.createLanguageModel(createLanguageModel: options, failure: failure) {
-            model in
+        speechToText.createLanguageModel(createLanguageModel: options) {
+            response, error in
+            if let error = error {
+                if !error.localizedDescription.contains(self.litePlanMessage) {
+                    XCTFail("Create for languageModel failed: \(error)")
+                }
+                expectation.fulfill()
+                return
+            }
+            guard let model = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             languageModel = model
             expectation.fulfill()
         }
@@ -97,10 +117,20 @@ class SpeechToTextTests: XCTestCase {
     func lookupOrCreateTestAcousticModel() -> AcousticModel? {
         var acousticModel: AcousticModel?
         let expectation = self.expectation(description: "listAcousticModels")
-        let failure = failureExceptLitePlan(expectation: expectation, message: "Failed to lookup acousticModel")
-        speechToText.listAcousticModels(failure: failure) {
-            response in
-            acousticModel = response.customizations.first { $0.name == "swift-test-model" }
+        speechToText.listAcousticModels {
+            response, error in
+            if let error = error {
+                if !error.localizedDescription.contains(self.litePlanMessage) {
+                    XCTFail("Lookup for acousticModel failed: \(error)")
+                }
+                expectation.fulfill()
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
+            acousticModel = result.customizations.first { $0.name == "swift-test-model" }
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
@@ -110,9 +140,19 @@ class SpeechToTextTests: XCTestCase {
     func createTestAcousticModel() -> AcousticModel? {
         var acousticModel: AcousticModel?
         let expectation = self.expectation(description: "createAcousticModel")
-        let failure = failureExceptLitePlan(expectation: expectation)
-        speechToText.createAcousticModel(name: "swift-test-model", baseModelName: "en-US_BroadbandModel", failure: failure) {
-            model in
+        speechToText.createAcousticModel(name: "swift-test-model", baseModelName: "en-US_BroadbandModel") {
+            response, error in
+            if let error = error {
+                if !error.localizedDescription.contains(self.litePlanMessage) {
+                    XCTFail("Lookup for languageModel failed: \(error)")
+                }
+                expectation.fulfill()
+                return
+            }
+            guard let model = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             acousticModel = model
             expectation.fulfill()
         }
@@ -123,15 +163,16 @@ class SpeechToTextTests: XCTestCase {
     func addTrainingData(to languageModel: LanguageModel) {
         let expectation = self.expectation(description: "addCorpus")
         let file = Bundle(for: type(of: self)).url(forResource: "healthcare-short", withExtension: "txt")!
-        let failure = { (error: Error) in XCTFail(error.localizedDescription) }
         speechToText.addCorpus(
             customizationID: languageModel.customizationID,
             corpusName: "swift-test-corpus",
             corpusFile: file,
-            allowOverwrite: true,
-            corpusFileContentType: "plain/text",
-            failure: failure)
+            allowOverwrite: true)
         {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
@@ -146,9 +187,12 @@ class SpeechToTextTests: XCTestCase {
             audioName: "audio",
             audioResource: audio,
             contentType: "audio/wav",
-            allowOverwrite: true,
-            failure: failWithError)
+            allowOverwrite: true)
         {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
@@ -172,8 +216,19 @@ class SpeechToTextTests: XCTestCase {
         waitUntil(maxRetries: 12) {
             var hasDesiredStatus = false
             let expectation = self.expectation(description: "getLanguageModel")
-            let failure = { (error: Error) in if !error.localizedDescription.contains("locked") { XCTFail(error.localizedDescription) }}
-            speechToText.getLanguageModel(customizationID: languageModel.customizationID, failure: failure) { model in
+            speechToText.getLanguageModel(customizationID: languageModel.customizationID) {
+                response, error in
+                if let error = error {
+                    if !error.localizedDescription.contains("locked") {
+                        XCTFail("Unexpected error response from service: \(error)")
+                    }
+                    expectation.fulfill()
+                    return
+                }
+                guard let model = response?.result else {
+                    XCTFail("Missing result value")
+                    return
+                }
                 hasDesiredStatus = (model.status == status)
                 expectation.fulfill()
             }
@@ -186,8 +241,19 @@ class SpeechToTextTests: XCTestCase {
         waitUntil {
             var hasDesiredStatus = false
             let expectation = self.expectation(description: "getAcousticModel")
-            let failure = { (error: Error) in if !error.localizedDescription.contains("locked") { XCTFail(error.localizedDescription) }}
-            speechToText.getAcousticModel(customizationID: acousticModel.customizationID, failure: failure) { model in
+            speechToText.getAcousticModel(customizationID: acousticModel.customizationID) {
+                response, error in
+                if let error = error {
+                    if !error.localizedDescription.contains("locked") {
+                        XCTFail("Unexpected error response from service: \(error)")
+                    }
+                    expectation.fulfill()
+                    return
+                }
+                guard let model = response?.result else {
+                    XCTFail("Missing result value")
+                    return
+                }
                 hasDesiredStatus = (model.status == status)
                 expectation.fulfill()
             }
@@ -200,8 +266,19 @@ class SpeechToTextTests: XCTestCase {
         waitUntil {
             var hasDesiredStatus = false
             let expectation = self.expectation(description: "getCorpus")
-            let failure = { (error: Error) in if !error.localizedDescription.contains("locked") { XCTFail(error.localizedDescription) }}
-            speechToText.getCorpus(customizationID: languageModel.customizationID, corpusName: corpus, failure: failure) { corpus in
+            speechToText.getCorpus(customizationID: languageModel.customizationID, corpusName: corpus) {
+                response, error in
+                if let error = error {
+                    if !error.localizedDescription.contains("locked") {
+                        XCTFail("Unexpected error response from service: \(error)")
+                    }
+                    expectation.fulfill()
+                    return
+                }
+                guard let corpus = response?.result else {
+                    XCTFail("Missing result value")
+                    return
+                }
                 hasDesiredStatus = (corpus.status == status)
                 expectation.fulfill()
             }
@@ -210,36 +287,21 @@ class SpeechToTextTests: XCTestCase {
         }
     }
 
-    // MARK: - Helper Functions
-
-    func failWithError(error: Error) {
-        XCTFail("Positive test failed with error: \(error)")
-    }
-
-    func failWithResult<T>(result: T) {
-        XCTFail("Negative test returned a result.")
-    }
-
-    func failWithResult() {
-        XCTFail("Negative test returned a result.")
-    }
-
-    func failureExceptLitePlan(expectation: XCTestExpectation,
-                               message: String = "Positive test failed with error") -> ((Error) -> Void) {
-        return { (error: Error) in
-            if !error.localizedDescription.contains(self.litePlanMessage) {
-                XCTFail("\(message): \(error)")
-            }
-            expectation.fulfill()
-        }
-    }
-
     // MARK: - Models
 
     func testListModels() {
         let expectation = self.expectation(description: "listModels")
-        speechToText.listModels(failure: failWithError) { results in
-            XCTAssertGreaterThan(results.models.count, 0)
+        speechToText.listModels {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
+            XCTAssertGreaterThan(result.models.count, 0)
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
@@ -248,7 +310,16 @@ class SpeechToTextTests: XCTestCase {
     func testGetModel() {
         let expectation = self.expectation(description: "getModel")
         let modelID = "en-US_BroadbandModel"
-        speechToText.getModel(modelID: modelID, failure: failWithError) { model in
+        speechToText.getModel(modelID: modelID) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let model = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertEqual(model.name, modelID)
             expectation.fulfill()
         }
@@ -260,8 +331,16 @@ class SpeechToTextTests: XCTestCase {
     func testRecognizeSessionless() {
         let expectation = self.expectation(description: "recognizeSessionless")
         let audio = try! Data(contentsOf: Bundle(for: type(of: self)).url(forResource: "SpeechSample", withExtension: "wav")!)
-        speechToText.recognizeSessionless(model: "en-US_BroadbandModel", audio: audio, contentType: "audio/wav", failure: failWithError) {
-            recognitionResults in
+        speechToText.recognizeSessionless(model: "en-US_BroadbandModel", audio: audio, contentType: "audio/wav") {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let recognitionResults = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertNotNil(recognitionResults.results)
             XCTAssertGreaterThan(recognitionResults.results!.count, 0)
             XCTAssertTrue(recognitionResults.results!.first!.finalResults)
@@ -280,8 +359,16 @@ class SpeechToTextTests: XCTestCase {
         let expectation1 = self.expectation(description: "createJob")
         let audio = try! Data(contentsOf: Bundle(for: type(of: self)).url(forResource: "SpeechSample", withExtension: "wav")!)
         var job: RecognitionJob!
-        speechToText.createJob(audio: audio, contentType: "audio/wav", model: "en-US_BroadbandModel", failure: failWithError) {
-            result in
+        speechToText.createJob(audio: audio, contentType: "audio/wav", model: "en-US_BroadbandModel") {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             job = result
             expectation1.fulfill()
         }
@@ -289,7 +376,16 @@ class SpeechToTextTests: XCTestCase {
 
         // check the jobs
         let expectation2 = self.expectation(description: "checkJobs")
-        speechToText.checkJobs(failure: failWithError) { result in
+        speechToText.checkJobs {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertGreaterThan(result.recognitions.count, 0)
             expectation2.fulfill()
         }
@@ -297,7 +393,16 @@ class SpeechToTextTests: XCTestCase {
 
         // check the job we created
         let expectation3 = self.expectation(description: "checkJob")
-        speechToText.checkJob(id: job.id, failure: failWithError) { result in
+        speechToText.checkJob(id: job.id) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertEqual(result.id, job.id)
             expectation3.fulfill()
         }
@@ -306,8 +411,16 @@ class SpeechToTextTests: XCTestCase {
         // register a callback
         let expectation4 = self.expectation(description: "registerCallback")
         let url = "https://watson-test-resources.mybluemix.net/speech-to-text-async/secure/callback"
-        speechToText.registerCallback(callbackUrl: url, userSecret: "ThisIsMySecret", failure: failWithError) {
-            status in
+        speechToText.registerCallback(callbackUrl: url, userSecret: "ThisIsMySecret") {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let status = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertEqual(status.url, url)
             expectation4.fulfill()
         }
@@ -315,14 +428,22 @@ class SpeechToTextTests: XCTestCase {
 
         // unregister a callback
         let expectation5 = self.expectation(description: "unregisterCallback")
-        speechToText.unregisterCallback(callbackUrl: url, failure: failWithError) {
+        speechToText.unregisterCallback(callbackUrl: url) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation5.fulfill()
         }
         wait(for: [expectation5], timeout: timeout)
 
         // delete the job we created
         let expectation6 = self.expectation(description: "deleteJob")
-        speechToText.deleteJob(id: job.id, failure: failWithError) {
+        speechToText.deleteJob(id: job.id) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation6.fulfill()
         }
         wait(for: [expectation6], timeout: timeout)
@@ -337,8 +458,19 @@ class SpeechToTextTests: XCTestCase {
         let expectation1 = self.expectation(description: "createLanguageModel")
         let createLanguageModel = CreateLanguageModel(name: "swift-test-model", baseModelName: "en-US_BroadbandModel", description: "Test model")
         var languageModel: LanguageModel!
-        speechToText.createLanguageModel(createLanguageModel: createLanguageModel,
-                                         failure: failureExceptLitePlan(expectation: expectation1)) { model in
+        speechToText.createLanguageModel(createLanguageModel: createLanguageModel) {
+            response, error in
+            if let error = error {
+                if !error.localizedDescription.contains(self.litePlanMessage) {
+                    XCTFail("Unexpected error response from service: \(error)")
+                }
+                expectation1.fulfill()
+                return
+            }
+            guard let model = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             languageModel = model
             expectation1.fulfill()
         }
@@ -351,15 +483,33 @@ class SpeechToTextTests: XCTestCase {
 
         // list the language models
         let expectation2 = self.expectation(description: "listLanguageModels")
-        speechToText.listLanguageModels(language: "en-US", failure: failWithError) { results in
-            XCTAssertTrue(results.customizations.contains { $0.customizationID == languageModel.customizationID })
+        speechToText.listLanguageModels(language: "en-US") {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
+            XCTAssertTrue(result.customizations.contains { $0.customizationID == languageModel.customizationID })
             expectation2.fulfill()
         }
         wait(for: [expectation2], timeout: timeout)
 
         // get the language model
         let expectation3 = self.expectation(description: "getLanguageModel")
-        speechToText.getLanguageModel(customizationID: languageModel.customizationID, failure: failWithError) { model in
+        speechToText.getLanguageModel(customizationID: languageModel.customizationID) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let model = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertEqual(model.customizationID, languageModel.customizationID)
             expectation3.fulfill()
         }
@@ -370,7 +520,11 @@ class SpeechToTextTests: XCTestCase {
 
         // train the language model
         let expectation4 = self.expectation(description: "trainLanguageModel")
-        speechToText.trainLanguageModel(customizationID: languageModel.customizationID, wordTypeToAdd: "all", customizationWeight: 0.3, failure: failWithError) {
+        speechToText.trainLanguageModel(customizationID: languageModel.customizationID, wordTypeToAdd: "all", customizationWeight: 0.3) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation4.fulfill()
         }
         wait(for: [expectation4], timeout: timeout)
@@ -380,15 +534,24 @@ class SpeechToTextTests: XCTestCase {
 
         // reset the language model
         let expectation5 = self.expectation(description: "resetLanguageModel")
-        speechToText.resetLanguageModel(customizationID: languageModel.customizationID, failure: failWithError) {
+        speechToText.resetLanguageModel(customizationID: languageModel.customizationID) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation5.fulfill()
         }
         wait(for: [expectation5], timeout: timeout)
 
         // upgrade the language model
         let expectation6 = self.expectation(description: "upgradeLanguageModel")
-        let failure = { (error: Error) in error.localizedDescription.contains("model is up-to-date") ? expectation6.fulfill() : XCTFail(error.localizedDescription) }
-        speechToText.upgradeLanguageModel(customizationID: languageModel.customizationID, failure: failure) {
+        speechToText.upgradeLanguageModel(customizationID: languageModel.customizationID) {
+            _, error in
+            if let error = error {
+                if !error.localizedDescription.contains("model is up-to-date") {
+                    XCTFail("Unexpected error response from service: \(error)")
+                }
+            }
             expectation6.fulfill()
         }
         wait(for: [expectation6], timeout: timeout)
@@ -398,7 +561,11 @@ class SpeechToTextTests: XCTestCase {
 
         // delete the language model
         let expectation7 = self.expectation(description: "deleteLanguageModel")
-        speechToText.deleteLanguageModel(customizationID: languageModel.customizationID, failure: failWithError) {
+        speechToText.deleteLanguageModel(customizationID: languageModel.customizationID) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation7.fulfill()
         }
         wait(for: [expectation7], timeout: timeout)
@@ -419,7 +586,11 @@ class SpeechToTextTests: XCTestCase {
         let id = languageModel.customizationID
         let corpusName = "test-corpus"
         let file = Bundle(for: type(of: self)).url(forResource: "healthcare-short", withExtension: "txt")!
-        speechToText.addCorpus(customizationID: id, corpusName: corpusName, corpusFile: file, allowOverwrite: true, corpusFileContentType: "plain/text", failure: failWithError) {
+        speechToText.addCorpus(customizationID: id, corpusName: corpusName, corpusFile: file, allowOverwrite: true) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: timeout)
@@ -429,15 +600,33 @@ class SpeechToTextTests: XCTestCase {
 
         // list all corpora
         let expectation2 = self.expectation(description: "listCorpora")
-        speechToText.listCorpora(customizationID: languageModel.customizationID, failure: failWithError) { results in
-            XCTAssertTrue(results.corpora.contains { $0.name == corpusName })
+        speechToText.listCorpora(customizationID: languageModel.customizationID) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
+            XCTAssertTrue(result.corpora.contains { $0.name == corpusName })
             expectation2.fulfill()
         }
         wait(for: [expectation2], timeout: timeout)
 
         // get the corpus we added
         let expectation3 = self.expectation(description: "getCorpus")
-        speechToText.getCorpus(customizationID: id, corpusName: corpusName, failure: failWithError) { corpus in
+        speechToText.getCorpus(customizationID: id, corpusName: corpusName) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let corpus = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertEqual(corpus.name, corpusName)
             expectation3.fulfill()
         }
@@ -445,7 +634,11 @@ class SpeechToTextTests: XCTestCase {
 
         // delete the corpus we added
         let expectation4 = self.expectation(description: "deleteCorpus")
-        speechToText.deleteCorpus(customizationID: id, corpusName: corpusName, failure: failWithError) {
+        speechToText.deleteCorpus(customizationID: id, corpusName: corpusName) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation4.fulfill()
         }
         wait(for: [expectation4], timeout: timeout)
@@ -464,7 +657,11 @@ class SpeechToTextTests: XCTestCase {
         // add an array of words
         let expectation2 = self.expectation(description: "addWords")
         let word = CustomWord(word: "helllo", soundsLike: ["hello"], displayAs: "hello")
-        speechToText.addWords(customizationID: languageModel.customizationID, words: [word], failure: failWithError) {
+        speechToText.addWords(customizationID: languageModel.customizationID, words: [word]) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation2.fulfill()
         }
         wait(for: [expectation2], timeout: timeout)
@@ -474,7 +671,11 @@ class SpeechToTextTests: XCTestCase {
 
         // add a single word
         let expectation3 = self.expectation(description: "addWord")
-        speechToText.addWord(customizationID: languageModel.customizationID, wordName: "worlld", soundsLike: ["world"], displayAs: "world", failure: failWithError) {
+        speechToText.addWord(customizationID: languageModel.customizationID, wordName: "worlld", soundsLike: ["world"], displayAs: "world") {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation3.fulfill()
         }
         wait(for: [expectation3], timeout: timeout)
@@ -484,19 +685,35 @@ class SpeechToTextTests: XCTestCase {
 
         // list all words
         let expectation4 = self.expectation(description: "listWords")
-        speechToText.listWords(customizationID: languageModel.customizationID, wordType: "user", sort: "+alphabetical", failure: failWithError) {
-            results in
-            XCTAssertEqual(results.words.count, 2)
-            XCTAssertTrue(results.words.contains { $0.word == "helllo" })
-            XCTAssertTrue(results.words.contains { $0.word == "worlld" })
+        speechToText.listWords(customizationID: languageModel.customizationID, wordType: "user", sort: "+alphabetical") {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
+            XCTAssertEqual(result.words.count, 2)
+            XCTAssertTrue(result.words.contains { $0.word == "helllo" })
+            XCTAssertTrue(result.words.contains { $0.word == "worlld" })
             expectation4.fulfill()
         }
         wait(for: [expectation4], timeout: timeout)
 
         // get a word that we added
         let expectation5 = self.expectation(description: "getWord")
-        speechToText.getWord(customizationID: languageModel.customizationID, wordName: "helllo", failure: failWithError) {
-            word in
+        speechToText.getWord(customizationID: languageModel.customizationID, wordName: "helllo") {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let word = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertEqual(word.word, "helllo")
             expectation5.fulfill()
         }
@@ -504,7 +721,11 @@ class SpeechToTextTests: XCTestCase {
 
         // delete a word that we added
         let expectation6 = self.expectation(description: "deleteWord")
-        speechToText.deleteWord(customizationID: languageModel.customizationID, wordName: "helllo", failure: failWithError) {
+        speechToText.deleteWord(customizationID: languageModel.customizationID, wordName: "helllo") {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation6.fulfill()
         }
         wait(for: [expectation6], timeout: timeout)
@@ -518,9 +739,19 @@ class SpeechToTextTests: XCTestCase {
         // create an acoustic model
         let expectation1 = self.expectation(description: "createAcousticModel")
         var acousticModel: AcousticModel!
-        speechToText.createAcousticModel(name: "swift-test-model", baseModelName: "en-US_BroadbandModel", description: "test",
-                                         failure: failureExceptLitePlan(expectation: expectation1)) {
-            model in
+        speechToText.createAcousticModel(name: "swift-test-model", baseModelName: "en-US_BroadbandModel", description: "test") {
+            response, error in
+            if let error = error {
+                if !error.localizedDescription.contains(self.litePlanMessage) {
+                    XCTFail("Unexpected error response from service: \(error)")
+                }
+                expectation1.fulfill()
+                return
+            }
+            guard let model = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             acousticModel = model
             expectation1.fulfill()
         }
@@ -533,16 +764,33 @@ class SpeechToTextTests: XCTestCase {
 
         // list acoustic models
         let expectation2 = self.expectation(description: "listAcousticModels")
-        speechToText.listAcousticModels(language: "en-US", failure: failWithError) {
-            results in
-            XCTAssertTrue(results.customizations.contains { $0.customizationID == acousticModel.customizationID })
+        speechToText.listAcousticModels(language: "en-US") {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
+            XCTAssertTrue(result.customizations.contains { $0.customizationID == acousticModel.customizationID })
             expectation2.fulfill()
         }
         wait(for: [expectation2], timeout: timeout)
 
         // get the acoustic model
         let expectation3 = self.expectation(description: "getAcousticModel")
-        speechToText.getAcousticModel(customizationID: acousticModel.customizationID, failure: failWithError) { model in
+        speechToText.getAcousticModel(customizationID: acousticModel.customizationID) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let model = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertEqual(model.customizationID, acousticModel.customizationID)
             expectation3.fulfill()
         }
@@ -553,8 +801,13 @@ class SpeechToTextTests: XCTestCase {
 
         // train the acoustic model
         let expectation4 = self.expectation(description: "trainAcousticModel")
-        let failure1 = { (error: Error) in error.localizedDescription.contains("audio duration must be between") ? expectation4.fulfill() : XCTFail(error.localizedDescription) }
-        speechToText.trainAcousticModel(customizationID: acousticModel.customizationID, failure: failure1) {
+        speechToText.trainAcousticModel(customizationID: acousticModel.customizationID) {
+            _, error in
+            if let error = error {
+                if !error.localizedDescription.contains("audio duration must be between") {
+                    XCTFail("Unexpected error response from service: \(error)")
+                }
+            }
             expectation4.fulfill()
         }
         wait(for: [expectation4], timeout: timeout)
@@ -564,15 +817,24 @@ class SpeechToTextTests: XCTestCase {
 
         // reset the acoustic model
         let expectation5 = self.expectation(description: "resetAcousticModel")
-        speechToText.resetAcousticModel(customizationID: acousticModel.customizationID, failure: failWithError) {
+        speechToText.resetAcousticModel(customizationID: acousticModel.customizationID) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation5.fulfill()
         }
         wait(for: [expectation5], timeout: timeout)
 
         // updgrade the acoustic model
         let expectation6 = self.expectation(description: "upgradeAcousticModel")
-        let failure2 = { (error: Error) in error.localizedDescription.contains("model is up-to-date") ? expectation6.fulfill() : XCTFail(error.localizedDescription) }
-        speechToText.upgradeAcousticModel(customizationID: acousticModel.customizationID, failure: failure2) {
+        speechToText.upgradeAcousticModel(customizationID: acousticModel.customizationID) {
+            _, error in
+            if let error = error {
+                if !error.localizedDescription.contains("model is up-to-date") {
+                    XCTFail("Unexpected error response from service: \(error)")
+                }
+            }
             expectation6.fulfill()
         }
         wait(for: [expectation6], timeout: timeout)
@@ -582,7 +844,11 @@ class SpeechToTextTests: XCTestCase {
 
         // delete the acoustic model
         let expectation7 = self.expectation(description: "deleteAcousticModel")
-        speechToText.deleteAcousticModel(customizationID: acousticModel.customizationID, failure: failWithError) {
+        speechToText.deleteAcousticModel(customizationID: acousticModel.customizationID) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation7.fulfill()
         }
         wait(for: [expectation7], timeout: timeout)
@@ -601,7 +867,11 @@ class SpeechToTextTests: XCTestCase {
         // add audio resource to acoustic model
         let expectation1 = self.expectation(description: "addAudio")
         let audio = try! Data(contentsOf: Bundle(for: type(of: self)).url(forResource: "SpeechSample", withExtension: "wav")!)
-        speechToText.addAudio(customizationID: acousticModel.customizationID, audioName: "audio", audioResource: audio, contentType: "audio/wav", allowOverwrite: true, failure: failWithError) {
+        speechToText.addAudio(customizationID: acousticModel.customizationID, audioName: "audio", audioResource: audio, contentType: "audio/wav", allowOverwrite: true) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: timeout)
@@ -611,17 +881,34 @@ class SpeechToTextTests: XCTestCase {
 
         // list audio resources
         let expectation2 = self.expectation(description: "listAudio")
-        speechToText.listAudio(customizationID: acousticModel.customizationID, failure: failWithError) { results in
-            XCTAssertGreaterThan(results.audio.count, 0)
-            XCTAssertGreaterThan(results.totalMinutesOfAudio, 0.0)
+        speechToText.listAudio(customizationID: acousticModel.customizationID) {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
+            XCTAssertGreaterThan(result.audio.count, 0)
+            XCTAssertGreaterThan(result.totalMinutesOfAudio, 0.0)
             expectation2.fulfill()
         }
         wait(for: [expectation2], timeout: timeout)
 
         // get audio resource
         let expectation3 = self.expectation(description: "getAudio")
-        speechToText.getAudio(customizationID: acousticModel.customizationID, audioName: "audio", failure: failWithError) {
-            audio in
+        speechToText.getAudio(customizationID: acousticModel.customizationID, audioName: "audio") {
+            response, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let audio = response?.result else {
+                XCTFail("Missing result value")
+                return
+            }
             XCTAssertEqual(audio.name, "audio")
             expectation3.fulfill()
         }
@@ -629,7 +916,11 @@ class SpeechToTextTests: XCTestCase {
 
         // delete audio resource
         let expectation4 = self.expectation(description: "deleteAudio")
-        speechToText.deleteAudio(customizationID: acousticModel.customizationID, audioName: "audio", failure: failWithError) {
+        speechToText.deleteAudio(customizationID: acousticModel.customizationID, audioName: "audio") {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation4.fulfill()
         }
         wait(for: [expectation4], timeout: timeout)

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -80,7 +80,7 @@ class SpeechToTextTests: XCTestCase {
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             languageModel = result.customizations.first { $0.name == "swift-test-model" }
@@ -104,7 +104,7 @@ class SpeechToTextTests: XCTestCase {
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             languageModel = model
@@ -127,7 +127,7 @@ class SpeechToTextTests: XCTestCase {
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             acousticModel = result.customizations.first { $0.name == "swift-test-model" }
@@ -150,7 +150,7 @@ class SpeechToTextTests: XCTestCase {
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             acousticModel = model
@@ -171,7 +171,7 @@ class SpeechToTextTests: XCTestCase {
         {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation.fulfill()
         }
@@ -191,7 +191,7 @@ class SpeechToTextTests: XCTestCase {
         {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation.fulfill()
         }
@@ -220,13 +220,13 @@ class SpeechToTextTests: XCTestCase {
                 response, error in
                 if let error = error {
                     if !error.localizedDescription.contains("locked") {
-                        XCTFail("Unexpected error response from service: \(error)")
+                        XCTFail("Received an unexpected error: \(error)")
                     }
                     expectation.fulfill()
                     return
                 }
                 guard let model = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail("Missing result from response")
                     return
                 }
                 hasDesiredStatus = (model.status == status)
@@ -245,13 +245,13 @@ class SpeechToTextTests: XCTestCase {
                 response, error in
                 if let error = error {
                     if !error.localizedDescription.contains("locked") {
-                        XCTFail("Unexpected error response from service: \(error)")
+                        XCTFail("Received an unexpected error: \(error)")
                     }
                     expectation.fulfill()
                     return
                 }
                 guard let model = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail("Missing result from response")
                     return
                 }
                 hasDesiredStatus = (model.status == status)
@@ -270,13 +270,13 @@ class SpeechToTextTests: XCTestCase {
                 response, error in
                 if let error = error {
                     if !error.localizedDescription.contains("locked") {
-                        XCTFail("Unexpected error response from service: \(error)")
+                        XCTFail("Received an unexpected error: \(error)")
                     }
                     expectation.fulfill()
                     return
                 }
                 guard let corpus = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail("Missing result from response")
                     return
                 }
                 hasDesiredStatus = (corpus.status == status)
@@ -294,11 +294,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listModels {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertGreaterThan(result.models.count, 0)
@@ -313,11 +313,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getModel(modelID: modelID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertEqual(model.name, modelID)
@@ -334,11 +334,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.recognizeSessionless(model: "en-US_BroadbandModel", audio: audio, contentType: "audio/wav") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let recognitionResults = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertNotNil(recognitionResults.results)
@@ -362,11 +362,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.createJob(audio: audio, contentType: "audio/wav", model: "en-US_BroadbandModel") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             job = result
@@ -379,11 +379,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.checkJobs {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertGreaterThan(result.recognitions.count, 0)
@@ -396,11 +396,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.checkJob(id: job.id) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertEqual(result.id, job.id)
@@ -414,11 +414,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.registerCallback(callbackUrl: url, userSecret: "ThisIsMySecret") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let status = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertEqual(status.url, url)
@@ -431,7 +431,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.unregisterCallback(callbackUrl: url) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation5.fulfill()
         }
@@ -442,7 +442,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteJob(id: job.id) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation6.fulfill()
         }
@@ -462,13 +462,13 @@ class SpeechToTextTests: XCTestCase {
             response, error in
             if let error = error {
                 if !error.localizedDescription.contains(self.litePlanMessage) {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail("Received an unexpected error: \(error)")
                 }
                 expectation1.fulfill()
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             languageModel = model
@@ -486,11 +486,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listLanguageModels(language: "en-US") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertTrue(result.customizations.contains { $0.customizationID == languageModel.customizationID })
@@ -503,11 +503,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getLanguageModel(customizationID: languageModel.customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertEqual(model.customizationID, languageModel.customizationID)
@@ -523,7 +523,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.trainLanguageModel(customizationID: languageModel.customizationID, wordTypeToAdd: "all", customizationWeight: 0.3) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation4.fulfill()
         }
@@ -537,7 +537,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.resetLanguageModel(customizationID: languageModel.customizationID) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation5.fulfill()
         }
@@ -549,7 +549,7 @@ class SpeechToTextTests: XCTestCase {
             _, error in
             if let error = error {
                 if !error.localizedDescription.contains("model is up-to-date") {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail("Received an unexpected error: \(error)")
                 }
             }
             expectation6.fulfill()
@@ -564,7 +564,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteLanguageModel(customizationID: languageModel.customizationID) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation7.fulfill()
         }
@@ -589,7 +589,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.addCorpus(customizationID: id, corpusName: corpusName, corpusFile: file, allowOverwrite: true) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation1.fulfill()
         }
@@ -603,11 +603,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listCorpora(customizationID: languageModel.customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertTrue(result.corpora.contains { $0.name == corpusName })
@@ -620,11 +620,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getCorpus(customizationID: id, corpusName: corpusName) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let corpus = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertEqual(corpus.name, corpusName)
@@ -637,7 +637,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteCorpus(customizationID: id, corpusName: corpusName) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation4.fulfill()
         }
@@ -660,7 +660,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.addWords(customizationID: languageModel.customizationID, words: [word]) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation2.fulfill()
         }
@@ -674,7 +674,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.addWord(customizationID: languageModel.customizationID, wordName: "worlld", soundsLike: ["world"], displayAs: "world") {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation3.fulfill()
         }
@@ -688,11 +688,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listWords(customizationID: languageModel.customizationID, wordType: "user", sort: "+alphabetical") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertEqual(result.words.count, 2)
@@ -707,11 +707,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getWord(customizationID: languageModel.customizationID, wordName: "helllo") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let word = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertEqual(word.word, "helllo")
@@ -724,7 +724,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteWord(customizationID: languageModel.customizationID, wordName: "helllo") {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation6.fulfill()
         }
@@ -743,13 +743,13 @@ class SpeechToTextTests: XCTestCase {
             response, error in
             if let error = error {
                 if !error.localizedDescription.contains(self.litePlanMessage) {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail("Received an unexpected error: \(error)")
                 }
                 expectation1.fulfill()
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             acousticModel = model
@@ -767,11 +767,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listAcousticModels(language: "en-US") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertTrue(result.customizations.contains { $0.customizationID == acousticModel.customizationID })
@@ -784,11 +784,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getAcousticModel(customizationID: acousticModel.customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertEqual(model.customizationID, acousticModel.customizationID)
@@ -805,7 +805,7 @@ class SpeechToTextTests: XCTestCase {
             _, error in
             if let error = error {
                 if !error.localizedDescription.contains("audio duration must be between") {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail("Received an unexpected error: \(error)")
                 }
             }
             expectation4.fulfill()
@@ -820,7 +820,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.resetAcousticModel(customizationID: acousticModel.customizationID) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation5.fulfill()
         }
@@ -832,7 +832,7 @@ class SpeechToTextTests: XCTestCase {
             _, error in
             if let error = error {
                 if !error.localizedDescription.contains("model is up-to-date") {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail("Received an unexpected error: \(error)")
                 }
             }
             expectation6.fulfill()
@@ -847,7 +847,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteAcousticModel(customizationID: acousticModel.customizationID) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation7.fulfill()
         }
@@ -870,7 +870,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.addAudio(customizationID: acousticModel.customizationID, audioName: "audio", audioResource: audio, contentType: "audio/wav", allowOverwrite: true) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation1.fulfill()
         }
@@ -884,11 +884,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listAudio(customizationID: acousticModel.customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertGreaterThan(result.audio.count, 0)
@@ -902,11 +902,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getAudio(customizationID: acousticModel.customizationID, audioName: "audio") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
                 return
             }
             guard let audio = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail("Missing result from response")
                 return
             }
             XCTAssertEqual(audio.name, "audio")
@@ -919,7 +919,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteAudio(customizationID: acousticModel.customizationID, audioName: "audio") {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail("Received an unexpected error: \(error)")
             }
             expectation4.fulfill()
         }


### PR DESCRIPTION
This PR updates the Speech-to-Text tests for the new single completion handler design.

The PR also includes some minor changes/fixes in RestKit needed for STT.

Also included are updates to the hand-written Recognize extension to adopt the new single completion handler design.