### PR TITLE
Update Discovery tests for single completion handler 

### DIFF
--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -121,10 +121,20 @@ class DiscoveryTests: XCTestCase {
     func lookupOrCreateTestEnvironment() -> Environment {
         var environment: Environment!
         let expectation = self.expectation(description: "listEnvironments")
-        let failure = { (error: Error) in XCTFail("Failed to lookup environment: \(error.localizedDescription)") }
-        discovery.listEnvironments(failure: failure) {
-            response in
-            environment = response.environments?.first { !($0.readOnly ?? true) }
+
+        discovery.listEnvironments {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            environment = result.environments?.first { !($0.readOnly ?? true) }
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -137,10 +147,20 @@ class DiscoveryTests: XCTestCase {
         let expectation = self.expectation(description: "createEnvironment")
         let name = "swift-sdk-test-" + UUID().uuidString
         let description = "An environment created while testing the Swift SDK. Safe to delete."
-        let failure = { (error: Error) in XCTFail("Failed to create an environment: \(error.localizedDescription)") }
-        discovery.createEnvironment(name: name, description: description, size: 0, failure: failure) {
-            response in
-            environment = response
+
+        discovery.createEnvironment(name: name, description: description, size: 0) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            environment = result
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -150,10 +170,20 @@ class DiscoveryTests: XCTestCase {
     func lookupOrCreateTestConfiguration(environmentID: String) -> Configuration {
         var configuration: Configuration!
         let expectation = self.expectation(description: "listConfigurations")
-        let failure = { (error: Error) in XCTFail("Failed to lookup Configuration: \(error.localizedDescription)") }
-        discovery.listConfigurations(environmentID: environmentID, failure: failure) {
-            response in
-            configuration = response.configurations?.first { $0.name.starts(with: "swift-sdk-test-") }
+
+        discovery.listConfigurations(environmentID: environmentID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            configuration = result.configurations?.first { $0.name.starts(with: "swift-sdk-test-") }
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -166,10 +196,20 @@ class DiscoveryTests: XCTestCase {
         let name = "swift-sdk-test-" + UUID().uuidString
         let description = "A configuration created while testing the Swift SDK. Safe to delete."
         let properties = Configuration(name: name, description: description)
-        let failure = { (error: Error) in XCTFail("Failed to create a test configuration: \(error.localizedDescription)") }
-        discovery.createConfiguration(environmentID: environmentID, configuration: properties, failure: failure) {
-            response in
-            configuration = response
+
+        discovery.createConfiguration(environmentID: environmentID, configuration: properties) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            configuration = result
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -179,10 +219,20 @@ class DiscoveryTests: XCTestCase {
     func lookupOrCreateTestCollection(environmentID: String, configurationID: String) -> DiscoveryV1.Collection {
         var collection: DiscoveryV1.Collection!
         let expectation = self.expectation(description: "listCollections")
-        let failure = { (error: Error) in XCTFail("Failed to lookup Collection: \(error.localizedDescription)") }
-        discovery.listCollections(environmentID: environmentID, failure: failure) {
-            response in
-            collection = response.collections?.first { $0.name?.starts(with: "swift-sdk-test-") ?? false }
+
+        discovery.listCollections(environmentID: environmentID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            collection = result.collections?.first { $0.name?.starts(with: "swift-sdk-test-") ?? false }
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -198,9 +248,20 @@ class DiscoveryTests: XCTestCase {
             configurationID: configurationID,
             language: "en"
         )
-        discovery.createCollection(environmentID: environmentID, properties: properties, failure: failWithError) {
-            response in
-            collection = response
+
+        discovery.createCollection(environmentID: environmentID, properties: properties) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            collection = result
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -216,40 +277,45 @@ class DiscoveryTests: XCTestCase {
             environmentID: environmentID,
             collectionID: collectionID,
             file: documentURL,
-            fileContentType: "text/html",
-            failure: failWithError)
+            fileContentType: "text/html")
         {
-            response in
-            documentAccepted = response
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            documentAccepted = result
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
         return documentAccepted
     }
 
-    // MARK: - Helper Functions
-
-    func failWithError(error: Error) {
-        XCTFail("Positive test failed with error: \(error)")
-    }
-
-    func failWithResult<T>(result: T) {
-        XCTFail("Negative test returned a result.")
-    }
-
-    func failWithResult() {
-        XCTFail("Negative test returned a result.")
-    }
-
     // MARK: - Environments
 
     func testListEnvironments() {
         let expectation = self.expectation(description: "listEnvironments")
-        discovery.listEnvironments(failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.environments)
-            XCTAssertGreaterThan(response.environments!.count, 0)
-            XCTAssert(response.environments!.contains { $0.environmentID! == "system" && $0.readOnly! })
+        discovery.listEnvironments {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.environments)
+            XCTAssertGreaterThan(result.environments!.count, 0)
+            XCTAssert(result.environments!.contains { $0.environmentID! == "system" && $0.readOnly! })
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -257,10 +323,20 @@ class DiscoveryTests: XCTestCase {
 
     func testListEnvironmentsByName() {
         let expectation = self.expectation(description: "listEnvironments")
-        discovery.listEnvironments(name: environment.name, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.environments)
-            XCTAssertGreaterThan(response.environments!.count, 0)
+        discovery.listEnvironments(name: environment.name) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.environments)
+            XCTAssertGreaterThan(result.environments!.count, 0)
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -268,10 +344,20 @@ class DiscoveryTests: XCTestCase {
 
     func testGetEnvironment() {
         let expectation = self.expectation(description: "getEnvironment")
-        discovery.getEnvironment(environmentID: environment.environmentID!, failure: failWithError) {
-            response in
-            XCTAssertEqual(self.environment.environmentID, response.environmentID)
-            XCTAssertEqual(self.environment.name, response.name)
+        discovery.getEnvironment(environmentID: environment.environmentID!) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(self.environment.environmentID, result.environmentID)
+            XCTAssertEqual(self.environment.name, result.name)
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -283,16 +369,22 @@ class DiscoveryTests: XCTestCase {
         let description = "An environment created while testing the Swift SDK. Safe to delete."
         let message1 = "Cannot provision more than one environment"
         let message2 = "Only one free environment is allowed"
-        let failure = { (error: Error) in
-            if !(error.localizedDescription.contains(message1) || error.localizedDescription.contains(message2)) {
-                self.failWithError(error: error)
-            }
-            expectation1.fulfill()
-        }
         var environment: Environment!
-        discovery.createEnvironment(name: name, description: description, size: 0, failure: failure) {
-            response in
-            environment = response
+        discovery.createEnvironment(name: name, description: description, size: 0) {
+            response, error in
+
+            if let error = error {
+                if !(error.localizedDescription.contains(message1) || error.localizedDescription.contains(message2)) {
+                    XCTFail("Unexpected error response from service: \(error)")
+                    return
+                }
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            environment = result
             expectation1.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -304,30 +396,60 @@ class DiscoveryTests: XCTestCase {
         }
 
         let expectation2 = self.expectation(description: "getEnvironment.")
-        discovery.getEnvironment(environmentID: environment.environmentID!, failure: failWithError) {
-            response in
-            XCTAssertEqual(environment.environmentID, response.environmentID)
-            XCTAssertEqual(environment.name, response.name)
-            XCTAssertEqual(environment.description, response.description)
-            XCTAssertEqual(environment.readOnly, response.readOnly)
+        discovery.getEnvironment(environmentID: environment.environmentID!) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(environment.environmentID, result.environmentID)
+            XCTAssertEqual(environment.name, result.name)
+            XCTAssertEqual(environment.description, result.description)
+            XCTAssertEqual(environment.readOnly, result.readOnly)
             expectation2.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation3 = self.expectation(description: "updateEnvironment.")
         let newName = "swift-sdk-test-" + UUID().uuidString
-        discovery.updateEnvironment(environmentID: environment.environmentID!, name: newName, failure: failWithError) {
-            response in
-            XCTAssertEqual(response.name!, newName)
+        discovery.updateEnvironment(environmentID: environment.environmentID!, name: newName) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.name!, newName)
             expectation3.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation4 = self.expectation(description: "deleteEnvironment.")
-        discovery.deleteEnvironment(environmentID: environment.environmentID!, failure: failWithError) {
-            response in
-            XCTAssertEqual(environment.environmentID!, response.environmentID)
-            XCTAssertEqual(response.status, "deleted")
+        discovery.deleteEnvironment(environmentID: environment.environmentID!) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(environment.environmentID!, result.environmentID)
+            XCTAssertEqual(result.status, "deleted")
             expectation4.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -341,12 +463,22 @@ class DiscoveryTests: XCTestCase {
         sleep(10) // wait for document to be ingested
         let expectation = self.expectation(description: "listFields")
         let collectionIDs = [collection.collectionID!]
-        discovery.listFields(environmentID: environmentID, collectionIds: collectionIDs, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.fields)
-            XCTAssertGreaterThan(response.fields!.count, 0)
-            XCTAssertNotNil(response.fields!.first!.fieldName)
-            XCTAssertNotNil(response.fields!.first!.fieldType)
+        discovery.listFields(environmentID: environmentID, collectionIds: collectionIDs) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.fields)
+            XCTAssertGreaterThan(result.fields!.count, 0)
+            XCTAssertNotNil(result.fields!.first!.fieldName)
+            XCTAssertNotNil(result.fields!.first!.fieldType)
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -357,11 +489,21 @@ class DiscoveryTests: XCTestCase {
     func testListConfigurations() {
         let configuration = lookupOrCreateTestConfiguration(environmentID: environment.environmentID!)
         let expectation = self.expectation(description: "listConfigurations")
-        discovery.listConfigurations(environmentID: environment.environmentID!, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.configurations)
-            XCTAssertGreaterThan(response.configurations!.count, 0)
-            XCTAssert(response.configurations!.contains { $0.configurationID! == configuration.configurationID! })
+        discovery.listConfigurations(environmentID: environment.environmentID!) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.configurations)
+            XCTAssertGreaterThan(result.configurations!.count, 0)
+            XCTAssert(result.configurations!.contains { $0.configurationID! == configuration.configurationID! })
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -371,11 +513,21 @@ class DiscoveryTests: XCTestCase {
         let configuration = lookupOrCreateTestConfiguration(environmentID: environment.environmentID!)
         let expectation = self.expectation(description: "listConfigurations")
         let name = configuration.name
-        discovery.listConfigurations(environmentID: environment.environmentID!, name: name, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.configurations)
-            XCTAssertGreaterThan(response.configurations!.count, 0)
-            XCTAssert(response.configurations!.contains { $0.configurationID! == configuration.configurationID! })
+        discovery.listConfigurations(environmentID: environment.environmentID!, name: name) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.configurations)
+            XCTAssertGreaterThan(result.configurations!.count, 0)
+            XCTAssert(result.configurations!.contains { $0.configurationID! == configuration.configurationID! })
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -388,9 +540,19 @@ class DiscoveryTests: XCTestCase {
         let description = "A configuration created while testing the Swift SDK. Safe to delete."
         let properties = Configuration(name: name, description: description)
         var configuration: Configuration!
-        discovery.createConfiguration(environmentID: environmentID, configuration: properties, failure: failWithError) {
-            response in
-            configuration = response
+        discovery.createConfiguration(environmentID: environmentID, configuration: properties) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            configuration = result
             XCTAssertEqual(configuration.name, name)
             XCTAssertEqual(configuration.description, description)
             expectation1.fulfill()
@@ -399,11 +561,21 @@ class DiscoveryTests: XCTestCase {
 
         let expectation2 = self.expectation(description: "getConfiguration")
         let configurationID = configuration.configurationID!
-        discovery.getConfiguration(environmentID: environmentID, configurationID: configurationID, failure: failWithError) {
-            response in
-            XCTAssertEqual(configuration.configurationID, response.configurationID)
-            XCTAssertEqual(configuration.name, response.name)
-            XCTAssertEqual(configuration.description, response.description)
+        discovery.getConfiguration(environmentID: environmentID, configurationID: configurationID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(configuration.configurationID, result.configurationID)
+            XCTAssertEqual(configuration.name, result.name)
+            XCTAssertEqual(configuration.description, result.description)
             expectation2.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -411,19 +583,39 @@ class DiscoveryTests: XCTestCase {
         let expectation3 = self.expectation(description: "updateConfiguration")
         let newName = "swift-sdk-test-" + UUID().uuidString
         let newProperties = Configuration(name: newName)
-        discovery.updateConfiguration(environmentID: environmentID, configurationID: configurationID, configuration: newProperties, failure: failWithError) {
-            response in
-            XCTAssertEqual(newName, response.name)
-            XCTAssertEqual(configuration.configurationID, response.configurationID)
+        discovery.updateConfiguration(environmentID: environmentID, configurationID: configurationID, configuration: newProperties) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(newName, result.name)
+            XCTAssertEqual(configuration.configurationID, result.configurationID)
             expectation3.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation4 = self.expectation(description: "deleteConfiguration")
-        discovery.deleteConfiguration(environmentID: environmentID, configurationID: configurationID, failure: failWithError) {
-            response in
-            XCTAssertEqual(response.configurationID, configuration.configurationID!)
-            XCTAssertEqual(response.status, "deleted")
+        discovery.deleteConfiguration(environmentID: environmentID, configurationID: configurationID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.configurationID, configuration.configurationID!)
+            XCTAssertEqual(result.status, "deleted")
             expectation4.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -440,17 +632,26 @@ class DiscoveryTests: XCTestCase {
             configurationID: configuration.configurationID,
             file: documentURL,
             metadata: "{ \"Creator\": \"John F. Kennedy\" }",
-            fileContentType: "text/html",
-            failure: failWithError)
+            fileContentType: "text/html")
         {
-            response in
-            XCTAssertEqual(response.status, "completed")
-            XCTAssertEqual(response.originalMediaType, "text/html")
-            XCTAssertNotNil(response.snapshots)
-            XCTAssertGreaterThan(response.snapshots!.count, 0)
-            XCTAssertEqual(response.snapshots!.first!.step, "html_input")
-            XCTAssertNotNil(response.snapshots!.first!.snapshot)
-            XCTAssertGreaterThan(response.snapshots!.first!.snapshot!.count, 0)
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.status, "completed")
+            XCTAssertEqual(result.originalMediaType, "text/html")
+            XCTAssertNotNil(result.snapshots)
+            XCTAssertGreaterThan(result.snapshots!.count, 0)
+            XCTAssertEqual(result.snapshots!.first!.step, "html_input")
+            XCTAssertNotNil(result.snapshots!.first!.snapshot)
+            XCTAssertGreaterThan(result.snapshots!.first!.snapshot!.count, 0)
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -463,11 +664,21 @@ class DiscoveryTests: XCTestCase {
         let configuration = lookupOrCreateTestConfiguration(environmentID: environmentID)
         let collection = lookupOrCreateTestCollection(environmentID: environmentID, configurationID: configuration.configurationID!)
         let expectation = self.expectation(description: "listCollections")
-        discovery.listCollections(environmentID: environmentID, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.collections)
-            XCTAssertGreaterThan(response.collections!.count, 0)
-            XCTAssert(response.collections!.contains { $0.collectionID == collection.collectionID })
+        discovery.listCollections(environmentID: environmentID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.collections)
+            XCTAssertGreaterThan(result.collections!.count, 0)
+            XCTAssert(result.collections!.contains { $0.collectionID == collection.collectionID })
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -478,11 +689,21 @@ class DiscoveryTests: XCTestCase {
         let configuration = lookupOrCreateTestConfiguration(environmentID: environmentID)
         let collection = lookupOrCreateTestCollection(environmentID: environmentID, configurationID: configuration.configurationID!)
         let expectation = self.expectation(description: "listCollections")
-        discovery.listCollections(environmentID: environmentID, name: collection.name!, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.collections)
-            XCTAssertGreaterThan(response.collections!.count, 0)
-            XCTAssert(response.collections!.contains { $0.collectionID == collection.collectionID })
+        discovery.listCollections(environmentID: environmentID, name: collection.name!) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.collections)
+            XCTAssertGreaterThan(result.collections!.count, 0)
+            XCTAssert(result.collections!.contains { $0.collectionID == collection.collectionID })
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -499,9 +720,19 @@ class DiscoveryTests: XCTestCase {
             configurationID: configuration.configurationID!,
             language: "en"
         )
-        discovery.createCollection(environmentID: environmentID, properties: properties, failure: failWithError) {
-            response in
-            collection = response
+        discovery.createCollection(environmentID: environmentID, properties: properties) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            collection = result
             XCTAssertNotNil(collection.name)
             XCTAssertEqual(collection.name!, properties.name)
             XCTAssertEqual(collection.description, properties.description!)
@@ -515,31 +746,61 @@ class DiscoveryTests: XCTestCase {
 
         let expectation2 = self.expectation(description: "getCollection")
         let collectionID = collection.collectionID!
-        discovery.getCollection(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {
-            response in
-            XCTAssertEqual(response.name, collection.name)
-            XCTAssertEqual(response.description, collection.description)
-            XCTAssertEqual(response.configurationID!, collection.configurationID)
-            XCTAssertEqual(response.language!, collection.language!)
+        discovery.getCollection(environmentID: environmentID, collectionID: collectionID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.name, collection.name)
+            XCTAssertEqual(result.description, collection.description)
+            XCTAssertEqual(result.configurationID!, collection.configurationID)
+            XCTAssertEqual(result.language!, collection.language!)
             expectation2.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation3 = self.expectation(description: "updateCollection")
         let newName = "swift-sdk-test-" + UUID().uuidString
-        discovery.updateCollection(environmentID: environmentID, collectionID: collectionID, name: newName, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.name)
-            XCTAssertEqual(response.name!, newName)
+        discovery.updateCollection(environmentID: environmentID, collectionID: collectionID, name: newName) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.name)
+            XCTAssertEqual(result.name!, newName)
             expectation3.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation4 = self.expectation(description: "deleteCollection")
-        discovery.deleteCollection(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {
-            response in
-            XCTAssertEqual(response.status, "deleted")
-            XCTAssertEqual(response.collectionID, collection.collectionID)
+        discovery.deleteCollection(environmentID: environmentID, collectionID: collectionID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.status, "deleted")
+            XCTAssertEqual(result.collectionID, collection.collectionID)
             expectation4.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -553,12 +814,22 @@ class DiscoveryTests: XCTestCase {
         sleep(10) // wait for document to be ingested
         let collectionID = collection.collectionID!
         let expectation = self.expectation(description: "listFields")
-        discovery.listCollectionFields(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.fields)
-            XCTAssertGreaterThan(response.fields!.count, 0)
-            XCTAssertNotNil(response.fields!.first!.fieldName)
-            XCTAssertNotNil(response.fields!.first!.fieldType)
+        discovery.listCollectionFields(environmentID: environmentID, collectionID: collectionID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.fields)
+            XCTAssertGreaterThan(result.fields!.count, 0)
+            XCTAssertNotNil(result.fields!.first!.fieldName)
+            XCTAssertNotNil(result.fields!.first!.fieldType)
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -575,29 +846,53 @@ class DiscoveryTests: XCTestCase {
         discovery.createExpansions(
             environmentID: environmentID,
             collectionID: collectionID,
-            expansions: [expansion],
-            failure: failWithError)
+            expansions: [expansion])
         {
-            response in
-            XCTAssertEqual(response.expansions.count, 1)
-            XCTAssertEqual(response.expansions.first!.expandedTerms.count, 2)
-            XCTAssertEqual(response.expansions.first!.inputTerms!.count, 1)
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.expansions.count, 1)
+            XCTAssertEqual(result.expansions.first!.expandedTerms.count, 2)
+            XCTAssertEqual(result.expansions.first!.inputTerms!.count, 1)
             expectation1.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation2 = self.expectation(description: "listExpansions")
-        discovery.listExpansions(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {
-            response in
-            XCTAssertEqual(response.expansions.count, 1)
-            XCTAssertEqual(response.expansions.first!.expandedTerms.count, 2)
-            XCTAssertEqual(response.expansions.first!.inputTerms!.count, 1)
+        discovery.listExpansions(environmentID: environmentID, collectionID: collectionID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.expansions.count, 1)
+            XCTAssertEqual(result.expansions.first!.expandedTerms.count, 2)
+            XCTAssertEqual(result.expansions.first!.inputTerms!.count, 1)
             expectation2.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation3 = self.expectation(description: "deleteExpansions")
-        discovery.deleteExpansions(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {
+        discovery.deleteExpansions(environmentID: environmentID, collectionID: collectionID) {
+            _, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation3.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -619,14 +914,23 @@ class DiscoveryTests: XCTestCase {
             collectionID: collectionID,
             file: documentURL,
             metadata: metadata,
-            fileContentType: "text/html",
-            failure: failWithError)
+            fileContentType: "text/html")
         {
-            response in
-            documentID = response.documentID
-            XCTAssertNotNil(response.documentID)
-            XCTAssertEqual(response.status, "processing")
-            XCTAssertNil(response.notices)
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            documentID = result.documentID
+            XCTAssertNotNil(result.documentID)
+            XCTAssertEqual(result.status, "processing")
+            XCTAssertNil(result.notices)
             expectation1.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -637,16 +941,25 @@ class DiscoveryTests: XCTestCase {
         discovery.getDocumentStatus(
             environmentID: environmentID,
             collectionID: collectionID,
-            documentID: documentID,
-            failure: failWithError)
+            documentID: documentID)
         {
-            response in
-            XCTAssertEqual(response.documentID, documentID)
-            XCTAssertEqual(response.status, "available")
-            XCTAssertGreaterThan(response.statusDescription.count, 0)
-            XCTAssertEqual(response.filename, "KennedySpeech.html")
-            XCTAssertEqual(response.fileType, "html")
-            XCTAssertEqual(response.notices.count, 0)
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.documentID, documentID)
+            XCTAssertEqual(result.status, "available")
+            XCTAssertGreaterThan(result.statusDescription.count, 0)
+            XCTAssertEqual(result.filename, "KennedySpeech.html")
+            XCTAssertEqual(result.fileType, "html")
+            XCTAssertEqual(result.notices.count, 0)
             expectation2.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -655,12 +968,21 @@ class DiscoveryTests: XCTestCase {
         discovery.deleteDocument(
             environmentID: environmentID,
             collectionID: collectionID,
-            documentID: documentID,
-            failure: failWithError)
+            documentID: documentID)
         {
-            response in
-            XCTAssertEqual(response.documentID, documentID)
-            XCTAssertEqual(response.status, "deleted")
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.documentID, documentID)
+            XCTAssertEqual(result.status, "deleted")
             expectation3.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -681,15 +1003,24 @@ class DiscoveryTests: XCTestCase {
             sort: ["enriched_text.sentiment.document.score"],
             highlight: true,
             deduplicate: true,
-            deduplicateField: "title",
-            failure: failWithError)
+            deduplicateField: "title")
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.matchingResults)
-            XCTAssertGreaterThan(queryResponse.matchingResults!, 0)
-            XCTAssertNotNil(queryResponse.results)
-            XCTAssertEqual(queryResponse.results!.count, 5)
-            for result in queryResponse.results! {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.matchingResults)
+            XCTAssertGreaterThan(query.matchingResults!, 0)
+            XCTAssertNotNil(query.results)
+            XCTAssertEqual(query.results!.count, 5)
+            for result in query.results! {
                 XCTAssertNotNil(result.id)
                 XCTAssertNotNil(result.resultMetadata)
                 XCTAssertNotNil(result.resultMetadata!.score)
@@ -705,15 +1036,24 @@ class DiscoveryTests: XCTestCase {
             environmentID: newsEnvironmentID,
             collectionID: newsCollectionID,
             naturalLanguageQuery: "Kubernetes",
-            count: 5,
-            failure: failWithError)
+            count: 5)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.matchingResults)
-            XCTAssertGreaterThan(queryResponse.matchingResults!, 0)
-            XCTAssertNotNil(queryResponse.results)
-            XCTAssertEqual(queryResponse.results!.count, 5)
-            for result in queryResponse.results! {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.matchingResults)
+            XCTAssertGreaterThan(query.matchingResults!, 0)
+            XCTAssertNotNil(query.results)
+            XCTAssertEqual(query.results!.count, 5)
+            for result in query.results! {
                 XCTAssertNotNil(result.id)
                 XCTAssertNotNil(result.resultMetadata)
                 XCTAssertNotNil(result.resultMetadata!.score)
@@ -732,13 +1072,22 @@ class DiscoveryTests: XCTestCase {
             passages: true,
             passagesFields: ["text"],
             passagesCount: 1,
-            passagesCharacters: 400,
-            failure: failWithError)
+            passagesCharacters: 400)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.matchingResults)
-            XCTAssertGreaterThan(queryResponse.matchingResults!, 0)
-            XCTAssertNotNil(queryResponse.passages)
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.matchingResults)
+            XCTAssertGreaterThan(query.matchingResults!, 0)
+            XCTAssertNotNil(query.passages)
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -752,12 +1101,21 @@ class DiscoveryTests: XCTestCase {
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             similar: true,
             similarDocumentIds: [],
-            similarFields: ["text"],
-            failure: failWithError)
+            similarFields: ["text"])
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.matchingResults)
-            XCTAssertGreaterThan(queryResponse.matchingResults!, 0)
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.matchingResults)
+            XCTAssertGreaterThan(query.matchingResults!, 0)
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -770,13 +1128,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "term(enriched_text.concepts.text,count:10)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .term(term) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .term(term) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -802,13 +1169,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "filter(enriched_text.concepts.text:\"cloud computing\")",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .filter(filter) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .filter(filter) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -829,13 +1205,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "nested(enriched_text.entities)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .nested(nested) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .nested(nested) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -856,13 +1241,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "histogram(enriched_text.concepts.relevance,interval:1)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .histogram(histogram) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .histogram(histogram) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -888,13 +1282,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "timeslice(publication_date,12hours)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .timeslice(timeslice) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .timeslice(timeslice) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -919,13 +1322,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "top_hits(1)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .topHits(topHits) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .topHits(topHits) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -949,13 +1361,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "unique_count(enriched_text.keywords.text)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .uniqueCount(uniqueCount) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .uniqueCount(uniqueCount) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -976,13 +1397,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "max(enriched_text.entities.count)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .max(calculation) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .max(calculation) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -1003,13 +1433,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "min(enriched_text.entities.count)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .min(calculation) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .min(calculation) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -1030,13 +1469,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "average(enriched_text.entities.count)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .average(calculation) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .average(calculation) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -1057,13 +1505,22 @@ class DiscoveryTests: XCTestCase {
             collectionID: newsCollectionID,
             query: "enriched_text.concepts.text:\"Cloud computing\"",
             aggregation: "sum(enriched_text.entities.count)",
-            count: 1,
-            failure: failWithError)
+            count: 1)
         {
-            queryResponse in
-            XCTAssertNotNil(queryResponse.aggregations)
-            XCTAssertEqual(queryResponse.aggregations!.count, 1)
-            guard case let .sum(calculation) = queryResponse.aggregations!.first! else {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let query = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(query.aggregations)
+            XCTAssertEqual(query.aggregations!.count, 1)
+            guard case let .sum(calculation) = query.aggregations!.first! else {
                 XCTFail("unexpected aggregation type")
                 expectation.fulfill()
                 return
@@ -1084,12 +1541,22 @@ class DiscoveryTests: XCTestCase {
         let collectionID = collection.collectionID!
 
         let expectation = self.expectation(description: "queryNotices")
-        discovery.queryNotices(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.matchingResults)
-            if let matchingResults = response.matchingResults, matchingResults > 0 {
-                XCTAssertNotNil(response.results)
-                XCTAssertEqual(matchingResults, response.results?.count)
+        discovery.queryNotices(environmentID: environmentID, collectionID: collectionID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.matchingResults)
+            if let matchingResults = result.matchingResults, matchingResults > 0 {
+                XCTAssertNotNil(result.results)
+                XCTAssertEqual(matchingResults, result.results?.count)
             }
             expectation.fulfill()
         }
@@ -1103,10 +1570,20 @@ class DiscoveryTests: XCTestCase {
         let collectionID = collection.collectionID!
 
         let expectation = self.expectation(description: "federatedQuery")
-        discovery.federatedQuery(environmentID: environmentID, collectionIds: [collectionID], failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.matchingResults)
-            XCTAssertGreaterThanOrEqual(response.matchingResults!, 0)
+        discovery.federatedQuery(environmentID: environmentID, collectionIds: [collectionID]) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.matchingResults)
+            XCTAssertGreaterThanOrEqual(result.matchingResults!, 0)
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1119,12 +1596,22 @@ class DiscoveryTests: XCTestCase {
         let collectionID = collection.collectionID!
 
         let expectation = self.expectation(description: "federatedQuery")
-        discovery.federatedQueryNotices(environmentID: environmentID, collectionIds: [collectionID], failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.matchingResults)
-            if let matchingResults = response.matchingResults, matchingResults > 0 {
-                XCTAssertNotNil(response.results)
-                XCTAssertEqual(matchingResults, response.results?.count)
+        discovery.federatedQueryNotices(environmentID: environmentID, collectionIds: [collectionID]) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.matchingResults)
+            if let matchingResults = result.matchingResults, matchingResults > 0 {
+                XCTAssertNotNil(result.results)
+                XCTAssertEqual(matchingResults, result.results?.count)
             }
             expectation.fulfill()
         }
@@ -1140,10 +1627,20 @@ class DiscoveryTests: XCTestCase {
         let collectionID = collection.collectionID!
 
         let expectation = self.expectation(description: "listTrainingData")
-        discovery.listTrainingData(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.queries)
-            XCTAssertEqual(response.queries!.count, 0)
+        discovery.listTrainingData(environmentID: environmentID, collectionID: collectionID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.queries)
+            XCTAssertEqual(result.queries!.count, 0)
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1165,35 +1662,59 @@ class DiscoveryTests: XCTestCase {
             collectionID: collectionID,
             naturalLanguageQuery: "1962 State of the Union",
             filter: "text:politics",
-            examples: [example],
-            failure: failWithError)
+            examples: [example])
         {
-            response in
-            trainingQuery = response
-            XCTAssertNotNil(response.queryID)
-            XCTAssertEqual(response.naturalLanguageQuery, "1962 State of the Union")
-            XCTAssertNotNil(response.filter)
-            XCTAssertEqual(response.filter, "text:politics")
-            XCTAssertNotNil(response.examples)
-            XCTAssertEqual(response.examples!.count, 1)
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            trainingQuery = result
+            XCTAssertNotNil(result.queryID)
+            XCTAssertEqual(result.naturalLanguageQuery, "1962 State of the Union")
+            XCTAssertNotNil(result.filter)
+            XCTAssertEqual(result.filter, "text:politics")
+            XCTAssertNotNil(result.examples)
+            XCTAssertEqual(result.examples!.count, 1)
             expectation1.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation2 = self.expectation(description: "getTrainingData")
         let queryID = trainingQuery.queryID!
-        discovery.getTrainingData(environmentID: environmentID, collectionID: collectionID, queryID: queryID, failure: failWithError) {
-            response in
-            XCTAssertEqual(response.queryID, trainingQuery.queryID)
-            XCTAssertEqual(response.naturalLanguageQuery, trainingQuery.naturalLanguageQuery)
-            XCTAssertEqual(response.filter, trainingQuery.filter)
-            XCTAssertEqual(response.examples!.count, trainingQuery.examples!.count)
+        discovery.getTrainingData(environmentID: environmentID, collectionID: collectionID, queryID: queryID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.queryID, trainingQuery.queryID)
+            XCTAssertEqual(result.naturalLanguageQuery, trainingQuery.naturalLanguageQuery)
+            XCTAssertEqual(result.filter, trainingQuery.filter)
+            XCTAssertEqual(result.examples!.count, trainingQuery.examples!.count)
             expectation2.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation3 = self.expectation(description: "deleteTrainingData")
-        discovery.deleteTrainingData(environmentID: environmentID, collectionID: collectionID, queryID: queryID, failure: failWithError) {
+        discovery.deleteTrainingData(environmentID: environmentID, collectionID: collectionID, queryID: queryID) {
+            _, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation3.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1201,7 +1722,12 @@ class DiscoveryTests: XCTestCase {
         // Test cleanup
 
         let expectation4 = self.expectation(description: "deleteCollection")
-        discovery.deleteCollection(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {_ in
+        discovery.deleteCollection(environmentID: environmentID, collectionID: collectionID) {
+            _, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation4.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1213,7 +1739,12 @@ class DiscoveryTests: XCTestCase {
         let collection = lookupOrCreateTestCollection(environmentID: environmentID, configurationID: configuration.configurationID!)
         let collectionID = collection.collectionID!
         let expectation = self.expectation(description: "deleteAllTrainingData")
-        discovery.deleteAllTrainingData(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {
+        discovery.deleteAllTrainingData(environmentID: environmentID, collectionID: collectionID) {
+            _, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1237,22 +1768,41 @@ class DiscoveryTests: XCTestCase {
             collectionID: collectionID,
             naturalLanguageQuery: "1962 State of the Union",
             filter: "text:politics",
-            examples: [example],
-            failure: failWithError)
+            examples: [example])
         {
-            response in
-            trainingQuery = response
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            trainingQuery = result
             expectation1.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation2 = self.expectation(description: "listTrainingExamples")
         let queryID = trainingQuery.queryID!
-        discovery.listTrainingExamples(environmentID: environmentID, collectionID: collectionID, queryID: queryID, failure: failWithError) {
-            response in
-            XCTAssertNotNil(response.examples)
-            XCTAssertEqual(response.examples!.count, 1)
-            XCTAssertEqual(response.examples!.first!.documentID, documentID)
+        discovery.listTrainingExamples(environmentID: environmentID, collectionID: collectionID, queryID: queryID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertNotNil(result.examples)
+            XCTAssertEqual(result.examples!.count, 1)
+            XCTAssertEqual(result.examples!.first!.documentID, documentID)
             expectation2.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1260,7 +1810,12 @@ class DiscoveryTests: XCTestCase {
         // Test cleanup
 
         let expectation3 = self.expectation(description: "deleteCollection")
-        discovery.deleteCollection(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {_ in
+        discovery.deleteCollection(environmentID: environmentID, collectionID: collectionID) {
+            _, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation3.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1280,11 +1835,20 @@ class DiscoveryTests: XCTestCase {
             environmentID: environmentID,
             collectionID: collectionID,
             naturalLanguageQuery: "1962 State of the Union",
-            filter: "text:politics",
-            failure: failWithError)
+            filter: "text:politics")
         {
-            response in
-            trainingQuery = response
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            trainingQuery = result
             expectation1.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1296,36 +1860,70 @@ class DiscoveryTests: XCTestCase {
             collectionID: collectionID,
             queryID: queryID,
             documentID: documentID,
-            relevance: 4,
-            failure: failWithError)
+            relevance: 4)
         {
-            response in
-            XCTAssertEqual(response.documentID, documentID)
-            XCTAssertEqual(response.relevance, 4)
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.documentID, documentID)
+            XCTAssertEqual(result.relevance, 4)
             expectation2.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation3 = self.expectation(description: "getTrainingExample")
-        discovery.getTrainingExample(environmentID: environmentID, collectionID: collectionID, queryID: queryID, exampleID: documentID, failure: failWithError) {
-            response in
-            XCTAssertEqual(response.documentID, documentID)
-            XCTAssertEqual(response.relevance, 4)
+        discovery.getTrainingExample(environmentID: environmentID, collectionID: collectionID, queryID: queryID, exampleID: documentID) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.documentID, documentID)
+            XCTAssertEqual(result.relevance, 4)
             expectation3.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation4 = self.expectation(description: "updateTrainingExample")
-        discovery.updateTrainingExample(environmentID: environmentID, collectionID: collectionID, queryID: queryID, exampleID: documentID, relevance: 0, failure: failWithError) {
-            response in
-            XCTAssertEqual(response.documentID, documentID)
-            XCTAssertEqual(response.relevance, 0)
+        discovery.updateTrainingExample(environmentID: environmentID, collectionID: collectionID, queryID: queryID, exampleID: documentID, relevance: 0) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let result = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
+            XCTAssertEqual(result.documentID, documentID)
+            XCTAssertEqual(result.relevance, 0)
             expectation4.fulfill()
         }
         waitForExpectations(timeout: timeout)
 
         let expectation5 = self.expectation(description: "deleteTrainingExample")
-        discovery.deleteTrainingExample(environmentID: environmentID, collectionID: collectionID, queryID: queryID, exampleID: documentID, failure: failWithError) {
+        discovery.deleteTrainingExample(environmentID: environmentID, collectionID: collectionID, queryID: queryID, exampleID: documentID) {
+            _, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
             expectation5.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1333,7 +1931,12 @@ class DiscoveryTests: XCTestCase {
         // Test cleanup
 
         let expectation6 = self.expectation(description: "deleteCollection")
-        discovery.deleteCollection(environmentID: environmentID, collectionID: collectionID, failure: failWithError) {_ in
+        discovery.deleteCollection(environmentID: environmentID, collectionID: collectionID) {
+            _, error in
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+            }
+
             expectation6.fulfill()
         }
         waitForExpectations(timeout: timeout)
@@ -1343,49 +1946,66 @@ class DiscoveryTests: XCTestCase {
 
     func testGetEnvironmentWithInvalidID() {
         let expectation = self.expectation(description: "getEnvironment")
-        let failure = { (error: Error) in
+        discovery.getEnvironment(environmentID: "invalid-id") {
+            _, error in
+
+            guard let error = error else {
+                XCTFail("Expected error response")
+                return
+            }
             XCTAssert(error.localizedDescription.lowercased().contains("invalid environment id"))
             expectation.fulfill()
         }
-        discovery.getEnvironment(environmentID: "invalid-id", failure: failure, success: failWithResult)
         waitForExpectations(timeout: timeout)
     }
 
     func testGetConfigurationWithInvalidID() {
         let expectation = self.expectation(description: "getEnvironment")
         let environmentID = environment.environmentID!
-        let failure = { (error: Error) in
+        discovery.getConfiguration(environmentID: environmentID, configurationID: "invalid-id") {
+            _, error in
+
+            guard let error = error else {
+                XCTFail("Expected error response")
+                return
+            }
             XCTAssert(error.localizedDescription.lowercased().contains("invalid configuration id"))
             expectation.fulfill()
         }
-        discovery.getConfiguration(environmentID: environmentID, configurationID: "invalid-id", failure: failure, success: failWithResult)
         waitForExpectations(timeout: timeout)
     }
 
     func testGetCollectionWithInvalidID() {
         let expectation = self.expectation(description: "getEnvironment")
         let environmentID = environment.environmentID!
-        let failure = { (error: Error) in
+        discovery.getCollection(environmentID: environmentID, collectionID: "invalid-id") {
+            _, error in
+
+            guard let error = error else {
+                XCTFail("Expected error response")
+                return
+            }
             XCTAssert(error.localizedDescription.lowercased().contains("could not find"))
             expectation.fulfill()
         }
-        discovery.getCollection(environmentID: environmentID, collectionID: "invalid-id", failure: failure, success: failWithResult)
         waitForExpectations(timeout: timeout)
     }
 
     func testQueryWithInvalidID() {
         let expectation = self.expectation(description: "getEnvironment")
-        let failure = { (error: Error) in
-            XCTAssert(error.localizedDescription.lowercased().contains("invalid environment id"))
-            expectation.fulfill()
-        }
         discovery.query(
             environmentID: "invalid-id",
             collectionID: "invalid-id",
-            query: "enriched_text.concepts.text:\"Cloud computing\"",
-            failure: failure,
-            success: failWithResult
-        )
+            query: "enriched_text.concepts.text:\"Cloud computing\"") {
+                _, error in
+
+                guard let error = error else {
+                    XCTFail("Expected error response")
+                    return
+                }
+                XCTAssert(error.localizedDescription.lowercased().contains("invalid environment id"))
+                expectation.fulfill()
+        }
         waitForExpectations(timeout: timeout)
     }
 }

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -376,8 +376,10 @@ class DiscoveryTests: XCTestCase {
             if let error = error {
                 if !(error.localizedDescription.contains(message1) || error.localizedDescription.contains(message2)) {
                     XCTFail("Unexpected error response from service: \(error)")
-                    return
+                } else {
+                    expectation1.fulfill()
                 }
+                return
             }
             guard let result = response?.result else {
                 XCTFail("Missing response value")


### PR DESCRIPTION
Continues work for https://github.com/watson-developer-cloud/swift-sdk/pull/857