### PR TITLE
Unit tests refactoring

### DIFF
--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -131,11 +131,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -180,11 +180,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -234,11 +234,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -259,11 +259,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -308,11 +308,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -330,11 +330,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -355,11 +355,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -400,11 +400,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -423,11 +423,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -457,11 +457,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspaceResult = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -486,11 +486,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspaceResult = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -516,11 +516,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspaceResult = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -564,11 +564,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -594,11 +594,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -643,7 +643,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -658,11 +658,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -696,11 +696,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -729,11 +729,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -752,7 +752,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation3.fulfill()
@@ -770,11 +770,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intents = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -801,11 +801,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intents = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -833,11 +833,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intents = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -865,11 +865,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intents = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -905,11 +905,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intent = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -926,7 +926,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation2.fulfill()
@@ -942,11 +942,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intent = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -976,11 +976,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intent = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1000,11 +1000,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intent = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1021,7 +1021,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation3.fulfill()
@@ -1039,11 +1039,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let examples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1068,11 +1068,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let examples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1098,11 +1098,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let examples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1130,11 +1130,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let example = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1150,7 +1150,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation2.fulfill()
@@ -1167,11 +1167,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let example = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1192,11 +1192,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let example = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1213,11 +1213,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let example = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1233,7 +1233,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation3.fulfill()
@@ -1251,11 +1251,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexamples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1281,11 +1281,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexamples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1312,11 +1312,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexamples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1343,11 +1343,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexample = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1363,7 +1363,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation2.fulfill()
@@ -1380,11 +1380,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexample = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1405,11 +1405,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexample = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1426,11 +1426,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexample = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1446,7 +1446,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation3.fulfill()
@@ -1464,11 +1464,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entities = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1495,11 +1495,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entities = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1526,11 +1526,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entities = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1558,11 +1558,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entities = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1592,11 +1592,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entity = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1613,7 +1613,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectationTwo.fulfill()
@@ -1633,11 +1633,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entity = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1657,11 +1657,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entity = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1678,7 +1678,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectationFour.fulfill()
@@ -1694,11 +1694,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entityCollection = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1708,11 +1708,11 @@ class AssistantTests: XCTestCase {
                 response, error in
 
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let entityExport = response?.result else {
-                    XCTFail("Missing response value")
+                    XCTFail(missingResultMessage)
                     return
                 }
 
@@ -1741,11 +1741,11 @@ class AssistantTests: XCTestCase {
                 response, error in
 
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let valueCollection = response?.result else {
-                    XCTFail("Missing response value")
+                    XCTFail(missingResultMessage)
                     return
                 }
 
@@ -1773,11 +1773,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let value = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1795,11 +1795,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let value = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1816,7 +1816,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectationThree.fulfill()
@@ -1834,11 +1834,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let valueCollection = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1848,11 +1848,11 @@ class AssistantTests: XCTestCase {
                 response, error in
 
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let valueExport = response?.result else {
-                    XCTFail("Missing response value")
+                    XCTFail(missingResultMessage)
                     return
                 }
 
@@ -1875,11 +1875,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonyms = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1904,11 +1904,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonyms = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1934,11 +1934,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonyms = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1966,11 +1966,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonym = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1986,7 +1986,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation2.fulfill()
@@ -2003,11 +2003,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonym = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2028,11 +2028,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonym = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2049,11 +2049,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonym = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2069,7 +2069,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation3.fulfill()
@@ -2087,11 +2087,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let nodes = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2131,11 +2131,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let node = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2163,7 +2163,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation2.fulfill()
@@ -2179,11 +2179,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let node = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2199,11 +2199,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let node = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2218,7 +2218,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation3.fulfill()
@@ -2233,11 +2233,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let nodes = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2249,11 +2249,11 @@ class AssistantTests: XCTestCase {
                     response, error in
 
                     if let error = error {
-                        XCTFail("Unexpected error response from service: \(error)")
+                        XCTFail(unexpectedErrorMessage(error))
                         return
                     }
                     guard let node = response?.result else {
-                        XCTFail("Missing response value")
+                        XCTFail(missingResultMessage)
                         return
                     }
 
@@ -2273,11 +2273,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let logCollection = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2293,11 +2293,11 @@ class AssistantTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let logCollection = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2317,7 +2317,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -2333,7 +2333,7 @@ class AssistantTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -2347,7 +2347,7 @@ class AssistantTests: XCTestCase {
         assistant.serviceURL = "this is broken"
         assistant.listWorkspaces { (_, error) in
             guard let error = error as? RestError else {
-                XCTFail("Expected to receive an error")
+                XCTFail(missingErrorMessage)
                 return
             }
 

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -112,18 +112,6 @@ class AssistantTests: XCTestCase {
         return assistant
     }
 
-    func failPositiveTest(_ error: Error?) {
-        var failureMessage = "Positive test failed to get a result."
-        if let error = error {
-            failureMessage += " Error: \(error)"
-        }
-        XCTFail(failureMessage)
-    }
-
-    func failNegativeTest() {
-        XCTFail("Negative test returned a result when it should have errored.")
-    }
-
     func waitForExpectations(timeout: TimeInterval = 10.0) {
         waitForExpectations(timeout: timeout) { error in
             XCTAssertNil(error, "Timeout")
@@ -142,37 +130,41 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID, nodesVisitedDetails: true) {
             response, error in
 
-            guard let result = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let message = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
             // verify input
-            XCTAssertNil(result.input?.text)
+            XCTAssertNil(message.input?.text)
 
             // verify context
-            XCTAssertNotNil(result.context.conversationID)
-            XCTAssertNotEqual(result.context.conversationID, "")
-            XCTAssertNotNil(result.context.system)
-            XCTAssertNotNil(result.context.system!.additionalProperties)
-            XCTAssertFalse(result.context.system!.additionalProperties.isEmpty)
+            XCTAssertNotNil(message.context.conversationID)
+            XCTAssertNotEqual(message.context.conversationID, "")
+            XCTAssertNotNil(message.context.system)
+            XCTAssertNotNil(message.context.system!.additionalProperties)
+            XCTAssertFalse(message.context.system!.additionalProperties.isEmpty)
 
             // verify entities
-            XCTAssertTrue(result.entities.isEmpty)
+            XCTAssertTrue(message.entities.isEmpty)
 
             // verify intents
-            XCTAssertTrue(result.intents.isEmpty)
+            XCTAssertTrue(message.intents.isEmpty)
 
             // verify output
-            XCTAssertTrue(result.output.logMessages.isEmpty)
-            XCTAssertEqual(result.output.text, result1)
-            XCTAssertNotNil(result.output.nodesVisited)
-            XCTAssertEqual(result.output.nodesVisited!.count, 1)
-            XCTAssertNotNil(result.output.nodesVisitedDetails)
-            XCTAssertNotNil(result.output.nodesVisitedDetails!.first)
-            XCTAssertNotNil(result.output.nodesVisitedDetails!.first!.dialogNode)
+            XCTAssertTrue(message.output.logMessages.isEmpty)
+            XCTAssertEqual(message.output.text, result1)
+            XCTAssertNotNil(message.output.nodesVisited)
+            XCTAssertEqual(message.output.nodesVisited!.count, 1)
+            XCTAssertNotNil(message.output.nodesVisitedDetails)
+            XCTAssertNotNil(message.output.nodesVisitedDetails!.first)
+            XCTAssertNotNil(message.output.nodesVisitedDetails!.first!.dialogNode)
 
-            context = result.context
+            context = message.context
             expectation1.fulfill()
         }
         waitForExpectations()
@@ -187,38 +179,42 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID, request: request) {
             response, error in
 
-            guard let result = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let message = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
             // verify input
-            XCTAssertEqual(result.input?.text, input.text)
+            XCTAssertEqual(message.input?.text, input.text)
 
             // verify context
-            XCTAssertEqual(result.context.conversationID, context!.conversationID)
-            XCTAssertNotNil(result.context.system)
-            XCTAssertNotNil(result.context.system!.additionalProperties)
-            XCTAssertFalse(result.context.system!.additionalProperties.isEmpty)
+            XCTAssertEqual(message.context.conversationID, context!.conversationID)
+            XCTAssertNotNil(message.context.system)
+            XCTAssertNotNil(message.context.system!.additionalProperties)
+            XCTAssertFalse(message.context.system!.additionalProperties.isEmpty)
 
             // verify entities
-            XCTAssertEqual(result.entities.count, 1)
-            XCTAssertEqual(result.entities[0].entity, "appliance")
-            XCTAssertEqual(result.entities[0].location[0], 12)
-            XCTAssertEqual(result.entities[0].location[1], 17)
-            XCTAssertEqual(result.entities[0].value, "music")
+            XCTAssertEqual(message.entities.count, 1)
+            XCTAssertEqual(message.entities[0].entity, "appliance")
+            XCTAssertEqual(message.entities[0].location[0], 12)
+            XCTAssertEqual(message.entities[0].location[1], 17)
+            XCTAssertEqual(message.entities[0].value, "music")
 
             // verify intents
-            XCTAssertEqual(result.intents.count, 1)
-            XCTAssertEqual(result.intents[0].intent, "turn_on")
-            XCTAssert(result.intents[0].confidence >= 0.80)
-            XCTAssert(result.intents[0].confidence <= 1.00)
+            XCTAssertEqual(message.intents.count, 1)
+            XCTAssertEqual(message.intents[0].intent, "turn_on")
+            XCTAssert(message.intents[0].confidence >= 0.80)
+            XCTAssert(message.intents[0].confidence <= 1.00)
 
             // verify output
-            XCTAssertTrue(result.output.logMessages.isEmpty)
-            XCTAssertEqual(result.output.text, result2)
-            XCTAssertNotNil(result.output.nodesVisited)
-            XCTAssertEqual(result.output.nodesVisited!.count, 3)
+            XCTAssertTrue(message.output.logMessages.isEmpty)
+            XCTAssertEqual(message.output.text, result2)
+            XCTAssertNotNil(message.output.nodesVisited)
+            XCTAssertEqual(message.output.nodesVisited!.count, 3)
 
             expectation2.fulfill()
         }
@@ -237,15 +233,19 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID) {
             response, error in
 
-            guard let result = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let message = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
-            context = result.context
-            entities = result.entities
-            intents = result.intents
-            output = result.output
+            context = message.context
+            entities = message.entities
+            intents = message.intents
+            output = message.output
             expectation1.fulfill()
         }
         waitForExpectations()
@@ -258,8 +258,12 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID, request: request2) {
             response, error in
 
-            guard let result = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let message = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
@@ -269,17 +273,17 @@ class AssistantTests: XCTestCase {
             XCTAssertNotNil(output)
 
             // verify intents are equal
-            for index in 0..<result.intents.count {
+            for index in 0..<message.intents.count {
                 let intent1 = intents![index]
-                let intent2 = result.intents[index]
+                let intent2 = message.intents[index]
                 XCTAssertEqual(intent1.intent, intent2.intent)
                 XCTAssertEqual(intent1.confidence, intent2.confidence, accuracy: 10E-5)
             }
 
             // verify entities are equal
-            for index in 0..<result.entities.count {
+            for index in 0..<message.entities.count {
                 let entity1 = entities![index]
-                let entity2 = result.entities[index]
+                let entity2 = message.entities[index]
                 XCTAssertEqual(entity1.entity, entity2.entity)
                 XCTAssertEqual(entity1.location[0], entity2.location[0])
                 XCTAssertEqual(entity1.location[1], entity2.location[1])
@@ -303,12 +307,16 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID) {
             response, error in
 
-            guard let result = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let message = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
-            context = result.context
+            context = message.context
             expectation1.fulfill()
         }
         waitForExpectations()
@@ -321,15 +329,19 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID, request: request2) {
             response, error in
 
-            guard let result = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let message = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
-            context = result.context
-            entities = result.entities
-            intents = result.intents
-            output = result.output
+            context = message.context
+            entities = message.entities
+            intents = message.intents
+            output = message.output
             expectation2.fulfill()
         }
         waitForExpectations()
@@ -342,8 +354,12 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID, request: request3) {
             response, error in
 
-            guard let result = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let message = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
@@ -353,17 +369,17 @@ class AssistantTests: XCTestCase {
             XCTAssertNotNil(output)
 
             // verify intents are equal
-            for index in 0..<result.intents.count {
+            for index in 0..<message.intents.count {
                 let intent1 = intents![index]
-                let intent2 = result.intents[index]
+                let intent2 = message.intents[index]
                 XCTAssertEqual(intent1.intent, intent2.intent)
                 XCTAssertEqual(intent1.confidence, intent2.confidence, accuracy: 10E-5)
             }
 
             // verify entities are equal
-            for index in 0..<result.entities.count {
+            for index in 0..<message.entities.count {
                 let entity1 = entities![index]
-                let entity2 = result.entities[index]
+                let entity2 = message.entities[index]
                 XCTAssertEqual(entity1.entity, entity2.entity)
                 XCTAssertEqual(entity1.location[0], entity2.location[0])
                 XCTAssertEqual(entity1.location[1], entity2.location[1])
@@ -383,12 +399,16 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID) {
             response, error in
 
-            guard let result = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let message = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
-            context = result.context
+            context = message.context
             context?.additionalProperties["foo"] = .string("bar")
             expectation1.fulfill()
         }
@@ -402,12 +422,16 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID, request: request2) {
             response, error in
 
-            guard let result = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let message = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
-            let additionalProperties = result.context.additionalProperties
+            let additionalProperties = message.context.additionalProperties
             guard case let .string(bar) = additionalProperties["foo"]! else {
                 XCTFail("Additional property \"foo\" expected but not present.")
                 return
@@ -432,8 +456,12 @@ class AssistantTests: XCTestCase {
         assistant.listWorkspaces(includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let workspaceResult = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -457,8 +485,12 @@ class AssistantTests: XCTestCase {
         assistant.listWorkspaces(pageLimit: 1, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let workspaceResult = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -483,8 +515,12 @@ class AssistantTests: XCTestCase {
         assistant.listWorkspaces(includeCount: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let workspaceResult = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -527,8 +563,12 @@ class AssistantTests: XCTestCase {
         assistant.createWorkspace(properties: createWorkspaceBody) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let workspace = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -553,8 +593,12 @@ class AssistantTests: XCTestCase {
         assistant.getWorkspace(workspaceID: newWorkspaceID, export: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let workspace = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -598,9 +642,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteWorkspace(workspaceID: newWorkspaceID) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
             expectation3.fulfill()
         }
@@ -614,8 +657,12 @@ class AssistantTests: XCTestCase {
         assistant.getWorkspace(workspaceID: workspaceID, export: false, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let workspace = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -648,8 +695,12 @@ class AssistantTests: XCTestCase {
         assistant.createWorkspace(properties: createWorkspaceBody) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let workspace = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -677,8 +728,12 @@ class AssistantTests: XCTestCase {
         assistant.updateWorkspace(workspaceID: newWorkspaceID, properties: updateWorkspaceBody) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let workspace = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -696,9 +751,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteWorkspace(workspaceID: newWorkspaceID) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation3.fulfill()
@@ -715,8 +769,12 @@ class AssistantTests: XCTestCase {
         assistant.listIntents(workspaceID: workspaceID, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let intents = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -742,8 +800,12 @@ class AssistantTests: XCTestCase {
         assistant.listIntents(workspaceID: workspaceID, includeCount: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let intents = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -770,8 +832,12 @@ class AssistantTests: XCTestCase {
         assistant.listIntents(workspaceID: workspaceID, pageLimit: 1, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let intents = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -798,8 +864,12 @@ class AssistantTests: XCTestCase {
         assistant.listIntents(workspaceID: workspaceID, export: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let intents = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -834,8 +904,12 @@ class AssistantTests: XCTestCase {
         assistant.createIntent(workspaceID: workspaceID, intent: newIntentName, description: newIntentDescription, examples: [example1, example2]) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let intent = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -851,9 +925,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteIntent(workspaceID: workspaceID, intent: newIntentName) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation2.fulfill()
@@ -868,8 +941,12 @@ class AssistantTests: XCTestCase {
         assistant.getIntent(workspaceID: workspaceID, intent: "weather", export: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let intent = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -898,8 +975,12 @@ class AssistantTests: XCTestCase {
         assistant.createIntent(workspaceID: workspaceID, intent: newIntentName, description: newIntentDescription, examples: [example1, example2]) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let intent = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -918,8 +999,12 @@ class AssistantTests: XCTestCase {
         assistant.updateIntent(workspaceID: workspaceID, intent: newIntentName, newIntent: updatedIntentName, newDescription: updatedIntentDescription, newExamples: [updatedExample1]) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let intent = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -935,9 +1020,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteIntent(workspaceID: workspaceID, intent: updatedIntentName) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation3.fulfill()
@@ -954,8 +1038,12 @@ class AssistantTests: XCTestCase {
         assistant.listExamples(workspaceID: workspaceID, intent: "weather", includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let examples = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -979,8 +1067,12 @@ class AssistantTests: XCTestCase {
         assistant.listExamples(workspaceID: workspaceID, intent: "weather", includeCount: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let examples = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1005,8 +1097,12 @@ class AssistantTests: XCTestCase {
         assistant.listExamples(workspaceID: workspaceID, intent: "weather", pageLimit: 1, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let examples = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1033,8 +1129,12 @@ class AssistantTests: XCTestCase {
         assistant.createExample(workspaceID: workspaceID, intent: "weather", text: newExample) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let example = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1049,9 +1149,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteExample(workspaceID: workspaceID, intent: "weather", text: newExample) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation2.fulfill()
@@ -1067,8 +1166,12 @@ class AssistantTests: XCTestCase {
         assistant.getExample(workspaceID: workspaceID, intent: "weather", text: exampleText, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let example = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1088,8 +1191,12 @@ class AssistantTests: XCTestCase {
         assistant.createExample(workspaceID: workspaceID, intent: "weather", text: newExample) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let example = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1105,8 +1212,12 @@ class AssistantTests: XCTestCase {
         assistant.updateExample(workspaceID: workspaceID, intent: "weather", text: newExample, newText: updatedText) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let example = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1121,9 +1232,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteExample(workspaceID: workspaceID, intent: "weather", text: updatedText) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation3.fulfill()
@@ -1140,8 +1250,12 @@ class AssistantTests: XCTestCase {
         assistant.listCounterexamples(workspaceID: workspaceID, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let counterexamples = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1166,8 +1280,12 @@ class AssistantTests: XCTestCase {
         assistant.listCounterexamples(workspaceID: workspaceID, includeCount: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let counterexamples = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1193,8 +1311,12 @@ class AssistantTests: XCTestCase {
         assistant.listCounterexamples(workspaceID: workspaceID, pageLimit: 1, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let counterexamples = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1220,8 +1342,12 @@ class AssistantTests: XCTestCase {
         assistant.createCounterexample(workspaceID: workspaceID, text: newExample) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let counterexample = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1236,9 +1362,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteCounterexample(workspaceID: workspaceID, text: newExample) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation2.fulfill()
@@ -1254,8 +1379,12 @@ class AssistantTests: XCTestCase {
         assistant.getCounterexample(workspaceID: workspaceID, text: exampleText, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let counterexample = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1275,8 +1404,12 @@ class AssistantTests: XCTestCase {
         assistant.createCounterexample(workspaceID: workspaceID, text: newExample) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let counterexample = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1292,8 +1425,12 @@ class AssistantTests: XCTestCase {
         assistant.updateCounterexample(workspaceID: workspaceID, text: newExample, newText: updatedText) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let counterexample = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1308,9 +1445,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteCounterexample(workspaceID: workspaceID, text: updatedText) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation3.fulfill()
@@ -1327,8 +1463,12 @@ class AssistantTests: XCTestCase {
         assistant.listEntities(workspaceID: workspaceID, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let entities = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1354,8 +1494,12 @@ class AssistantTests: XCTestCase {
         assistant.listEntities(workspaceID: workspaceID, includeCount: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let entities = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1381,8 +1525,12 @@ class AssistantTests: XCTestCase {
         assistant.listEntities(workspaceID: workspaceID, pageLimit: 1, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let entities = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1409,8 +1557,12 @@ class AssistantTests: XCTestCase {
         assistant.listEntities(workspaceID: workspaceID, export: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let entities = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1439,8 +1591,12 @@ class AssistantTests: XCTestCase {
         assistant.createEntity(workspaceID: workspaceID, properties: entity){
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let entity = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1456,9 +1612,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteEntity(workspaceID: workspaceID, entity: entity.entity) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectationTwo.fulfill()
@@ -1477,13 +1632,17 @@ class AssistantTests: XCTestCase {
         assistant.createEntity(workspaceID: workspaceID, properties: entity){
             response, error in
 
-            guard let entityResponse = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let entity = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
-            XCTAssertEqual(entityResponse.entityName, entityName)
-            XCTAssertEqual(entityResponse.description, entityDescription)
+            XCTAssertEqual(entity.entityName, entityName)
+            XCTAssertEqual(entity.description, entityDescription)
             expectation.fulfill()
         }
         waitForExpectations()
@@ -1497,13 +1656,17 @@ class AssistantTests: XCTestCase {
         assistant.updateEntity(workspaceID: workspaceID, entity: entityName, properties: updatedEntity){
             response, error in
 
-            guard let entityResponse = response?.result else {
-                self.failPositiveTest(error)
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
+            guard let entity = response?.result else {
+                XCTFail("Missing response value")
                 return
             }
 
-            XCTAssertEqual(entityResponse.entityName, updatedEntityName)
-            XCTAssertEqual(entityResponse.description, updatedEntityDescription)
+            XCTAssertEqual(entity.entityName, updatedEntityName)
+            XCTAssertEqual(entity.description, updatedEntityDescription)
             expectationTwo.fulfill()
         }
         waitForExpectations()
@@ -1514,9 +1677,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteEntity(workspaceID: workspaceID, entity: updatedEntityName) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectationFour.fulfill()
@@ -1531,8 +1693,12 @@ class AssistantTests: XCTestCase {
         assistant.listEntities(workspaceID: workspaceID) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let entityCollection = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1541,8 +1707,12 @@ class AssistantTests: XCTestCase {
             self.assistant.getEntity(workspaceID: self.workspaceID, entity: entity.entityName, export: true, includeAudit: true) {
                 response, error in
 
+                if let error = error {
+                    XCTFail("Unexpected error response from service: \(error)")
+                    return
+                }
                 guard let entityExport = response?.result else {
-                    self.failPositiveTest(error)
+                    XCTFail("Missing response value")
                     return
                 }
 
@@ -1570,8 +1740,12 @@ class AssistantTests: XCTestCase {
             includeAudit: true) {
                 response, error in
 
+                if let error = error {
+                    XCTFail("Unexpected error response from service: \(error)")
+                    return
+                }
                 guard let valueCollection = response?.result else {
-                    self.failPositiveTest(error)
+                    XCTFail("Missing response value")
                     return
                 }
 
@@ -1598,8 +1772,12 @@ class AssistantTests: XCTestCase {
         assistant.createValue(workspaceID: workspaceID, entity: entityName, properties: value) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let value = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1616,8 +1794,12 @@ class AssistantTests: XCTestCase {
         assistant.updateValue(workspaceID: workspaceID, entity: entityName, value: valueName, properties: updatedValue) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let value = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1633,9 +1815,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteValue(workspaceID: workspaceID, entity: entityName, value: updatedValueName) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectationThree.fulfill()
@@ -1652,8 +1833,12 @@ class AssistantTests: XCTestCase {
         assistant.listValues(workspaceID: workspaceID, entity: entityName) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let valueCollection = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1662,8 +1847,12 @@ class AssistantTests: XCTestCase {
             self.assistant.getValue(workspaceID: self.workspaceID, entity: entityName, value: value.valueText, export: true, includeAudit: true) {
                 response, error in
 
+                if let error = error {
+                    XCTFail("Unexpected error response from service: \(error)")
+                    return
+                }
                 guard let valueExport = response?.result else {
-                    self.failPositiveTest(error)
+                    XCTFail("Missing response value")
                     return
                 }
 
@@ -1685,8 +1874,12 @@ class AssistantTests: XCTestCase {
         assistant.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let synonyms = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1710,8 +1903,12 @@ class AssistantTests: XCTestCase {
         assistant.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", includeCount: true, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let synonyms = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1736,8 +1933,12 @@ class AssistantTests: XCTestCase {
         assistant.listSynonyms(workspaceID: workspaceID, entity: "appliance", value: "lights", pageLimit: 1, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let synonyms = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1764,8 +1965,12 @@ class AssistantTests: XCTestCase {
         assistant.createSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let synonym = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1780,9 +1985,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation2.fulfill()
@@ -1798,8 +2002,12 @@ class AssistantTests: XCTestCase {
         assistant.getSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: synonymName, includeAudit: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let synonym = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1819,8 +2027,12 @@ class AssistantTests: XCTestCase {
         assistant.createSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let synonym = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1836,8 +2048,12 @@ class AssistantTests: XCTestCase {
         assistant.updateSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: newSynonym, newSynonym: updatedSynonym){
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let synonym = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1852,9 +2068,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteSynonym(workspaceID: workspaceID, entity: "appliance", value: "lights", synonym: updatedSynonym) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation3.fulfill()
@@ -1871,8 +2086,12 @@ class AssistantTests: XCTestCase {
         assistant.listDialogNodes(workspaceID: workspaceID, includeCount: true) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let nodes = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1911,8 +2130,12 @@ class AssistantTests: XCTestCase {
         assistant.createDialogNode(workspaceID: workspaceID, properties: dialogNode) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let node = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1939,9 +2162,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteDialogNode(workspaceID: workspaceID, dialogNode: dialogNode.dialogNode) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation2.fulfill()
@@ -1956,8 +2178,12 @@ class AssistantTests: XCTestCase {
         assistant.createDialogNode(workspaceID: workspaceID, properties: dialogNode) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let node = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1972,8 +2198,12 @@ class AssistantTests: XCTestCase {
         assistant.updateDialogNode(workspaceID: workspaceID, dialogNode: "test-node", properties: updatedNode) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let node = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -1987,9 +2217,8 @@ class AssistantTests: XCTestCase {
         assistant.deleteDialogNode(workspaceID: workspaceID, dialogNode: updatedNode.dialogNode!) {
             _, error in
 
-            guard error == nil else {
-                self.failPositiveTest(error)
-                return
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
             }
 
             expectation3.fulfill()
@@ -2003,8 +2232,12 @@ class AssistantTests: XCTestCase {
         assistant.listDialogNodes(workspaceID: workspaceID) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let nodes = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -2015,8 +2248,12 @@ class AssistantTests: XCTestCase {
                 dialogNode: dialogNode.dialogNodeID) {
                     response, error in
 
-                    guard let node = response?.result, error == nil else {
-                        self.failPositiveTest(error)
+                    if let error = error {
+                        XCTFail("Unexpected error response from service: \(error)")
+                        return
+                    }
+                    guard let node = response?.result else {
+                        XCTFail("Missing response value")
                         return
                     }
 
@@ -2035,8 +2272,12 @@ class AssistantTests: XCTestCase {
         assistant.listAllLogs(filter: filter) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let logCollection = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -2051,8 +2292,12 @@ class AssistantTests: XCTestCase {
         assistant.listLogs(workspaceID: workspaceID) {
             response, error in
 
+            if let error = error {
+                XCTFail("Unexpected error response from service: \(error)")
+                return
+            }
             guard let logCollection = response?.result else {
-                self.failPositiveTest(error)
+                XCTFail("Missing response value")
                 return
             }
 
@@ -2071,9 +2316,8 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID) {
             _, error in
 
-            guard error != nil else {
-                self.failNegativeTest()
-                return
+            if error == nil {
+                XCTFail("Expected error response")
             }
             expectation.fulfill()
         }
@@ -2088,9 +2332,8 @@ class AssistantTests: XCTestCase {
         assistant.message(workspaceID: workspaceID) {
             _, error in
 
-            guard error != nil else {
-                self.failNegativeTest()
-                return
+            if error == nil {
+                XCTFail("Expected error response")
             }
             expectation.fulfill()
         }

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -122,11 +122,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -171,11 +171,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -225,11 +225,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -250,11 +250,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -299,11 +299,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -321,11 +321,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -346,11 +346,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -391,11 +391,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -414,11 +414,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let message = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -448,11 +448,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspaces = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -477,11 +477,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspaces = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -507,11 +507,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspaces = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -555,11 +555,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -585,11 +585,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -634,7 +634,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -649,11 +649,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -687,11 +687,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -720,11 +720,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let workspace = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -743,7 +743,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -760,11 +760,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intents = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -791,11 +791,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intents = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -823,11 +823,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intents = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -855,11 +855,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intents = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -895,11 +895,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intent = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -916,7 +916,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation2.fulfill()
         }
@@ -931,11 +931,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intent = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -965,11 +965,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intent = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -990,11 +990,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let intent = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1011,7 +1011,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -1028,11 +1028,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let examples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1057,11 +1057,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let examples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1087,11 +1087,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let examples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1119,11 +1119,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let example = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1139,7 +1139,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation2.fulfill()
         }
@@ -1155,11 +1155,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let example = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1180,11 +1180,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let example = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1201,11 +1201,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let example = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1221,7 +1221,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -1238,11 +1238,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexamples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1268,11 +1268,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexamples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1299,11 +1299,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexamples = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1330,11 +1330,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexample = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1350,7 +1350,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation2.fulfill()
         }
@@ -1366,11 +1366,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexample = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1391,11 +1391,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexample = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1412,11 +1412,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let counterexample = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1432,7 +1432,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -1449,11 +1449,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entities = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1480,11 +1480,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entities = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1511,11 +1511,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entities = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1543,11 +1543,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entities = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1577,11 +1577,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entity = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1598,7 +1598,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectationTwo.fulfill()
         }
@@ -1617,11 +1617,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entity = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1641,11 +1641,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entity = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1662,7 +1662,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectationFour.fulfill()
         }
@@ -1677,11 +1677,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let entityCollection = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1691,11 +1691,11 @@ class ConversationTests: XCTestCase {
                 response, error in
 
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let entityExport = response?.result else {
-                    XCTFail("Missing response value")
+                    XCTFail(missingResultMessage)
                     return
                 }
 
@@ -1724,11 +1724,11 @@ class ConversationTests: XCTestCase {
                 response, error in
 
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let valueCollection = response?.result else {
-                    XCTFail("Missing response value")
+                    XCTFail(missingResultMessage)
                     return
                 }
 
@@ -1756,11 +1756,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let value = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1778,11 +1778,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let value = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1799,7 +1799,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectationThree.fulfill()
         }
@@ -1816,11 +1816,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let valueCollection = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1830,11 +1830,11 @@ class ConversationTests: XCTestCase {
                 response, error in
 
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let valueExport = response?.result else {
-                    XCTFail("Missing response value")
+                    XCTFail(missingResultMessage)
                     return
                 }
 
@@ -1857,11 +1857,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonyms = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1886,11 +1886,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonyms = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1916,11 +1916,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonyms = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1948,11 +1948,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonym = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1968,7 +1968,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation2.fulfill()
         }
@@ -1984,11 +1984,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonym = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2009,11 +2009,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonym = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2030,11 +2030,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let synonym = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2050,7 +2050,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -2067,11 +2067,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let nodes = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2115,11 +2115,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let node = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2148,7 +2148,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation2.fulfill()
         }
@@ -2163,11 +2163,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let node = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2183,11 +2183,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let node = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2202,7 +2202,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -2216,11 +2216,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let nodes = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2232,11 +2232,11 @@ class ConversationTests: XCTestCase {
                                 response, error in
 
                     if let error = error {
-                        XCTFail("Unexpected error response from service: \(error)")
+                        XCTFail(unexpectedErrorMessage(error))
                         return
                     }
                     guard let node = response?.result else {
-                        XCTFail("Missing response value")
+                        XCTFail(missingResultMessage)
                         return
                     }
                     XCTAssertEqual(dialogNode.dialogNodeID, node.dialogNodeID)
@@ -2255,11 +2255,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let logCollection = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2275,11 +2275,11 @@ class ConversationTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let logCollection = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -2299,7 +2299,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -2314,7 +2314,7 @@ class ConversationTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -126,11 +126,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -152,11 +152,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -175,11 +175,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -201,11 +201,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -224,11 +224,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -253,11 +253,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -282,11 +282,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -305,11 +305,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -327,11 +327,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -348,11 +348,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -375,14 +375,14 @@ class DiscoveryTests: XCTestCase {
 
             if let error = error {
                 if !(error.localizedDescription.contains(message1) || error.localizedDescription.contains(message2)) {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 } else {
                     expectation1.fulfill()
                 }
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -402,11 +402,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -424,11 +424,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -442,11 +442,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -469,11 +469,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -495,11 +495,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -519,11 +519,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -546,11 +546,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -567,11 +567,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -589,11 +589,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -608,11 +608,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -639,11 +639,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -670,11 +670,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -695,11 +695,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -726,11 +726,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -752,11 +752,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -774,11 +774,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -793,11 +793,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -820,11 +820,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -853,11 +853,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -873,11 +873,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -893,7 +893,7 @@ class DiscoveryTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -921,11 +921,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -948,11 +948,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -975,11 +975,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1010,11 +1010,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1043,11 +1043,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1079,11 +1079,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1108,11 +1108,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1135,11 +1135,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1176,11 +1176,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1212,11 +1212,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1248,11 +1248,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1289,11 +1289,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1329,11 +1329,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1368,11 +1368,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1404,11 +1404,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1440,11 +1440,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1476,11 +1476,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1512,11 +1512,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let query = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1547,11 +1547,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1576,11 +1576,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1602,11 +1602,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1633,11 +1633,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1669,11 +1669,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1694,11 +1694,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1715,7 +1715,7 @@ class DiscoveryTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -1728,7 +1728,7 @@ class DiscoveryTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation4.fulfill()
         }
@@ -1745,7 +1745,7 @@ class DiscoveryTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation.fulfill()
         }
@@ -1775,11 +1775,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1794,11 +1794,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1816,7 +1816,7 @@ class DiscoveryTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -1842,11 +1842,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1867,11 +1867,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1886,11 +1886,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1905,11 +1905,11 @@ class DiscoveryTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1924,7 +1924,7 @@ class DiscoveryTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation5.fulfill()
         }
@@ -1936,7 +1936,7 @@ class DiscoveryTests: XCTestCase {
         discovery.deleteCollection(environmentID: environmentID, collectionID: collectionID) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
 
             expectation6.fulfill()
@@ -1952,7 +1952,7 @@ class DiscoveryTests: XCTestCase {
             _, error in
 
             guard let error = error else {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
                 return
             }
             XCTAssert(error.localizedDescription.lowercased().contains("invalid environment id"))
@@ -1968,7 +1968,7 @@ class DiscoveryTests: XCTestCase {
             _, error in
 
             guard let error = error else {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
                 return
             }
             XCTAssert(error.localizedDescription.lowercased().contains("invalid configuration id"))
@@ -1984,7 +1984,7 @@ class DiscoveryTests: XCTestCase {
             _, error in
 
             guard let error = error else {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
                 return
             }
             XCTAssert(error.localizedDescription.lowercased().contains("could not find"))
@@ -2002,7 +2002,7 @@ class DiscoveryTests: XCTestCase {
                 _, error in
 
                 guard let error = error else {
-                    XCTFail("Expected error response")
+                    XCTFail(missingErrorMessage)
                     return
                 }
                 XCTAssert(error.localizedDescription.lowercased().contains("invalid environment id"))

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -28,6 +28,7 @@ class DiscoveryTests: XCTestCase {
     private let newsCollectionID = "news-en"
     private var documentURL: URL!
     private let timeout: TimeInterval = 30.0
+    private let unexpectedAggregationTypeMessage = "Unexpected aggregation type"
 
     // MARK: - Test Configuration
 
@@ -1146,7 +1147,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .term(term) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1187,7 +1188,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .filter(filter) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1223,7 +1224,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .nested(nested) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1259,7 +1260,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .histogram(histogram) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1300,7 +1301,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .timeslice(timeslice) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1340,7 +1341,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .topHits(topHits) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1379,7 +1380,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .uniqueCount(uniqueCount) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1415,7 +1416,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .max(calculation) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1451,7 +1452,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .min(calculation) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1487,7 +1488,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .average(calculation) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }
@@ -1523,7 +1524,7 @@ class DiscoveryTests: XCTestCase {
             XCTAssertNotNil(query.aggregations)
             XCTAssertEqual(query.aggregations!.count, 1)
             guard case let .sum(calculation) = query.aggregations!.first! else {
-                XCTFail("unexpected aggregation type")
+                XCTFail(self.unexpectedAggregationTypeMessage)
                 expectation.fulfill()
                 return
             }

--- a/Tests/LanguageTranslatorV3Tests/LanguageTranslatorTests.swift
+++ b/Tests/LanguageTranslatorV3Tests/LanguageTranslatorTests.swift
@@ -75,11 +75,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let models = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -88,7 +88,7 @@ class LanguageTranslatorTests: XCTestCase {
                     _, error in
 
                     if let error = error {
-                        XCTFail("Unexpected error response from service: \(error)")
+                        XCTFail(unexpectedErrorMessage(error))
                         return
                     }
                 }
@@ -113,11 +113,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let models = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -133,11 +133,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let models = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -153,11 +153,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let models = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -173,11 +173,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let models = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -208,12 +208,12 @@ class LanguageTranslatorTests: XCTestCase {
                     expectation.fulfill()
                     return
                 } else {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
             }
             guard let model = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -222,7 +222,7 @@ class LanguageTranslatorTests: XCTestCase {
                 _, error in
 
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation.fulfill()
             }
@@ -236,11 +236,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -257,11 +257,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let translation = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -281,11 +281,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let translation = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -304,11 +304,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let identifiableLanguages = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -324,11 +324,11 @@ class LanguageTranslatorTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let identifiableLanguages = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -350,7 +350,7 @@ class LanguageTranslatorTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }

--- a/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
+++ b/Tests/NaturalLanguageClassifierV1Tests/NaturalLanguageClassifierTests.swift
@@ -115,11 +115,11 @@ class NaturalLanguageClassifierTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifier = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -129,7 +129,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
                 _, error in
 
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation.fulfill()
             }
@@ -143,11 +143,11 @@ class NaturalLanguageClassifierTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifier = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -157,7 +157,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
                 _, error in
 
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation.fulfill()
             }
@@ -171,11 +171,11 @@ class NaturalLanguageClassifierTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiers = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -190,11 +190,11 @@ class NaturalLanguageClassifierTests: XCTestCase {
         naturalLanguageClassifier.getClassifier(classifierID: trainedClassifierId) { response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifier = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -210,11 +210,11 @@ class NaturalLanguageClassifierTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classification = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -235,11 +235,11 @@ class NaturalLanguageClassifierTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifications = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -267,7 +267,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
                 _, error in
 
                 if error == nil {
-                    XCTFail("Expected error response")
+                    XCTFail(missingErrorMessage)
                 }
                 expectation.fulfill()
         }
@@ -280,7 +280,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -296,7 +296,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -311,7 +311,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -326,7 +326,7 @@ class NaturalLanguageClassifierTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }

--- a/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
+++ b/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
@@ -616,7 +616,6 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
     func testDeleteModel() {
         let description = "Delete an invalid model."
         let expectation = self.expectation(description: description)
-        let failure = { (error: Error) in expectation.fulfill() }
         naturalLanguageUnderstanding.deleteModel(modelID: "invalid_model_id") {
             _, error in
 

--- a/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
+++ b/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
@@ -107,7 +107,7 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation.fulfill()
         }
@@ -125,7 +125,7 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation.fulfill()
         }
@@ -143,7 +143,7 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             _, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation.fulfill()
         }
@@ -170,11 +170,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -203,11 +203,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -242,11 +242,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -292,11 +292,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -331,11 +331,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -367,11 +367,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -403,11 +403,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -431,11 +431,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -458,11 +458,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -496,11 +496,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -529,11 +529,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -558,11 +558,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -596,11 +596,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -621,7 +621,7 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -635,11 +635,11 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 

--- a/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
@@ -102,11 +102,11 @@ class PersonalityInsightsTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let profile = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -125,11 +125,11 @@ class PersonalityInsightsTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let profile = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -160,11 +160,11 @@ class PersonalityInsightsTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let profile = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -184,11 +184,11 @@ class PersonalityInsightsTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let csv = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -204,11 +204,11 @@ class PersonalityInsightsTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let csv = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -236,11 +236,11 @@ class PersonalityInsightsTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let csv = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -256,11 +256,11 @@ class PersonalityInsightsTests: XCTestCase {
             response, error in
 
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let profile = response?.result else {
-                XCTFail("Missing response value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -293,7 +293,7 @@ class PersonalityInsightsTests: XCTestCase {
             _, error in
 
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -53,6 +53,14 @@ class SpeechToTextRecognizeTests: XCTestCase {
         speechToText.defaultHeaders["X-Watson-Test"] = "true"
     }
 
+    func cannotLocateFileMessage(_ fileName: String, _ withExtension: String) -> String {
+        return "Unable to locate \(fileName).\(withExtension)"
+    }
+
+    func cannotReadFileMessage(_ fileName: String, _ withExtension: String) -> String {
+        return "Unable to read \(fileName).\(withExtension)"
+    }
+
     // MARK: - Test Definition for Linux
 
     static var allTests: [(String, (SpeechToTextRecognizeTests) -> () throws -> Void)] {
@@ -98,7 +106,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
 
         let bundle = Bundle(for: type(of: self))
         guard let file = bundle.url(forResource: filename, withExtension: withExtension) else {
-            XCTFail("Unable to locate \(filename).\(withExtension).")
+            XCTFail(cannotLocateFileMessage(filename, withExtension))
             return
         }
 
@@ -145,7 +153,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
 
         let bundle = Bundle(for: type(of: self))
         guard let file = bundle.url(forResource: filename, withExtension: withExtension) else {
-            XCTFail("Unable to locate \(filename).\(withExtension).")
+            XCTFail(cannotLocateFileMessage(filename, withExtension))
             return
         }
 
@@ -203,7 +211,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
 
         let bundle = Bundle(for: type(of: self))
         guard let file = bundle.url(forResource: filename, withExtension: withExtension) else {
-            XCTFail("Unable to locate \(filename).\(withExtension).")
+            XCTFail(cannotLocateFileMessage(filename, withExtension))
             return
         }
 
@@ -232,7 +240,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
             }
             wait(for: [expectation], timeout: timeout)
         } catch {
-            XCTFail("Unable to read \(filename).\(withExtension).")
+            XCTFail(cannotReadFileMessage(filename, withExtension))
             return
         }
     }
@@ -257,7 +265,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
 
         let bundle = Bundle(for: type(of: self))
         guard let file = bundle.url(forResource: filename, withExtension: withExtension) else {
-            XCTFail("Unable to locate \(filename).\(withExtension).")
+            XCTFail(cannotLocateFileMessage(filename, withExtension))
             return
         }
 
@@ -296,7 +304,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
             }
             wait(for: [expectation], timeout: timeout)
         } catch {
-            XCTFail("Unable to read \(filename).\(withExtension).")
+            XCTFail(cannotReadFileMessage(filename, withExtension))
             return
         }
     }
@@ -318,12 +326,12 @@ class SpeechToTextRecognizeTests: XCTestCase {
 
         let bundle = Bundle(for: type(of: self))
         guard let file = bundle.url(forResource: filename, withExtension: withExtension) else {
-            XCTFail("Unable to locate \(filename).\(withExtension).")
+            XCTFail(cannotLocateFileMessage(filename, withExtension))
             return
         }
 
         guard let audio = try? Data(contentsOf: file) else {
-            XCTFail("Unable to read \(filename).\(withExtension).")
+            XCTFail(cannotReadFileMessage(filename, withExtension))
             return
         }
 
@@ -372,7 +380,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
 
         let bundle = Bundle(for: type(of: self))
         guard let file = bundle.url(forResource: filename, withExtension: withExtension) else {
-            XCTFail("Unable to locate \(filename).\(withExtension).")
+            XCTFail(cannotLocateFileMessage(filename, withExtension))
             return
         }
 
@@ -406,7 +414,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
             }
             wait(for: [expectation], timeout: timeout)
         } catch {
-            XCTFail("Unable to read \(filename).\(withExtension).")
+            XCTFail(cannotReadFileMessage(filename, withExtension))
             return
         }
     }

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -106,11 +106,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         speechToText.recognize(audio: file, settings: settings) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             self.validateSTTResults(results: results, settings: settings)
@@ -164,11 +164,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         speechToText.recognize(audio: file, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             self.validateSTTResults(results: results, settings: settings)
@@ -214,11 +214,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
             speechToText.recognize(audio: audio, settings: settings) {
                 response, error in
                 if let error = error {
-                    XCTFail("Received an unexpected error: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let results = response?.result else {
-                    XCTFail("Missing result from response")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 self.validateSTTResults(results: results, settings: settings)
@@ -279,11 +279,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
             speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
                 response, error in
                 if let error = error {
-                    XCTFail("Received an unexpected error: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let results = response?.result else {
-                    XCTFail("Missing result from response")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 self.validateSTTResults(results: results, settings: settings)
@@ -333,11 +333,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let results = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             self.validateSTTResults(results: results, settings: settings)
@@ -390,11 +390,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
             speechToText.recognize(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true) {
                 response, error in
                 if let error = error {
-                    XCTFail("Received an unexpected error: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let results = response?.result else {
-                    XCTFail("Missing result from response")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 XCTAssertNotNil(results.speakerLabels)

--- a/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextTests.swift
@@ -80,7 +80,7 @@ class SpeechToTextTests: XCTestCase {
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             languageModel = result.customizations.first { $0.name == "swift-test-model" }
@@ -104,7 +104,7 @@ class SpeechToTextTests: XCTestCase {
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             languageModel = model
@@ -127,7 +127,7 @@ class SpeechToTextTests: XCTestCase {
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             acousticModel = result.customizations.first { $0.name == "swift-test-model" }
@@ -150,7 +150,7 @@ class SpeechToTextTests: XCTestCase {
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             acousticModel = model
@@ -171,7 +171,7 @@ class SpeechToTextTests: XCTestCase {
         {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation.fulfill()
         }
@@ -191,7 +191,7 @@ class SpeechToTextTests: XCTestCase {
         {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation.fulfill()
         }
@@ -220,13 +220,13 @@ class SpeechToTextTests: XCTestCase {
                 response, error in
                 if let error = error {
                     if !error.localizedDescription.contains("locked") {
-                        XCTFail("Received an unexpected error: \(error)")
+                        XCTFail(unexpectedErrorMessage(error))
                     }
                     expectation.fulfill()
                     return
                 }
                 guard let model = response?.result else {
-                    XCTFail("Missing result from response")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 hasDesiredStatus = (model.status == status)
@@ -245,13 +245,13 @@ class SpeechToTextTests: XCTestCase {
                 response, error in
                 if let error = error {
                     if !error.localizedDescription.contains("locked") {
-                        XCTFail("Received an unexpected error: \(error)")
+                        XCTFail(unexpectedErrorMessage(error))
                     }
                     expectation.fulfill()
                     return
                 }
                 guard let model = response?.result else {
-                    XCTFail("Missing result from response")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 hasDesiredStatus = (model.status == status)
@@ -270,13 +270,13 @@ class SpeechToTextTests: XCTestCase {
                 response, error in
                 if let error = error {
                     if !error.localizedDescription.contains("locked") {
-                        XCTFail("Received an unexpected error: \(error)")
+                        XCTFail(unexpectedErrorMessage(error))
                     }
                     expectation.fulfill()
                     return
                 }
                 guard let corpus = response?.result else {
-                    XCTFail("Missing result from response")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 hasDesiredStatus = (corpus.status == status)
@@ -294,11 +294,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listModels {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(result.models.count, 0)
@@ -313,11 +313,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getModel(modelID: modelID) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(model.name, modelID)
@@ -334,11 +334,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.recognizeSessionless(model: "en-US_BroadbandModel", audio: audio, contentType: "audio/wav") {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let recognitionResults = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertNotNil(recognitionResults.results)
@@ -362,11 +362,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.createJob(audio: audio, contentType: "audio/wav", model: "en-US_BroadbandModel") {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             job = result
@@ -379,11 +379,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.checkJobs {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(result.recognitions.count, 0)
@@ -396,11 +396,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.checkJob(id: job.id) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(result.id, job.id)
@@ -414,11 +414,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.registerCallback(callbackUrl: url, userSecret: "ThisIsMySecret") {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let status = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(status.url, url)
@@ -431,7 +431,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.unregisterCallback(callbackUrl: url) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation5.fulfill()
         }
@@ -442,7 +442,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteJob(id: job.id) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation6.fulfill()
         }
@@ -462,13 +462,13 @@ class SpeechToTextTests: XCTestCase {
             response, error in
             if let error = error {
                 if !error.localizedDescription.contains(self.litePlanMessage) {
-                    XCTFail("Received an unexpected error: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation1.fulfill()
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             languageModel = model
@@ -486,11 +486,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listLanguageModels(language: "en-US") {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertTrue(result.customizations.contains { $0.customizationID == languageModel.customizationID })
@@ -503,11 +503,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getLanguageModel(customizationID: languageModel.customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(model.customizationID, languageModel.customizationID)
@@ -523,7 +523,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.trainLanguageModel(customizationID: languageModel.customizationID, wordTypeToAdd: "all", customizationWeight: 0.3) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation4.fulfill()
         }
@@ -537,7 +537,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.resetLanguageModel(customizationID: languageModel.customizationID) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation5.fulfill()
         }
@@ -549,7 +549,7 @@ class SpeechToTextTests: XCTestCase {
             _, error in
             if let error = error {
                 if !error.localizedDescription.contains("model is up-to-date") {
-                    XCTFail("Received an unexpected error: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
             }
             expectation6.fulfill()
@@ -564,7 +564,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteLanguageModel(customizationID: languageModel.customizationID) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation7.fulfill()
         }
@@ -589,7 +589,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.addCorpus(customizationID: id, corpusName: corpusName, corpusFile: file, allowOverwrite: true) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation1.fulfill()
         }
@@ -603,11 +603,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listCorpora(customizationID: languageModel.customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertTrue(result.corpora.contains { $0.name == corpusName })
@@ -620,11 +620,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getCorpus(customizationID: id, corpusName: corpusName) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let corpus = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(corpus.name, corpusName)
@@ -637,7 +637,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteCorpus(customizationID: id, corpusName: corpusName) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation4.fulfill()
         }
@@ -660,7 +660,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.addWords(customizationID: languageModel.customizationID, words: [word]) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation2.fulfill()
         }
@@ -674,7 +674,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.addWord(customizationID: languageModel.customizationID, wordName: "worlld", soundsLike: ["world"], displayAs: "world") {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -688,11 +688,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listWords(customizationID: languageModel.customizationID, wordType: "user", sort: "+alphabetical") {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(result.words.count, 2)
@@ -707,11 +707,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getWord(customizationID: languageModel.customizationID, wordName: "helllo") {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let word = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(word.word, "helllo")
@@ -724,7 +724,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteWord(customizationID: languageModel.customizationID, wordName: "helllo") {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation6.fulfill()
         }
@@ -743,13 +743,13 @@ class SpeechToTextTests: XCTestCase {
             response, error in
             if let error = error {
                 if !error.localizedDescription.contains(self.litePlanMessage) {
-                    XCTFail("Received an unexpected error: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation1.fulfill()
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             acousticModel = model
@@ -767,11 +767,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listAcousticModels(language: "en-US") {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertTrue(result.customizations.contains { $0.customizationID == acousticModel.customizationID })
@@ -784,11 +784,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getAcousticModel(customizationID: acousticModel.customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let model = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(model.customizationID, acousticModel.customizationID)
@@ -805,7 +805,7 @@ class SpeechToTextTests: XCTestCase {
             _, error in
             if let error = error {
                 if !error.localizedDescription.contains("audio duration must be between") {
-                    XCTFail("Received an unexpected error: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
             }
             expectation4.fulfill()
@@ -820,7 +820,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.resetAcousticModel(customizationID: acousticModel.customizationID) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation5.fulfill()
         }
@@ -832,7 +832,7 @@ class SpeechToTextTests: XCTestCase {
             _, error in
             if let error = error {
                 if !error.localizedDescription.contains("model is up-to-date") {
-                    XCTFail("Received an unexpected error: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
             }
             expectation6.fulfill()
@@ -847,7 +847,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteAcousticModel(customizationID: acousticModel.customizationID) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation7.fulfill()
         }
@@ -870,7 +870,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.addAudio(customizationID: acousticModel.customizationID, audioName: "audio", audioResource: audio, contentType: "audio/wav", allowOverwrite: true) {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation1.fulfill()
         }
@@ -884,11 +884,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.listAudio(customizationID: acousticModel.customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(result.audio.count, 0)
@@ -902,11 +902,11 @@ class SpeechToTextTests: XCTestCase {
         speechToText.getAudio(customizationID: acousticModel.customizationID, audioName: "audio") {
             response, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let audio = response?.result else {
-                XCTFail("Missing result from response")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(audio.name, "audio")
@@ -919,7 +919,7 @@ class SpeechToTextTests: XCTestCase {
         speechToText.deleteAudio(customizationID: acousticModel.customizationID, audioName: "audio") {
             _, error in
             if let error = error {
-                XCTFail("Received an unexpected error: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation4.fulfill()
         }

--- a/Tests/TestUtilities.swift
+++ b/Tests/TestUtilities.swift
@@ -1,0 +1,19 @@
+//
+//  TestUtilities.swift
+//  WatsonDeveloperCloud
+//
+//  Created by Anthony Oliveri on 8/1/18.
+//  Copyright © 2018 Glenn R. Fisher. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - Messages used in XCTFail
+
+let missingResultMessage = "Missing result from response"
+let missingErrorMessage = "Expected error not received"
+
+func unexpectedErrorMessage(_ error: Error) -> String {
+    return "Received an unexpected error: \(error)"
+}

--- a/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
@@ -89,7 +89,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(3)
                 }
             } catch {
-                XCTFail(failedToInitializeAudioPlayerMessage)
+                XCTFail(self.failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }
@@ -120,7 +120,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(3)
                 }
             } catch {
-                XCTFail(failedToInitializeAudioPlayerMessage)
+                XCTFail(self.failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }
@@ -151,7 +151,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(2)
                 }
             } catch {
-                XCTFail(failedToInitializeAudioPlayerMessage)
+                XCTFail(self.failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }
@@ -182,7 +182,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(2)
                 }
             } catch {
-                XCTFail(failedToInitializeAudioPlayerMessage)
+                XCTFail(self.failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }
@@ -213,7 +213,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(1)
                 }
             } catch {
-                XCTFail(failedToInitializeAudioPlayerMessage)
+                XCTFail(self.failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }

--- a/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
@@ -72,11 +72,11 @@ class TextToSpeechPlaybackTests: XCTestCase {
         textToSpeech.synthesize(text: text, accept: "audio/wav") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)
@@ -103,11 +103,11 @@ class TextToSpeechPlaybackTests: XCTestCase {
         textToSpeech.synthesize(text: text, accept: "audio/wav", voice: "en-US_LisaVoice") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)
@@ -134,11 +134,11 @@ class TextToSpeechPlaybackTests: XCTestCase {
         textToSpeech.synthesize(text: germanText, accept: "audio/wav", voice: "de-DE_DieterVoice") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)
@@ -165,11 +165,11 @@ class TextToSpeechPlaybackTests: XCTestCase {
         textToSpeech.synthesize(text: japaneseText, accept: "audio/wav", voice: "ja-JP_EmiVoice") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)
@@ -196,11 +196,11 @@ class TextToSpeechPlaybackTests: XCTestCase {
         textToSpeech.synthesize(text: ssmlString, accept: "audio/wav") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)
@@ -230,11 +230,11 @@ class TextToSpeechPlaybackTests: XCTestCase {
         textToSpeech.synthesize(text: text, accept: "audio/ogg;codecs=opus") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)

--- a/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechPlaybackTests.swift
@@ -30,6 +30,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
     private let japaneseText = "こんにちは"
     private let ssmlString = "<speak xml:lang=\"En-US\" version=\"1.0\">" +
     "<say-as interpret-as=\"letters\">Hello</say-as></speak>"
+    private let failedToInitializeAudioPlayerMessage = "Failed to initialize an AVAudioPlayer with the received data"
 
     // MARK: - Test Configuration
 
@@ -88,7 +89,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(3)
                 }
             } catch {
-                XCTFail("Failed to initialize an AVAudioPlayer with the received data.")
+                XCTFail(failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }
@@ -119,7 +120,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(3)
                 }
             } catch {
-                XCTFail("Failed to initialize an AVAudioPlayer with the received data.")
+                XCTFail(failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }
@@ -150,7 +151,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(2)
                 }
             } catch {
-                XCTFail("Failed to initialize an AVAudioPlayer with the received data.")
+                XCTFail(failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }
@@ -181,7 +182,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(2)
                 }
             } catch {
-                XCTFail("Failed to initialize an AVAudioPlayer with the received data.")
+                XCTFail(failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }
@@ -212,7 +213,7 @@ class TextToSpeechPlaybackTests: XCTestCase {
                     sleep(1)
                 }
             } catch {
-                XCTFail("Failed to initialize an AVAudioPlayer with the received data.")
+                XCTFail(failedToInitializeAudioPlayerMessage)
             }
             expectation.fulfill()
         }

--- a/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
+++ b/Tests/TextToSpeechV1Tests/TextToSpeechTests.swift
@@ -104,13 +104,13 @@ class TextToSpeechTests: XCTestCase {
             response, error in
             if let error = error {
                 if !error.localizedDescription.contains(self.litePlanMessage) {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation.fulfill()
                 return
             }
             guard let voiceModels = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             for voiceModel in voiceModels.customizations {
@@ -136,13 +136,13 @@ class TextToSpeechTests: XCTestCase {
             response, error in
             if let error = error {
                 if !error.localizedDescription.contains(self.litePlanMessage) {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation.fulfill()
                 return
             }
             guard let voiceModels = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThanOrEqual(voiceModels.voices.count, self.allVoices.count)
@@ -157,11 +157,11 @@ class TextToSpeechTests: XCTestCase {
             textToSpeech.getVoice(voice: voice) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let result = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 XCTAssertEqual(result.name, voice)
@@ -178,11 +178,11 @@ class TextToSpeechTests: XCTestCase {
             textToSpeech.getPronunciation(text: text, voice: voice, format: "ibm") {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let pronunciation = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 XCTAssertGreaterThan(pronunciation.pronunciation.count, 0)
@@ -197,11 +197,11 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.synthesize(text: text, accept: "audio/ogg;codecs=opus") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)
@@ -215,11 +215,11 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.synthesize(text: text, accept: "audio/wav") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)
@@ -233,11 +233,11 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.synthesize(text: text, accept: "audio/flac") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)
@@ -251,11 +251,11 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.synthesize(text: text, accept: "audio/l16;rate=44100") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let data = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertGreaterThan(data.count, 0)
@@ -270,13 +270,13 @@ class TextToSpeechTests: XCTestCase {
             response, error in
             if let error = error {
                 if !error.localizedDescription.contains(self.litePlanMessage) {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation.fulfill()
                 return
             }
             guard let voiceModels = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(voiceModels.customizations.count, 0)
@@ -293,13 +293,13 @@ class TextToSpeechTests: XCTestCase {
             response, error in
             if let error = error {
                 if !error.localizedDescription.contains(self.litePlanMessage) {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation1.fulfill()
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssert(!result.customizationID.isEmpty)
@@ -318,11 +318,11 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.getVoiceModel(customizationID: customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(result.customizationID, voiceModel.customizationID)
@@ -338,7 +338,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.updateVoiceModel(customizationID: customizationID, name: newName, description: description, words: words) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -348,11 +348,11 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.getVoiceModel(customizationID: customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(result.customizationID, voiceModel.customizationID)
@@ -370,7 +370,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.deleteVoiceModel(customizationID: customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation5.fulfill()
         }
@@ -384,13 +384,13 @@ class TextToSpeechTests: XCTestCase {
             response, error in
             if let error = error {
                 if !error.localizedDescription.contains(self.litePlanMessage) {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation1.fulfill()
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssert(!result.customizationID.isEmpty)
@@ -410,7 +410,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.addWords(customizationID: customizationID, words: words) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation2.fulfill()
         }
@@ -420,7 +420,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.addWord(customizationID: customizationID, word: "MIL", translation: "mill") {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -430,11 +430,11 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.listWords(customizationID: customizationID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let result = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(result.words.count, 2)
@@ -448,11 +448,11 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.getWord(customizationID: customizationID, word: "IBM") {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let translation = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(translation.translation, "eye bee em")
@@ -464,7 +464,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.deleteWord(customizationID: customizationID, word: "MIL") {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation6.fulfill()
         }
@@ -479,7 +479,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.getPronunciation(text: text, voice: voice) {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -492,7 +492,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.getVoice(voice: voice) {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -504,7 +504,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.synthesize(text: "") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -517,7 +517,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.synthesize(text: text, voice: voice) {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -529,7 +529,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.listVoiceModels(language: "invalid-language") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -541,7 +541,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.createVoiceModel(name: "custom-model", language: "invalid-language") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -553,7 +553,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.deleteVoiceModel(customizationID: "invalid-id") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -565,7 +565,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.getVoiceModel(customizationID: "invalid-id") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -577,7 +577,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.updateVoiceModel(customizationID: "invalid-id") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -589,7 +589,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.listWords(customizationID: "invalid-id") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -601,7 +601,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.addWords(customizationID: "invalid-id", words: []) {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -613,7 +613,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.deleteWord(customizationID: "invalid-id", word: "invalid-word") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -625,7 +625,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.getWord(customizationID: "invalid-id", word: "invalid-word") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
 
@@ -638,7 +638,7 @@ class TextToSpeechTests: XCTestCase {
         textToSpeech.addWord(customizationID: "invalid-id", word: "invalid-word", translation: "invalid-translation") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -89,10 +89,16 @@ class ToneAnalyzerTests: XCTestCase {
         let expectation = self.expectation(description: "Get tone.")
         toneAnalyzer.tone(toneContent: .toneInput(ToneInput(text: text))) {
             response, error in
-            guard let toneAnalysis = response?.result else {
-                XCTFail("Positive test failed with error: \(error!)")
+
+            if let error = error {
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
+            guard let toneAnalysis = response?.result else {
+                XCTFail(missingResultMessage)
+                return
+            }
+
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
             XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
             XCTAssertNotNil(toneAnalysis.sentencesTone)
@@ -113,10 +119,16 @@ class ToneAnalyzerTests: XCTestCase {
         let expectation = self.expectation(description: "Get tone.")
         toneAnalyzer.tone(toneContent: .text(text)) {
             response, error in
-            guard let toneAnalysis = response?.result else {
-                XCTFail("Positive test failed with error: \(error!)")
+
+            if let error = error {
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
+            guard let toneAnalysis = response?.result else {
+                XCTFail(missingResultMessage)
+                return
+            }
+
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
             XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
             XCTAssertNotNil(toneAnalysis.sentencesTone)
@@ -138,10 +150,16 @@ class ToneAnalyzerTests: XCTestCase {
         let html = "<!DOCTYPE html><html><body><p>\(text)</p></body></html>"
         toneAnalyzer.tone(toneContent: .html(html)) {
             response, error in
-            guard let toneAnalysis = response?.result else {
-                XCTFail("Positive test failed with error: \(error!)")
+
+            if let error = error {
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
+            guard let toneAnalysis = response?.result else {
+                XCTFail(missingResultMessage)
+                return
+            }
+
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
             XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
             XCTAssertNotNil(toneAnalysis.sentencesTone)
@@ -166,10 +184,16 @@ class ToneAnalyzerTests: XCTestCase {
             acceptLanguage: "en")
         {
             response, error in
-            guard let toneAnalysis = response?.result else {
-                XCTFail("Positive test failed with error: \(error!)")
+
+            if let error = error {
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
+            guard let toneAnalysis = response?.result else {
+                XCTFail(missingResultMessage)
+                return
+            }
+
             XCTAssertNotNil(toneAnalysis.documentTone.tones)
             XCTAssertGreaterThan(toneAnalysis.documentTone.tones!.count, 0)
             XCTAssertNil(toneAnalysis.sentencesTone)
@@ -182,10 +206,16 @@ class ToneAnalyzerTests: XCTestCase {
         let expectation = self.expectation(description: "Tone chat.")
         toneAnalyzer.toneChat(utterances: utterances, acceptLanguage: "en") {
             response, error in
-            guard let analyses = response?.result else {
-                XCTFail("Positive test failed with error: \(error!)")
+
+            if let error = error {
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
+            guard let analyses = response?.result else {
+                XCTFail(missingResultMessage)
+                return
+            }
+
             XCTAssert(!analyses.utterancesTone.isEmpty)
             expectation.fulfill()
         }
@@ -198,8 +228,9 @@ class ToneAnalyzerTests: XCTestCase {
         let expectation = self.expectation(description: "Get tone with an empty string.")
         toneAnalyzer.tone(toneContent: .toneInput(ToneInput(text: ""))) {
             _, error in
+
             if error == nil {
-                XCTFail("Negative test did not return error.")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -210,8 +241,9 @@ class ToneAnalyzerTests: XCTestCase {
         let expectation = self.expectation(description: "Tone chat with an empty array.")
         toneAnalyzer.toneChat(utterances: [], acceptLanguage: "en") {
             _, error in
+
             if error == nil {
-                XCTFail("Negative test did not return error.")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
@@ -65,7 +65,7 @@ class VisualRecognitionCoreMLTests: XCTestCase {
             visualRecognition.updateLocalModel(classifierID: classifierID) {
                 _, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation.fulfill()
             }
@@ -113,7 +113,7 @@ class VisualRecognitionCoreMLTests: XCTestCase {
             visualRecognition.updateLocalModel(classifierID: classifierID) {
                 _, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation1.fulfill()
             }
@@ -125,7 +125,7 @@ class VisualRecognitionCoreMLTests: XCTestCase {
             visualRecognition.classifyWithLocalModel(image: image, classifierIDs: [classifierID], threshold: 0.1) {
                 _, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                 }
                 expectation2.fulfill()
             }

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
@@ -71,11 +71,11 @@ class VisualRecognitionUIImageTests: XCTestCase {
         visualRecognition.classify(image: car) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             var containsPersonClass = false
@@ -120,11 +120,11 @@ class VisualRecognitionUIImageTests: XCTestCase {
         visualRecognition.detectFaces(image: obama) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let faceImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -126,11 +126,11 @@ class VisualRecognitionTests: XCTestCase {
 
         visualRecognition.listClassifiers { response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiers = response?.result?.classifiers else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             for classifier in classifiers where classifier.classifierID == self.classifierID {
@@ -149,11 +149,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.listClassifiers(verbose: true) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiers = response?.result?.classifiers else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             for classifier in classifiers where classifier.classifierID == self.classifierID {
@@ -178,11 +178,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.createClassifier(name: name, positiveExamples: classes) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifier = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertEqual(classifier.name, name)
@@ -201,11 +201,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.listClassifiers(verbose: true) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiers = response?.result?.classifiers else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             for classifier in classifiers where classifier.classifierID == classifierIDToDelete {
@@ -225,7 +225,7 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.deleteClassifier(classifierID: classifierIDToDelete) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -245,11 +245,11 @@ class VisualRecognitionTests: XCTestCase {
             negativeExamples: examplesTrucks) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let classifier = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 XCTAssertEqual(classifier.name, name)
@@ -269,11 +269,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.listClassifiers(verbose: true) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiers = response?.result?.classifiers else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             for classifier in classifiers where classifier.classifierID == newClassifierID {
@@ -293,7 +293,7 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.deleteClassifier(classifierID: newClassifierID) {
             _, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
             }
             expectation3.fulfill()
         }
@@ -306,11 +306,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.getClassifier(classifierID: classifierID) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifier = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             XCTAssertNotNil(classifier.classes)
@@ -334,11 +334,11 @@ class VisualRecognitionTests: XCTestCase {
             negativeExamples: examplesBaseball) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let classifier = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 XCTAssertEqual(classifier.name, name)
@@ -365,11 +365,11 @@ class VisualRecognitionTests: XCTestCase {
             visualRecognition.getClassifier(classifierID: newClassifierID) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let classifier = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 if classifier.status == "ready" {
@@ -393,11 +393,11 @@ class VisualRecognitionTests: XCTestCase {
             positiveExamples: [trucks]) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let classifier = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 XCTAssertEqual(classifier.name, name)
@@ -414,11 +414,11 @@ class VisualRecognitionTests: XCTestCase {
             visualRecognition.getClassifier(classifierID: newClassifierID) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let classifier = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 if classifier.status == "ready" {
@@ -453,11 +453,11 @@ class VisualRecognitionTests: XCTestCase {
             negativeExamples: examplesTrucks) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let classifier = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 XCTAssertEqual(classifier.name, name)
@@ -484,11 +484,11 @@ class VisualRecognitionTests: XCTestCase {
             visualRecognition.getClassifier(classifierID: newClassifierID) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let classifier = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 if classifier.status == "ready" {
@@ -511,11 +511,11 @@ class VisualRecognitionTests: XCTestCase {
             negativeExamples: examplesBaseball) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let classifier = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 XCTAssertEqual(classifier.name, name)
@@ -532,11 +532,11 @@ class VisualRecognitionTests: XCTestCase {
             visualRecognition.getClassifier(classifierID: newClassifierID) {
                 response, error in
                 if let error = error {
-                    XCTFail("Unexpected error response from service: \(error)")
+                    XCTFail(unexpectedErrorMessage(error))
                     return
                 }
                 guard let classifier = response?.result else {
-                    XCTFail("Missing result value")
+                    XCTFail(missingResultMessage)
                     return
                 }
                 if classifier.status == "ready" {
@@ -563,11 +563,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.classify(url: obamaURL) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -623,11 +623,11 @@ class VisualRecognitionTests: XCTestCase {
         {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -676,11 +676,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.classify(url: carURL, classifierIDs: [classifierID]) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -722,11 +722,11 @@ class VisualRecognitionTests: XCTestCase {
         {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -762,11 +762,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.classify(url: carURL, classifierIDs: ["default", classifierID]) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -825,11 +825,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.classify(imagesFile: car) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
             var containsPersonClass = false
@@ -882,11 +882,11 @@ class VisualRecognitionTests: XCTestCase {
         {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -934,11 +934,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.classify(imagesFile: car, classifierIDs: [classifierID]) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -980,11 +980,11 @@ class VisualRecognitionTests: XCTestCase {
         {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1023,11 +1023,11 @@ class VisualRecognitionTests: XCTestCase {
         {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1090,11 +1090,11 @@ class VisualRecognitionTests: XCTestCase {
         {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1152,11 +1152,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.detectFaces(url: obamaURL) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let faceImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1202,11 +1202,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.detectFaces(imagesFile: obama) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let faceImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1252,11 +1252,11 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.detectFaces(imagesFile: faces) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let faceImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -1312,7 +1312,7 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.getClassifier(classifierID: "foo-bar-baz") {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()        }
         waitForExpectations()
@@ -1327,7 +1327,7 @@ class VisualRecognitionTests: XCTestCase {
         {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -1342,7 +1342,7 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.classify(url: invalidImageURL) {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -1357,7 +1357,7 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.detectFaces(url: invalidImageURL) {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }
@@ -1371,7 +1371,7 @@ class VisualRecognitionTests: XCTestCase {
         visualRecognition.getClassifier(classifierID: "foo-bar-baz")  {
             _, error in
             if error == nil {
-                XCTFail("Expected error response")
+                XCTFail(missingErrorMessage)
             }
             expectation.fulfill()
         }

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionWithIAMTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionWithIAMTests.swift
@@ -27,11 +27,6 @@ class VisualRecognitionWithIAMTests: XCTestCase {
     private let trumpURL = "https://watson-developer-cloud.github.io/doc-tutorial-downloads/" +
         "visual-recognition/prez-trump.jpg"
 
-    /** Fail false negatives. */
-    func failWithError(error: Error) {
-        XCTFail("Positive test failed with error: \(error)")
-    }
-
     /** Get access token using IAM API Key. */
     func getTokenInfo(apiKey: String, refreshToken: String? = nil) -> [String: Any]? {
         // swiftlint:disable force_unwrapping
@@ -87,11 +82,11 @@ class VisualRecognitionWithIAMTests: XCTestCase {
         visualRecognition.classify(url: ginniURL) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -142,11 +137,11 @@ class VisualRecognitionWithIAMTests: XCTestCase {
         visualRecognition.classify(url: obamaURL) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 
@@ -189,11 +184,11 @@ class VisualRecognitionWithIAMTests: XCTestCase {
         visualRecognition.classify(url: trumpURL) {
             response, error in
             if let error = error {
-                XCTFail("Unexpected error response from service: \(error)")
+                XCTFail(unexpectedErrorMessage(error))
                 return
             }
             guard let classifiedImages = response?.result else {
-                XCTFail("Missing result value")
+                XCTFail(missingResultMessage)
                 return
             }
 

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -548,6 +548,18 @@
 		7AC97FC71D8308690046124C /* opus_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A9EC81B1D79B76100507725 /* opus_types.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7AC97FC81D830A020046124C /* os_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A9EC8151D79B76100507725 /* os_types.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7AF31BFB1D7A414D0040D944 /* SpeechToTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAA9A251CEE3026002C9564 /* SpeechToTextTests.swift */; };
+		929A23E621123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23E721123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23E821123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23E921123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23EA21123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23EB21123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23EC21123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23ED21123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23EE21123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23EF21123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23F021123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
+		929A23F121123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
 		CA151FA2200EE23F00DBA44F /* carz.zip in Resources */ = {isa = PBXBuildFile; fileRef = CA151FA0200EE0CF00DBA44F /* carz.zip */; };
 		CA28815D20CB07D600FC992C /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6C7B3C1D8C960300CD97FA /* Credentials.swift */; };
 		CA28817620CB095100FC992C /* glossary.tmx in Resources */ = {isa = PBXBuildFile; fileRef = CA28817420CB095100FC992C /* glossary.tmx */; };
@@ -1223,6 +1235,7 @@
 		7AB445241D3E647A00E8748A /* ConversationV1.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ConversationV1.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AB4452D1D3E647A00E8748A /* ConversationV1Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ConversationV1Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AD240081DC7B4360002FEB5 /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
+		929A23E521123E7E00E4C78A /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestUtilities.swift; path = Tests/TestUtilities.swift; sourceTree = "<group>"; };
 		B1F21DF21CE2461800393146 /* SentenceAnalysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentenceAnalysis.swift; sourceTree = "<group>"; };
 		B1F21DF31CE2461800393146 /* ToneAnalysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneAnalysis.swift; sourceTree = "<group>"; };
 		B1F21DF41CE2461800393146 /* ToneCategory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneCategory.swift; sourceTree = "<group>"; };
@@ -1926,6 +1939,7 @@
 				7AAAF5B41CEEA62C00B74848 /* TextToSpeechV1.h */,
 				7AAAF5B51CEEA62C00B74848 /* ToneAnalyzerV3.h */,
 				7AAAF5B61CEEA62C00B74848 /* VisualRecognitionV3.h */,
+				929A23E521123E7E00E4C78A /* TestUtilities.swift */,
 			);
 			name = SupportingFiles;
 			sourceTree = "<group>";
@@ -3727,6 +3741,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23EC21123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				1241DFCE1E38111500B8B33E /* Credentials.swift in Sources */,
 				1241DFCB1E38106F00B8B33E /* NaturalLanguageUnderstandingV1Tests.swift in Sources */,
 			);
@@ -3769,6 +3784,7 @@
 			files = (
 				7A6C7B4A1D8C960300CD97FA /* Credentials.swift in Sources */,
 				12819F6F1DCA8753004E8467 /* TextToSpeechPlaybackTests.swift in Sources */,
+				929A23EF21123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				124C2E231D19E30700D9F602 /* TextToSpeechTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3882,6 +3898,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23E821123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				12F800581DF71AD9006851D6 /* Credentials.swift in Sources */,
 				12F8005E1DF71BED006851D6 /* DiscoveryTests.swift in Sources */,
 			);
@@ -3961,6 +3978,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23E621123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				6800FCD62056D8EC0078788A /* AssistantTests.swift in Sources */,
 				6877FAA02056D4F500383B25 /* Credentials.swift in Sources */,
 			);
@@ -3995,6 +4013,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23ED21123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				7A6711A81DD0F1CC0070CA9D /* Credentials.swift in Sources */,
 				7A6711A71DD0F1970070CA9D /* PersonalityInsightsTests.swift in Sources */,
 			);
@@ -4058,6 +4077,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23F121123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				CAF9A5CB20B75B3A006C86B7 /* VisualRecognitionWithIAMTests.swift in Sources */,
 				7A6C7B4D1D8C960300CD97FA /* Credentials.swift in Sources */,
 				68FBD8221FE0873900878788 /* VisualRecognition+CoreMLTests.swift in Sources */,
@@ -4098,6 +4118,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23F021123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				7A6C7B4B1D8C960300CD97FA /* Credentials.swift in Sources */,
 				7AAAF4151CEE9D5A00B74848 /* ToneAnalyzerTests.swift in Sources */,
 			);
@@ -4167,6 +4188,7 @@
 			files = (
 				7A6C7B491D8C960300CD97FA /* Credentials.swift in Sources */,
 				7AF31BFB1D7A414D0040D944 /* SpeechToTextTests.swift in Sources */,
+				929A23EE21123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				68BB78F92089A97E00173438 /* SpeechToTextRecognizeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4199,6 +4221,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23EB21123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				7A6C7B451D8C960300CD97FA /* Credentials.swift in Sources */,
 				7AAAF4CA1CEEA11E00B74848 /* NaturalLanguageClassifierTests.swift in Sources */,
 			);
@@ -4234,6 +4257,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23E921123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				7A6C7B441D8C960300CD97FA /* Credentials.swift in Sources */,
 				7AAAF4FC1CEEA17C00B74848 /* LanguageTranslatorTests.swift in Sources */,
 			);
@@ -4313,6 +4337,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23E721123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				7A6C7B401D8C960300CD97FA /* Credentials.swift in Sources */,
 				7AB445441D3E658200E8748A /* ConversationTests.swift in Sources */,
 			);
@@ -4348,6 +4373,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				929A23EA21123E7E00E4C78A /* TestUtilities.swift in Sources */,
 				CA28815D20CB07D600FC992C /* Credentials.swift in Sources */,
 				CA28817720CB095100FC992C /* LanguageTranslatorTests.swift in Sources */,
 			);


### PR DESCRIPTION
The main purpose of these changes is to take common XCTFail() messages and turn them into reusable constants or functions. I created a new file called `TestUtilities.swift` that we can use to hold code that is shared across multiple test suites. `Discovery`, `STT`, and `TTS` also have some failure messages unique to their tests.

I also made updates to the `Assistant` and `Tone Analyzer` tests for the new strategy we're using to decide how and when to fail tests (checking for an error, checking for `response?.result`, etc).