### PR TITLE
Update Personality Insights tests for single completion handler

### DIFF
--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -316,7 +316,7 @@ public class PersonalityInsights {
         )
 
         // execute REST request
-        request.responseObject(completionHandler: completionHandler)
+        request.response(completionHandler: completionHandler)
     }
 
 }

--- a/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
@@ -84,21 +84,6 @@ class PersonalityInsightsTests: XCTestCase {
         self.short = load(forResource: "MobyDickIntro", ofType: "txt")
     }
 
-    /** Fail false negatives. */
-    func failWithError(error: Error) {
-        XCTFail("Positive test failed with error: \(error)")
-    }
-
-    /** Fail false positives. */
-    func failWithResult<T>(result: T) {
-        XCTFail("Negative test returned a result.")
-    }
-
-    /** Fail false positives. */
-    func failWithResult() {
-        XCTFail("Negative test returned a result.")
-    }
-
     /** Wait for expectations. */
     func waitForExpectations(timeout: TimeInterval = 5.0) {
         waitForExpectations(timeout: timeout) { error in
@@ -110,7 +95,18 @@ class PersonalityInsightsTests: XCTestCase {
 
     func testProfileText() {
         let expectation = self.expectation(description: "profile(text:)")
-        personalityInsights.profile(text: text, failure: failWithError) { profile in
+        personalityInsights.profile(text: text) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let profile = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
             for preference in profile.personality {
                 XCTAssertNotNil(preference.name)
                 break
@@ -122,7 +118,18 @@ class PersonalityInsightsTests: XCTestCase {
 
     func testProfileHTML() {
         let expectation = self.expectation(description: "profile(html:)")
-        personalityInsights.profile(html: html, failure: failWithError) { profile in
+        personalityInsights.profile(html: html) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let profile = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
             for preference in profile.personality {
                 XCTAssertNotNil(preference.name)
                 break
@@ -146,7 +153,18 @@ class PersonalityInsightsTests: XCTestCase {
             forward: false
         )
         let content = Content(contentItems: [contentItem])
-        personalityInsights.profile(content: content, failure: failWithError) { profile in
+        personalityInsights.profile(content: content) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let profile = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
             if let behaviors = profile.behavior {
                 for behavior in behaviors {
                     XCTAssertNotNil(behavior.traitID)
@@ -159,7 +177,18 @@ class PersonalityInsightsTests: XCTestCase {
 
     func testProfileAsCsvText() {
         let expectation = self.expectation(description: "profile(text:)")
-        personalityInsights.profileAsCsv(text: text, failure: failWithError) { csv in
+        personalityInsights.profileAsCsv(text: text) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let csv = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
             XCTAssertGreaterThan(csv.count, 0)
             expectation.fulfill()
         }
@@ -168,7 +197,18 @@ class PersonalityInsightsTests: XCTestCase {
 
     func testProfileAsCsvHTML() {
         let expectation = self.expectation(description: "profile(html:)")
-        personalityInsights.profileAsCsv(html: html, failure: failWithError) { csv in
+        personalityInsights.profileAsCsv(html: html) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let csv = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
             XCTAssertGreaterThan(csv.count, 0)
             expectation.fulfill()
         }
@@ -189,7 +229,18 @@ class PersonalityInsightsTests: XCTestCase {
             forward: false
         )
         let content = Content(contentItems: [contentItem])
-        personalityInsights.profileAsCsv(content: content, failure: failWithError) { csv in
+        personalityInsights.profileAsCsv(content: content) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let csv = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
             XCTAssertGreaterThan(csv.count, 0)
             expectation.fulfill()
         }
@@ -198,8 +249,18 @@ class PersonalityInsightsTests: XCTestCase {
 
     func testNeedsAndConsumptionPreferences() {
         let expectation = self.expectation(description: "profile(text:)")
-        personalityInsights.profile(text: text, rawScores: true, consumptionPreferences: true, failure: failWithError) {
-            profile in
+        personalityInsights.profile(text: text, rawScores: true, consumptionPreferences: true) {
+            response, error in
+
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let profile = response?.result else {
+                XCTFail("Missing response value")
+                return
+            }
+
             for need in profile.needs {
                 XCTAssertNotNil(need.rawScore)
                 break
@@ -225,8 +286,14 @@ class PersonalityInsightsTests: XCTestCase {
 
     func testProfileWithShortText() {
         let expectation = self.expectation(description: "profile(text:)")
-        let failure = { (error: Error) in expectation.fulfill() }
-        personalityInsights.profile(text: short, failure: failure, success: failWithResult)
+        personalityInsights.profile(text: short) {
+            _, error in
+
+            if error == nil {
+                XCTFail("Expected error response")
+            }
+            expectation.fulfill()
+        }
         waitForExpectations()
     }
 }

--- a/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
@@ -22,9 +22,11 @@ import PersonalityInsightsV3
 class PersonalityInsightsTests: XCTestCase {
 
     private var personalityInsights: PersonalityInsights!
-    private var text: String!
-    private var html: String!
-    private var short: String!
+
+    private var rawText: String!
+    private var text: ProfileContent!
+    private var html: ProfileContent!
+    private var short: ProfileContent!
 
     static var allTests: [(String, (PersonalityInsightsTests) -> () throws -> Void)] {
         return [
@@ -78,10 +80,11 @@ class PersonalityInsightsTests: XCTestCase {
         #endif
     }
 
-    public func loadTestResources() {
-        self.text = load(forResource: "KennedySpeech", ofType: "txt")
-        self.html = load(forResource: "KennedySpeech", ofType: "html")
-        self.short = load(forResource: "MobyDickIntro", ofType: "txt")
+    func loadTestResources() {
+        self.rawText = load(forResource: "KennedySpeech", ofType: "txt")
+        self.text = ProfileContent.text(self.rawText!)
+        self.html = ProfileContent.html(load(forResource: "KennedySpeech", ofType: "html")!)
+        self.short = ProfileContent.text(load(forResource: "MobyDickIntro", ofType: "txt")!)
     }
 
     /** Wait for expectations. */
@@ -94,8 +97,8 @@ class PersonalityInsightsTests: XCTestCase {
     // MARK: - Positive Tests
 
     func testProfileText() {
-        let expectation = self.expectation(description: "profile(text:)")
-        personalityInsights.profile(text: text) {
+        let expectation = self.expectation(description: "profile(profileContent:)")
+        personalityInsights.profile(profileContent: text) {
             response, error in
 
             if let error = error {
@@ -118,7 +121,7 @@ class PersonalityInsightsTests: XCTestCase {
 
     func testProfileHTML() {
         let expectation = self.expectation(description: "profile(html:)")
-        personalityInsights.profile(html: html) {
+        personalityInsights.profile(profileContent: html) {
             response, error in
 
             if let error = error {
@@ -142,7 +145,7 @@ class PersonalityInsightsTests: XCTestCase {
     func testProfileContent() {
         let expectation = self.expectation(description: "profile(content:)")
         let contentItem = ContentItem(
-            content: text,
+            content: rawText,
             id: "245160944223793152",
             created: 1427720427,
             updated: 1427720427,
@@ -152,8 +155,8 @@ class PersonalityInsightsTests: XCTestCase {
             reply: false,
             forward: false
         )
-        let content = Content(contentItems: [contentItem])
-        personalityInsights.profile(content: content) {
+        let content = ProfileContent.content(Content(contentItems: [contentItem]))
+        personalityInsights.profile(profileContent: content) {
             response, error in
 
             if let error = error {
@@ -176,8 +179,8 @@ class PersonalityInsightsTests: XCTestCase {
     }
 
     func testProfileAsCsvText() {
-        let expectation = self.expectation(description: "profile(text:)")
-        personalityInsights.profileAsCsv(text: text) {
+        let expectation = self.expectation(description: "profile(profileContent:)")
+        personalityInsights.profileAsCsv(profileContent: text) {
             response, error in
 
             if let error = error {
@@ -197,7 +200,7 @@ class PersonalityInsightsTests: XCTestCase {
 
     func testProfileAsCsvHTML() {
         let expectation = self.expectation(description: "profile(html:)")
-        personalityInsights.profileAsCsv(html: html) {
+        personalityInsights.profileAsCsv(profileContent: html) {
             response, error in
 
             if let error = error {
@@ -218,7 +221,7 @@ class PersonalityInsightsTests: XCTestCase {
     func testProfileAsCsvContent() {
         let expectation = self.expectation(description: "profile(content:)")
         let contentItem = ContentItem(
-            content: text,
+            content: rawText,
             id: "245160944223793152",
             created: 1427720427,
             updated: 1427720427,
@@ -228,8 +231,8 @@ class PersonalityInsightsTests: XCTestCase {
             reply: false,
             forward: false
         )
-        let content = Content(contentItems: [contentItem])
-        personalityInsights.profileAsCsv(content: content) {
+        let content = ProfileContent.content(Content(contentItems: [contentItem]))
+        personalityInsights.profileAsCsv(profileContent: content) {
             response, error in
 
             if let error = error {
@@ -248,8 +251,8 @@ class PersonalityInsightsTests: XCTestCase {
     }
 
     func testNeedsAndConsumptionPreferences() {
-        let expectation = self.expectation(description: "profile(text:)")
-        personalityInsights.profile(text: text, rawScores: true, consumptionPreferences: true) {
+        let expectation = self.expectation(description: "profile(profileContent:)")
+        personalityInsights.profile(profileContent: text, rawScores: true, consumptionPreferences: true) {
             response, error in
 
             if let error = error {
@@ -285,8 +288,8 @@ class PersonalityInsightsTests: XCTestCase {
     // MARK: - Negative Tests
 
     func testProfileWithShortText() {
-        let expectation = self.expectation(description: "profile(text:)")
-        personalityInsights.profile(text: short) {
+        let expectation = self.expectation(description: "profile(profileContent:)")
+        personalityInsights.profile(profileContent: short) {
             _, error in
 
             if error == nil {


### PR DESCRIPTION
Continues work for https://github.com/watson-developer-cloud/swift-sdk/pull/857

This framework had somehow gotten out of sync with the API definitions, so I made the following changes in addition to the single completion handler updates:

1. `request.responseObject()` --> `request.response()`
1. Changed the `content` parameter in `PersonalityInsights.profile(content:)` from `String` --> `ProfileContent`