### PR TITLE
Add support for acoustic customizations to STT recognizeUsingWebSocket

### DIFF
--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -78,6 +78,10 @@ extension SpeechToText {
      - parameter customizationID: The GUID of a custom language model that is to be used with the
        request. The base language model of the specified custom language model must match the
        model specified with the `model` parameter. By default, no custom model is used.
+     - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model
+       that is to be used with the recognition request. The base model of the specified custom
+       acoustic model must match the model specified with the `model` parameter. By default, no
+       custom acoustic model is used.
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed whenever an error occurs.
@@ -89,6 +93,7 @@ extension SpeechToText {
         settings: RecognitionSettings,
         model: String? = nil,
         customizationID: String? = nil,
+        acousticCustomizationID: String? = nil,
         learningOptOut: Bool? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
@@ -99,6 +104,7 @@ extension SpeechToText {
             authMethod: authMethod,
             model: model,
             customizationID: customizationID,
+            acousticCustomizationID: acousticCustomizationID,
             learningOptOut: learningOptOut
         )
 
@@ -144,6 +150,10 @@ extension SpeechToText {
      - parameter customizationID: The GUID of a custom language model that is to be used with the
        request. The base language model of the specified custom language model must match the
        model specified with the `model` parameter. By default, no custom model is used.
+     - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model
+       that is to be used with the recognition request. The base model of the specified custom
+       acoustic model must match the model specified with the `model` parameter. By default, no
+       custom acoustic model is used.
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
      - parameter compress: Should microphone audio be compressed to Opus format?
        (Opus compression reduces latency and bandwidth.)
@@ -156,6 +166,7 @@ extension SpeechToText {
         settings: RecognitionSettings,
         model: String? = nil,
         customizationID: String? = nil,
+        acousticCustomizationID: String? = nil,
         learningOptOut: Bool? = nil,
         compress: Bool = true,
         headers: [String: String]? = nil,
@@ -194,6 +205,7 @@ extension SpeechToText {
             password: basicAuth.password,
             model: model,
             customizationID: customizationID,
+            acousticCustomizationID: acousticCustomizationID,
             learningOptOut: learningOptOut
         )
 

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -79,6 +79,7 @@ extension SpeechToText {
        request. The base language model of the specified custom language model must match the
        model specified with the `model` parameter. By default, no custom model is used.
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
+     - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed whenever an error occurs.
      - parameter success: A function executed with all transcription results whenever
        a final or interim transcription is received.
@@ -89,6 +90,7 @@ extension SpeechToText {
         model: String? = nil,
         customizationID: String? = nil,
         learningOptOut: Bool? = nil,
+        headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (SpeechRecognitionResults) -> Void)
     {
@@ -107,6 +109,9 @@ extension SpeechToText {
 
         // set headers
         session.defaultHeaders = defaultHeaders
+        if let headers = headers {
+            session.defaultHeaders.merge(headers) { (_, new) in new }
+        }
 
         // set callbacks
         session.onResults = success
@@ -142,6 +147,7 @@ extension SpeechToText {
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
      - parameter compress: Should microphone audio be compressed to Opus format?
        (Opus compression reduces latency and bandwidth.)
+     - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed whenever an error occurs.
      - parameter success: A function executed with all transcription results whenever
        a final or interim transcription is received.
@@ -152,6 +158,7 @@ extension SpeechToText {
         customizationID: String? = nil,
         learningOptOut: Bool? = nil,
         compress: Bool = true,
+        headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (SpeechRecognitionResults) -> Void)
     {
@@ -197,6 +204,9 @@ extension SpeechToText {
 
         // set headers
         session.defaultHeaders = defaultHeaders
+        if let headers = headers {
+            session.defaultHeaders.merge(headers) { (_, new) in new }
+        }
 
         // set callbacks
         session.onResults = success

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -50,7 +50,7 @@ extension SpeechToText {
     {
         do {
             let data = try Data(contentsOf: audio)
-            recognize(
+            recognizeUsingWebSocket(
                 audio: data,
                 settings: settings,
                 model: model,

--- a/Source/SpeechToTextV1/WebSockets/RecognitionSettings.swift
+++ b/Source/SpeechToTextV1/WebSockets/RecognitionSettings.swift
@@ -33,6 +33,11 @@ public struct RecognitionSettings: Encodable {
     /// https://console.bluemix.net/docs/services/speech-to-text/input.html#formats
     public var contentType: String
 
+    /// If you specify a customization ID when you open the connection, you can use the customization
+    /// weight to tell the service how much weight to give to words from the custom language model
+    /// compared to those from the base model for the current request.
+    public var customizationWeight: Double?
+
     /// The number of seconds after which the connection is to time out due to inactivity.
     /// Use `-1` to set the timeout to infinity. The default is `30` seconds.
     public var inactivityTimeout: Int?
@@ -101,6 +106,7 @@ public struct RecognitionSettings: Encodable {
     private enum CodingKeys: String, CodingKey {
         case action = "action"
         case contentType = "content-type"
+        case customizationWeight = "customization_weight"
         case inactivityTimeout = "inactivity_timeout"
         case keywords = "keywords"
         case keywordsThreshold = "keywords_threshold"

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
@@ -86,6 +86,7 @@ public class SpeechToTextSession {
             url: websocketsURL,
             model: model,
             customizationID: customizationID,
+            acousticCustomizationID: acousticCustomizationID,
             learningOptOut: learningOptOut
         )!
         var socket = SpeechToTextSocket(
@@ -111,12 +112,19 @@ public class SpeechToTextSession {
     private let authMethod: AuthenticationMethod
     private let model: String?
     private let customizationID: String?
+    private let acousticCustomizationID: String?
     private let learningOptOut: Bool?
 
-    internal init(authMethod: AuthenticationMethod, model: String? = nil, customizationID: String? = nil, learningOptOut: Bool? = nil) {
+    internal init(authMethod: AuthenticationMethod,
+                  model: String? = nil,
+                  customizationID: String? = nil,
+                  acousticCustomizationID: String? = nil,
+                  learningOptOut: Bool? = nil)
+    {
         self.authMethod = authMethod
         self.model = model
         self.customizationID = customizationID
+        self.acousticCustomizationID = acousticCustomizationID
         self.learningOptOut = learningOptOut
 
         recorder = SpeechToTextRecorder()
@@ -138,11 +146,15 @@ public class SpeechToTextSession {
      - parameter customizationID: The GUID of a custom language model that is to be used with the
         request. The base language model of the specified custom language model must match the
         model specified with the `model` parameter. By default, no custom model is used.
+     - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model
+       that is to be used with the recognition request. The base model of the specified custom
+       acoustic model must match the model specified with the `model` parameter. By default, no
+       custom acoustic model is used.
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
      */
-    public convenience init(username: String, password: String, model: String? = nil, customizationID: String? = nil, learningOptOut: Bool? = nil) {
+    public convenience init(username: String, password: String, model: String? = nil, customizationID: String? = nil, acousticCustomizationID: String?, learningOptOut: Bool? = nil) {
         let authMethod = BasicAuthentication(username: username, password: password)
-        self.init(authMethod: authMethod, model: model, customizationID: customizationID, learningOptOut: learningOptOut)
+        self.init(authMethod: authMethod, model: model, customizationID: customizationID, acousticCustomizationID: acousticCustomizationID, learningOptOut: learningOptOut)
     }
 
     /**
@@ -155,11 +167,15 @@ public class SpeechToTextSession {
      - parameter customizationID: The GUID of a custom language model that is to be used with the
      request. The base language model of the specified custom language model must match the
      model specified with the `model` parameter. By default, no custom model is used.
+     - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model
+       that is to be used with the recognition request. The base model of the specified custom
+       acoustic model must match the model specified with the `model` parameter. By default, no
+       custom acoustic model is used.
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
      */
-    public convenience init(apiKey: String, iamUrl: String? = nil, model: String? = nil, customizationID: String? = nil, learningOptOut: Bool? = nil) {
+    public convenience init(apiKey: String, iamUrl: String? = nil, model: String? = nil, customizationID: String? = nil, acousticCustomizationID: String? = nil, learningOptOut: Bool? = nil) {
         let authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
-        self.init(authMethod: authMethod, model: model, customizationID: customizationID, learningOptOut: learningOptOut)
+        self.init(authMethod: authMethod, model: model, customizationID: customizationID, acousticCustomizationID: acousticCustomizationID, learningOptOut: learningOptOut)
     }
 
     /**

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
@@ -156,13 +156,16 @@ internal class SpeechToTextSocket: WebSocketDelegate {
         }
     }
 
-    internal static func buildURL(url: String, model: String?, customizationID: String?, learningOptOut: Bool?) -> URL? {
+    internal static func buildURL(url: String, model: String?, customizationID: String?, acousticCustomizationID: String?, learningOptOut: Bool?) -> URL? {
         var queryParameters = [URLQueryItem]()
         if let model = model {
             queryParameters.append(URLQueryItem(name: "model", value: model))
         }
         if let customizationID = customizationID {
             queryParameters.append(URLQueryItem(name: "customization_id", value: customizationID))
+        }
+        if let acousticCustomizationID = acousticCustomizationID {
+            queryParameters.append(URLQueryItem(name: "acoustic_customization_id", value: acousticCustomizationID))
         }
         if let learningOptOut = learningOptOut {
             let value = "\(learningOptOut)"

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -207,7 +207,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
             let audio = try Data(contentsOf: file)
 
             let settings = RecognitionSettings(contentType: format)
-            speechToText.recognize(audio: audio, settings: settings, failure: failWithError) { results in
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, failure: failWithError) { results in
                 self.validateSTTResults(results: results, settings: settings)
                 XCTAssertNotNil(results.results)
                 XCTAssertEqual(results.results!.count, 1)
@@ -263,7 +263,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
             settings.filterProfanity = false
             settings.smartFormatting = true
 
-            speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true, failure: failWithError) { results in
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true, failure: failWithError) { results in
                 self.validateSTTResults(results: results, settings: settings)
                 if results.results?.last?.finalResults == true {
                     let transcript = results.results!.last?.alternatives.last?.transcript
@@ -308,7 +308,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
         var settings = RecognitionSettings(contentType: format)
         settings.smartFormatting = true
 
-        speechToText.recognize(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true, failure: failWithError) { results in
+        speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true, failure: failWithError) { results in
             self.validateSTTResults(results: results, settings: settings)
             XCTAssertNotNil(results.results)
             if results.results!.last?.finalResults == true {
@@ -356,7 +356,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
             settings.filterProfanity = false
             settings.speakerLabels = true
 
-            speechToText.recognize(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true, failure: failWithError) { results in
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true, failure: failWithError) { results in
                 XCTAssertNotNil(results.speakerLabels)
                 if !expectationFulfilled && results.speakerLabels!.count > 0 {
                     self.validateSTTSpeakerLabels(speakerLabels: results.speakerLabels!)

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -332,6 +332,58 @@ class SpeechToTextRecognizeTests: XCTestCase {
         }
     }
 
+    func testRecognizeWithCustomAcousticModel() {
+        let filename = "SpeechSample"
+        let withExtension = "wav"
+        let format = "audio/wav"
+        let baseModelName = "en-US_BroadbandModel"
+
+        // find a suitable acoustic model
+        var customizationID: String!
+        let expectation1 = self.expectation(description: "listAcousticModels")
+        speechToText.listAcousticModels(language: "en-US", failure: failWithError) { results in
+            let acousticModel = results.customizations.first(where: { model in
+                model.baseModelName == baseModelName && model.status == AcousticModel.Status.available.rawValue
+            })
+            customizationID = acousticModel?.customizationID
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: timeout)
+
+        // If the create request failed, skip the rest of the test.
+        guard customizationID != nil else {
+            XCTFail("No suitable acoustic model is available for test")
+            return
+        }
+
+        let expectation = self.expectation(description: "Recognize with custom language model")
+        let bundle = Bundle(for: type(of: self))
+        guard let file = bundle.url(forResource: filename, withExtension: withExtension) else {
+            XCTFail("Unable to locate \(filename).\(withExtension).")
+            return
+        }
+
+        do {
+            let audio = try Data(contentsOf: file)
+
+            let settings = RecognitionSettings(contentType: format)
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: baseModelName, acousticCustomizationID: customizationID, failure: failWithError) { results in
+                self.validateSTTResults(results: results, settings: settings)
+                XCTAssertNotNil(results.results)
+                XCTAssertEqual(results.results!.count, 1)
+                XCTAssert(results.results!.last?.finalResults == true)
+                let transcript = results.results!.last?.alternatives.last?.transcript
+                XCTAssertNotNil(transcript)
+                XCTAssertGreaterThan(transcript!.count, 0)
+                expectation.fulfill()
+            }
+            wait(for: [expectation], timeout: timeout)
+        } catch {
+            XCTFail("Unable to read \(filename).\(withExtension).")
+            return
+        }
+    }
+
      // MARK: - Transcribe Data with Smart Formatting
 
     func testTranscribeStockAnnouncementCustomWAV() {


### PR DESCRIPTION
This PR adds support for acoustic customizations to the STT `recognizeUsingWebSocket` method.

I've also added a `headers` parameter to this method to allow custom headers to be applied to the recognize operation, fixed some warning messages for use of deprecated methods, and added a test for recognize using a custom language model.