### PR TITLE
Fix RestKit sdkVersion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
 branches:
   only:
     - master
+    - develop
 env:
   global:
     - IOS_SDK="iphonesimulator"

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "daltoniam/Starscream" ~> 3.0
-github "watson-developer-cloud/restkit" ~> 1.0
+github "watson-developer-cloud/restkit" ~> 1.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "daltoniam/Starscream" ~> 3.0
-github "watson-developer-cloud/restkit" ~> 1.1
+github "watson-developer-cloud/restkit" ~> 1.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "daltoniam/Starscream" "3.0.5"
-github "watson-developer-cloud/restkit" "1.0.0"
+github "watson-developer-cloud/restkit" "1.1.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "daltoniam/Starscream" "3.0.5"
-github "watson-developer-cloud/restkit" "1.1.0"
+github "watson-developer-cloud/restkit" "1.2.0"

--- a/IBMWatsonAssistantV1.podspec
+++ b/IBMWatsonAssistantV1.podspec
@@ -18,6 +18,6 @@ natural-language input and uses machine learning to respond to customers in a wa
   
   s.source_files          = 'Source/AssistantV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
   
 end

--- a/IBMWatsonAssistantV1.podspec
+++ b/IBMWatsonAssistantV1.podspec
@@ -16,7 +16,9 @@ natural-language input and uses machine learning to respond to customers in a wa
   s.ios.deployment_target = '8.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
-  s.source_files          = 'Source/AssistantV1/**/*.swift'
+  s.source_files          = 'Source/AssistantV1/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift'
+  s.exclude_files         = 'Source/AssistantV1/Shared.swift'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
   

--- a/IBMWatsonAssistantV1.podspec
+++ b/IBMWatsonAssistantV1.podspec
@@ -14,7 +14,7 @@ natural-language input and uses machine learning to respond to customers in a wa
 
   s.module_name           = 'Assistant'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
   s.source_files          = 'Source/AssistantV1/**/*.swift'
 

--- a/IBMWatsonAssistantV1.podspec
+++ b/IBMWatsonAssistantV1.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonAssistantV1'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Assistant service'
   s.description           = <<-DESC
 With the IBM Watson™ Assistant service, you can build a solution that understands 

--- a/IBMWatsonAssistantV1.podspec
+++ b/IBMWatsonAssistantV1.podspec
@@ -18,6 +18,6 @@ natural-language input and uses machine learning to respond to customers in a wa
   
   s.source_files          = 'Source/AssistantV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
   
 end

--- a/IBMWatsonConversationV1.podspec
+++ b/IBMWatsonConversationV1.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonConversationV1'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Conversation service'
   s.description           = <<-DESC
 With the IBM Watson™ Assistant service, you can build a solution that understands 

--- a/IBMWatsonConversationV1.podspec
+++ b/IBMWatsonConversationV1.podspec
@@ -15,7 +15,7 @@ IMPORTANT: The Conversation service is deprecated, and will be removed in the ne
 
   s.module_name           = 'Conversation'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
   s.source_files          = 'Source/ConversationV1/**/*.swift'
 

--- a/IBMWatsonConversationV1.podspec
+++ b/IBMWatsonConversationV1.podspec
@@ -17,7 +17,9 @@ IMPORTANT: The Conversation service is deprecated, and will be removed in the ne
   s.ios.deployment_target = '8.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
-  s.source_files          = 'Source/ConversationV1/**/*.swift'
+  s.source_files          = 'Source/ConversationV1/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift'
+  s.exclude_files         = 'Source/ConversationV1/Shared.swift'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
   

--- a/IBMWatsonConversationV1.podspec
+++ b/IBMWatsonConversationV1.podspec
@@ -19,6 +19,6 @@ IMPORTANT: The Conversation service is deprecated, and will be removed in the ne
   
   s.source_files          = 'Source/ConversationV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
   
 end

--- a/IBMWatsonConversationV1.podspec
+++ b/IBMWatsonConversationV1.podspec
@@ -19,6 +19,6 @@ IMPORTANT: The Conversation service is deprecated, and will be removed in the ne
   
   s.source_files          = 'Source/ConversationV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
   
 end

--- a/IBMWatsonDiscoveryV1.podspec
+++ b/IBMWatsonDiscoveryV1.podspec
@@ -19,6 +19,6 @@ as well as public and third-party data.
   
   s.source_files          = 'Source/DiscoveryV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
   
 end

--- a/IBMWatsonDiscoveryV1.podspec
+++ b/IBMWatsonDiscoveryV1.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonDiscoveryV1'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Discovery service'
   s.description           = <<-DESC
 IBM Watson™ Discovery makes it possible to rapidly build cognitive, cloud-based exploration applications 

--- a/IBMWatsonDiscoveryV1.podspec
+++ b/IBMWatsonDiscoveryV1.podspec
@@ -19,6 +19,6 @@ as well as public and third-party data.
   
   s.source_files          = 'Source/DiscoveryV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
   
 end

--- a/IBMWatsonDiscoveryV1.podspec
+++ b/IBMWatsonDiscoveryV1.podspec
@@ -15,7 +15,7 @@ as well as public and third-party data.
 
   s.module_name           = 'Discovery'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
   s.source_files          = 'Source/DiscoveryV1/**/*.swift'
 

--- a/IBMWatsonDiscoveryV1.podspec
+++ b/IBMWatsonDiscoveryV1.podspec
@@ -17,7 +17,9 @@ as well as public and third-party data.
   s.ios.deployment_target = '8.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
-  s.source_files          = 'Source/DiscoveryV1/**/*.swift'
+  s.source_files          = 'Source/DiscoveryV1/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift'
+  s.exclude_files         = 'Source/DiscoveryV1/Shared.swift'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
   

--- a/IBMWatsonLanguageTranslatorV3.podspec
+++ b/IBMWatsonLanguageTranslatorV3.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonLanguageTranslatorV3'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Language Translator service'
   s.description           = <<-DESC
 IBM Watson™ Language Translator can identify the language of text and translate it into different languages programmatically.

--- a/IBMWatsonLanguageTranslatorV3.podspec
+++ b/IBMWatsonLanguageTranslatorV3.podspec
@@ -17,6 +17,6 @@ IBM Watson™ Language Translator can identify the language of text and translat
 
   s.source_files          = 'Source/LanguageTranslatorV3/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
 
 end

--- a/IBMWatsonLanguageTranslatorV3.podspec
+++ b/IBMWatsonLanguageTranslatorV3.podspec
@@ -17,6 +17,6 @@ IBM Watson™ Language Translator can identify the language of text and translat
 
   s.source_files          = 'Source/LanguageTranslatorV3/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
 
 end

--- a/IBMWatsonLanguageTranslatorV3.podspec
+++ b/IBMWatsonLanguageTranslatorV3.podspec
@@ -15,7 +15,9 @@ IBM Watson™ Language Translator can identify the language of text and translat
   s.ios.deployment_target = '8.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
-  s.source_files          = 'Source/LanguageTranslatorV3/**/*.swift'
+  s.source_files          = 'Source/LanguageTranslatorV3/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift'
+  s.exclude_files         = 'Source/LanguageTranslatorV3/Shared.swift'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
 

--- a/IBMWatsonLanguageTranslatorV3.podspec
+++ b/IBMWatsonLanguageTranslatorV3.podspec
@@ -13,7 +13,7 @@ IBM Watson™ Language Translator can identify the language of text and translat
 
   s.module_name           = 'LanguageTranslator'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/LanguageTranslatorV3/**/*.swift'
 

--- a/IBMWatsonNaturalLanguageClassifierV1.podspec
+++ b/IBMWatsonNaturalLanguageClassifierV1.podspec
@@ -15,7 +15,7 @@ return information for texts that it is not trained on.
 
   s.module_name           = 'NaturalLanguageClassifier'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
   s.source_files          = 'Source/NaturalLanguageClassifierV1/**/*.swift'
 

--- a/IBMWatsonNaturalLanguageClassifierV1.podspec
+++ b/IBMWatsonNaturalLanguageClassifierV1.podspec
@@ -17,7 +17,9 @@ return information for texts that it is not trained on.
   s.ios.deployment_target = '8.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
-  s.source_files          = 'Source/NaturalLanguageClassifierV1/**/*.swift'
+  s.source_files          = 'Source/NaturalLanguageClassifierV1/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift'
+  s.exclude_files         = 'Source/NaturalLanguageClassifierV1/Shared.swift'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
   

--- a/IBMWatsonNaturalLanguageClassifierV1.podspec
+++ b/IBMWatsonNaturalLanguageClassifierV1.podspec
@@ -19,6 +19,6 @@ return information for texts that it is not trained on.
   
   s.source_files          = 'Source/NaturalLanguageClassifierV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
   
 end

--- a/IBMWatsonNaturalLanguageClassifierV1.podspec
+++ b/IBMWatsonNaturalLanguageClassifierV1.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonNaturalLanguageClassifierV1'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Natural Language Classifier service'
   s.description           = <<-DESC
 Natural Language Classifier can help your application understand the language of short texts and 

--- a/IBMWatsonNaturalLanguageClassifierV1.podspec
+++ b/IBMWatsonNaturalLanguageClassifierV1.podspec
@@ -19,6 +19,6 @@ return information for texts that it is not trained on.
   
   s.source_files          = 'Source/NaturalLanguageClassifierV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
   
 end

--- a/IBMWatsonNaturalLanguageUnderstandingV1.podspec
+++ b/IBMWatsonNaturalLanguageUnderstandingV1.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonNaturalLanguageUnderstandingV1'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Natural Language Understanding service'
   s.description           = <<-DESC
 IBM Watson™ Natural Language Understanding can analyze semantic features of text input, 

--- a/IBMWatsonNaturalLanguageUnderstandingV1.podspec
+++ b/IBMWatsonNaturalLanguageUnderstandingV1.podspec
@@ -18,6 +18,6 @@ including categories, concepts, emotion, entities, keywords, metadata, relations
   
   s.source_files          = 'Source/NaturalLanguageUnderstandingV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
   
 end

--- a/IBMWatsonNaturalLanguageUnderstandingV1.podspec
+++ b/IBMWatsonNaturalLanguageUnderstandingV1.podspec
@@ -18,6 +18,6 @@ including categories, concepts, emotion, entities, keywords, metadata, relations
   
   s.source_files          = 'Source/NaturalLanguageUnderstandingV1/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
   
 end

--- a/IBMWatsonNaturalLanguageUnderstandingV1.podspec
+++ b/IBMWatsonNaturalLanguageUnderstandingV1.podspec
@@ -14,7 +14,7 @@ including categories, concepts, emotion, entities, keywords, metadata, relations
 
   s.module_name           = 'NaturalLanguageUnderstanding'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
   s.source_files          = 'Source/NaturalLanguageUnderstandingV1/**/*.swift'
 

--- a/IBMWatsonNaturalLanguageUnderstandingV1.podspec
+++ b/IBMWatsonNaturalLanguageUnderstandingV1.podspec
@@ -16,7 +16,9 @@ including categories, concepts, emotion, entities, keywords, metadata, relations
   s.ios.deployment_target = '8.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
-  s.source_files          = 'Source/NaturalLanguageUnderstandingV1/**/*.swift'
+  s.source_files          = 'Source/NaturalLanguageUnderstandingV1/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift'
+  s.exclude_files         = 'Source/NaturalLanguageUnderstandingV1/Shared.swift'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
   

--- a/IBMWatsonPersonalityInsightsV3.podspec
+++ b/IBMWatsonPersonalityInsightsV3.podspec
@@ -18,6 +18,6 @@ from digital communications such as email, text messages, tweets, and forum post
 
   s.source_files          = 'Source/PersonalityInsightsV3/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
   
 end

--- a/IBMWatsonPersonalityInsightsV3.podspec
+++ b/IBMWatsonPersonalityInsightsV3.podspec
@@ -14,7 +14,7 @@ from digital communications such as email, text messages, tweets, and forum post
 
   s.module_name           = 'PersonalityInsights'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/PersonalityInsightsV3/**/*.swift'
 

--- a/IBMWatsonPersonalityInsightsV3.podspec
+++ b/IBMWatsonPersonalityInsightsV3.podspec
@@ -16,7 +16,9 @@ from digital communications such as email, text messages, tweets, and forum post
   s.ios.deployment_target = '8.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
-  s.source_files          = 'Source/PersonalityInsightsV3/**/*.swift'
+  s.source_files          = 'Source/PersonalityInsightsV3/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift'
+  s.exclude_files         = 'Source/PersonalityInsightsV3/Shared.swift'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
   

--- a/IBMWatsonPersonalityInsightsV3.podspec
+++ b/IBMWatsonPersonalityInsightsV3.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonPersonalityInsightsV3'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Personality Insights service'
   s.description           = <<-DESC
 IBM Watson™ Personality Insights uses linguistic analytics to infer individuals' intrinsic personality characteristics 

--- a/IBMWatsonPersonalityInsightsV3.podspec
+++ b/IBMWatsonPersonalityInsightsV3.podspec
@@ -18,6 +18,6 @@ from digital communications such as email, text messages, tweets, and forum post
 
   s.source_files          = 'Source/PersonalityInsightsV3/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
   
 end

--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -23,7 +23,7 @@ of the audio signal. It continuously returns and retroactively updates a transcr
                             '**/opus_header.h',
                             '**/opus_header.c'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
   s.dependency              'Starscream', '~> 3.0'
   s.vendored_libraries    = 'Source/SupportingFiles/Dependencies/Libraries/*.a'
 

--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -15,7 +15,7 @@ of the audio signal. It continuously returns and retroactively updates a transcr
 
   s.module_name           = 'SpeechToText'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
   s.source_files          = 'Source/SpeechToTextV1/**/*.swift',
                             'Source/SupportingFiles/Dependencies/Source/**/*'

--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonSpeechToTextV1'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Speech to Text service'
   s.description           = <<-DESC
 The IBM® Speech to Text leverages machine intelligence to transcribe the human voice accurately. 

--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -18,8 +18,10 @@ of the audio signal. It continuously returns and retroactively updates a transcr
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
   s.source_files          = 'Source/SpeechToTextV1/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift',
                             'Source/SupportingFiles/Dependencies/Source/**/*'
-  s.exclude_files         = '**/config_types.h',
+  s.exclude_files         = 'Source/SpeechToTextV1/Shared.swift',
+                            '**/config_types.h',
                             '**/opus_header.h',
                             '**/opus_header.c'
 

--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -23,7 +23,7 @@ of the audio signal. It continuously returns and retroactively updates a transcr
                             '**/opus_header.h',
                             '**/opus_header.c'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
   s.dependency              'Starscream', '~> 3.0'
   s.vendored_libraries    = 'Source/SupportingFiles/Dependencies/Libraries/*.a'
 

--- a/IBMWatsonTextToSpeechV1.podspec
+++ b/IBMWatsonTextToSpeechV1.podspec
@@ -17,8 +17,10 @@ The service streams the results back to the client with minimal delay.
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/TextToSpeechV1/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift',
                             'Source/SupportingFiles/Dependencies/Source/**/*'
-  s.exclude_files         = '**/config_types.h'
+  s.exclude_files         = 'Source/TextToSpeechV1/Shared.swift',
+                            '**/config_types.h'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
   s.vendored_libraries    = 'Source/SupportingFiles/Dependencies/Libraries/*.a'

--- a/IBMWatsonTextToSpeechV1.podspec
+++ b/IBMWatsonTextToSpeechV1.podspec
@@ -20,7 +20,7 @@ The service streams the results back to the client with minimal delay.
                             'Source/SupportingFiles/Dependencies/Source/**/*'
   s.exclude_files         = '**/config_types.h'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
   s.vendored_libraries    = 'Source/SupportingFiles/Dependencies/Libraries/*.a'
 
   # The renaming of libogg.a and libopus.a is done to avoid duplicate library name errors

--- a/IBMWatsonTextToSpeechV1.podspec
+++ b/IBMWatsonTextToSpeechV1.podspec
@@ -14,7 +14,7 @@ The service streams the results back to the client with minimal delay.
 
   s.module_name           = 'TextToSpeech'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/TextToSpeechV1/**/*.swift',
                             'Source/SupportingFiles/Dependencies/Source/**/*'

--- a/IBMWatsonTextToSpeechV1.podspec
+++ b/IBMWatsonTextToSpeechV1.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonTextToSpeechV1'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Text to Speech service'
   s.description           = <<-DESC
 IBM® Text to Speech uses IBM's speech-synthesis capabilities to convert written text to natural-sounding speech. 

--- a/IBMWatsonTextToSpeechV1.podspec
+++ b/IBMWatsonTextToSpeechV1.podspec
@@ -20,7 +20,7 @@ The service streams the results back to the client with minimal delay.
                             'Source/SupportingFiles/Dependencies/Source/**/*'
   s.exclude_files         = '**/config_types.h'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
   s.vendored_libraries    = 'Source/SupportingFiles/Dependencies/Libraries/*.a'
 
   # The renaming of libogg.a and libopus.a is done to avoid duplicate library name errors

--- a/IBMWatsonToneAnalyzerV3.podspec
+++ b/IBMWatsonToneAnalyzerV3.podspec
@@ -14,7 +14,7 @@ The service can analyze tone at both the document and sentence levels.
 
   s.module_name           = 'ToneAnalyzer'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
   s.source_files          = 'Source/ToneAnalyzerV3/**/*.swift'
 

--- a/IBMWatsonToneAnalyzerV3.podspec
+++ b/IBMWatsonToneAnalyzerV3.podspec
@@ -18,6 +18,6 @@ The service can analyze tone at both the document and sentence levels.
   
   s.source_files          = 'Source/ToneAnalyzerV3/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
 
 end

--- a/IBMWatsonToneAnalyzerV3.podspec
+++ b/IBMWatsonToneAnalyzerV3.podspec
@@ -18,6 +18,6 @@ The service can analyze tone at both the document and sentence levels.
   
   s.source_files          = 'Source/ToneAnalyzerV3/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
 
 end

--- a/IBMWatsonToneAnalyzerV3.podspec
+++ b/IBMWatsonToneAnalyzerV3.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   
   s.name                  = 'IBMWatsonToneAnalyzerV3'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Tone Analyzer service'
   s.description           = <<-DESC
 IBM Watson™ Tone Analyzer uses linguistic analysis to detect emotional and language tones in written text. 

--- a/IBMWatsonToneAnalyzerV3.podspec
+++ b/IBMWatsonToneAnalyzerV3.podspec
@@ -16,7 +16,9 @@ The service can analyze tone at both the document and sentence levels.
   s.ios.deployment_target = '8.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
-  s.source_files          = 'Source/ToneAnalyzerV3/**/*.swift'
+  s.source_files          = 'Source/ToneAnalyzerV3/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift'
+  s.exclude_files         = 'Source/ToneAnalyzerV3/Shared.swift'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
 

--- a/IBMWatsonVisualRecognitionV3.podspec
+++ b/IBMWatsonVisualRecognitionV3.podspec
@@ -18,6 +18,6 @@ scenes, objects, faces, and other content. The response includes keywords that p
   
   s.source_files          = 'Source/VisualRecognitionV3/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.0.0'
+  s.dependency              'IBMWatsonRestKit', '1.1.0'
   
 end

--- a/IBMWatsonVisualRecognitionV3.podspec
+++ b/IBMWatsonVisualRecognitionV3.podspec
@@ -14,7 +14,7 @@ scenes, objects, faces, and other content. The response includes keywords that p
 
   s.module_name           = 'VisualRecognition'
   s.ios.deployment_target = '8.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version.to_s}" }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
   s.source_files          = 'Source/VisualRecognitionV3/**/*.swift'
 

--- a/IBMWatsonVisualRecognitionV3.podspec
+++ b/IBMWatsonVisualRecognitionV3.podspec
@@ -18,6 +18,6 @@ scenes, objects, faces, and other content. The response includes keywords that p
   
   s.source_files          = 'Source/VisualRecognitionV3/**/*.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.1.0'
+  s.dependency              'IBMWatsonRestKit', '1.2.0'
   
 end

--- a/IBMWatsonVisualRecognitionV3.podspec
+++ b/IBMWatsonVisualRecognitionV3.podspec
@@ -16,7 +16,9 @@ scenes, objects, faces, and other content. The response includes keywords that p
   s.ios.deployment_target = '8.0'
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
   
-  s.source_files          = 'Source/VisualRecognitionV3/**/*.swift'
+  s.source_files          = 'Source/VisualRecognitionV3/**/*.swift',
+                            'Source/SupportingFiles/Shared.swift'
+  s.exclude_files         = 'Source/VisualRecognitionV3/Shared.swift'
 
   s.dependency              'IBMWatsonRestKit', '1.2.0'
   

--- a/IBMWatsonVisualRecognitionV3.podspec
+++ b/IBMWatsonVisualRecognitionV3.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                  = 'IBMWatsonVisualRecognitionV3'
-  s.version               = '0.33.0'
+  s.version               = '0.33.1'
   s.summary               = 'Client framework for the IBM Watson Visual Recognition service'
   s.description           = <<-DESC
 IBM Watson™ Visual Recognition uses deep learning algorithms to analyze images for 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/watson-developer-cloud/restkit.git",
         "state": {
           "branch": null,
-          "revision": "b5d50558c7e981a3022302e1baa52670075a8f64",
-          "version": "1.0.0"
+          "revision": "80b5c2a71394061c3916d3eae571084301470f92",
+          "version": "1.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         .library(name: "VisualRecognitionV3", targets: ["VisualRecognitionV3"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/watson-developer-cloud/restkit.git", from: "1.0.0")
+        .package(url: "https://github.com/watson-developer-cloud/restkit.git", from: "1.2.0")
     ],
     targets: [
         .target(name: "AssistantV1", dependencies: ["RestKit"]),

--- a/README.md
+++ b/README.md
@@ -77,17 +77,17 @@ If your project does not yet have a Podfile, use the `pod init` command in the r
 use_frameworks!
 
 target 'MyApp' do
-    pod 'IBMWatsonAssistantV1', '~> 0.33.0'
-    pod 'IBMWatsonConversationV1', '~> 0.33.0'
-    pod 'IBMWatsonDiscoveryV1', '~> 0.33.0'
-    pod 'IBMWatsonLanguageTranslatorV3', '~> 0.33.0'
-    pod 'IBMWatsonNaturalLanguageClassifierV1', '~> 0.33.0'
-    pod 'IBMWatsonNaturalLanguageUnderstandingV1', '~> 0.33.0'
-    pod 'IBMWatsonPersonalityInsightsV3', '~> 0.33.0'
-    pod 'IBMWatsonSpeechToTextV1', '~> 0.33.0'
-    pod 'IBMWatsonTextToSpeechV1', '~> 0.33.0'
-    pod 'IBMWatsonToneAnalyzerV3', '~> 0.33.0'
-    pod 'IBMWatsonVisualRecognitionV3', '~> 0.33.0'
+    pod 'IBMWatsonAssistantV1', '~> 0.33.1'
+    pod 'IBMWatsonConversationV1', '~> 0.33.1'
+    pod 'IBMWatsonDiscoveryV1', '~> 0.33.1'
+    pod 'IBMWatsonLanguageTranslatorV3', '~> 0.33.1'
+    pod 'IBMWatsonNaturalLanguageClassifierV1', '~> 0.33.1'
+    pod 'IBMWatsonNaturalLanguageUnderstandingV1', '~> 0.33.1'
+    pod 'IBMWatsonPersonalityInsightsV3', '~> 0.33.1'
+    pod 'IBMWatsonSpeechToTextV1', '~> 0.33.1'
+    pod 'IBMWatsonTextToSpeechV1', '~> 0.33.1'
+    pod 'IBMWatsonToneAnalyzerV3', '~> 0.33.1'
+    pod 'IBMWatsonVisualRecognitionV3', '~> 0.33.1'
 end
 ```
 
@@ -110,7 +110,7 @@ $ brew install carthage
 If your project does not have a Cartfile yet, use the `touch Cartfile` command in the root directory of your project. To install the IBM Watson Swift SDK using Carthage, add the following to your Cartfile. 
 
 ```
-github "watson-developer-cloud/swift-sdk" ~> 0.33.0
+github "watson-developer-cloud/swift-sdk" ~> 0.33.1
 ```
 
 Then run the following command to build the dependencies and frameworks:
@@ -131,7 +131,7 @@ Add the following to your `Package.swift` file to identify the IBM Watson Swift 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/watson-developer-cloud/swift-sdk", from: "0.33.0")
+    .package(url: "https://github.com/watson-developer-cloud/swift-sdk", from: "0.33.1")
 ]
 ```
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -45,6 +45,8 @@ done
 readmeVersion=$(grep -m 1 -o '~>.*[0-9.][0-9.][0-9]' README.md | cut -f 2 -d " ")
 sed -i '' -e "s/${readmeVersion}/${releaseVersion}/g" README.md
 
+# Update SDK version in Shared struct
+sed -i '' -e "s/let sdkVersion = \".*\"/let sdkVersion = \"${releaseVersion}\"/g" Source/SupportingFiles/Shared.swift
 
 # Commit the podspec updates, move the git tag, and push to Github
 git add *.podspec

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -28,16 +28,12 @@ declare -a allPods=(
 git fetch --tags
 releaseVersion=$(git describe --abbrev=0 --tags)
 
-# Update podspec versions and release to Cocoapods
+# Update podspec versions
 for podspec in "${allPods[@]}"
 do
 	podVersion=$(grep -o 'version.*=.*[0-9.][0-9.][0-9]' $podspec | cut -f 2 -d "'")
-	# Only release to Cocoapods if the pod's version is behind the latest git tag version
 	if [[ $releaseVersion > $podVersion ]]; then
 		sed -i '' -e "/s.version/s/${podVersion}/${releaseVersion}/g" $podspec
-		### DANGER ZONE ###
-		pod trunk push $podspec --allow-warnings
-		### DANGER ZONE ###
 	fi
 done
 
@@ -53,11 +49,20 @@ git add *.podspec
 git commit -m "Release SDK version ${releaseVersion}"
 ### DANGER ZONE ###
 git push
-### DANGER ZONE ###
 git tag -d $releaseVersion
 git push --delete origin $releaseVersion
 git tag $releaseVersion
 git push origin $releaseVersion
+### /DANGER ZONE ###
+
+# Release to Cocoapods
+for podspec in "${allPods[@]}"
+do
+  # This will only publish pods that have new versions
+  ### DANGER ZONE ###
+  pod trunk push $podspec --allow-warnings
+  ### /DANGER ZONE ###
+done
 
 # Builds WatsonDeveloperCloud.framework.zip, which needs to be uploaded to Github under the latest release
 sh ./Scripts/generate-binaries.sh

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -46,6 +46,8 @@ sed -i '' -e "s/let sdkVersion = \".*\"/let sdkVersion = \"${releaseVersion}\"/g
 
 # Commit the podspec updates, move the git tag, and push to Github
 git add *.podspec
+git add README.md
+git add Source/SupportingFiles/Shared.swift
 git commit -m "Release SDK version ${releaseVersion}"
 ### DANGER ZONE ###
 git push

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -46,6 +46,7 @@ public class Assistant {
     public init(username: String, password: String, version: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
         self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -57,8 +58,9 @@ public class Assistant {
      - parameter iamUrl: The URL for the IAM service.
      */
     public init(version: String, apiKey: String, iamUrl: String? = nil) {
-        self.version = version
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -69,8 +71,9 @@ public class Assistant {
      - parameter accessToken: An access token for the service.
      */
     public init(version: String, accessToken: String) {
-        self.version = version
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/AssistantV1/Shared.swift
+++ b/Source/AssistantV1/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -47,6 +47,7 @@ public class Conversation {
     public init(username: String, password: String, version: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
         self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -58,8 +59,9 @@ public class Conversation {
      - parameter iamUrl: The URL for the IAM service.
      */
     public init(version: String, apiKey: String, iamUrl: String? = nil) {
-        self.version = version
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -70,8 +72,9 @@ public class Conversation {
      - parameter accessToken: An access token for the service.
      */
     public init(version: String, accessToken: String) {
-        self.version = version
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/ConversationV1/Shared.swift
+++ b/Source/ConversationV1/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -48,6 +48,7 @@ public class Discovery {
     public init(username: String, password: String, version: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
         self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -59,8 +60,9 @@ public class Discovery {
      - parameter iamUrl: The URL for the IAM service.
      */
     public init(version: String, apiKey: String, iamUrl: String? = nil) {
-        self.version = version
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -71,8 +73,9 @@ public class Discovery {
      - parameter accessToken: An access token for the service.
      */
     public init(version: String, accessToken: String) {
-        self.version = version
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/DiscoveryV1/Shared.swift
+++ b/Source/DiscoveryV1/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -50,6 +50,7 @@ public class LanguageTranslator {
      */
     public init(username: String, password: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
+        Shared.configureRestRequest()
     }
 
     /**
@@ -60,6 +61,7 @@ public class LanguageTranslator {
      */
     public init(apiKey: String, iamUrl: String? = nil) {
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        Shared.configureRestRequest()
     }
 
     /**
@@ -69,6 +71,7 @@ public class LanguageTranslator {
      */
     public init(accessToken: String) {
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/LanguageTranslatorV2/Shared.swift
+++ b/Source/LanguageTranslatorV2/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -48,6 +48,7 @@ public class LanguageTranslator {
     public init(username: String, password: String, version: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
         self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -59,8 +60,9 @@ public class LanguageTranslator {
      - parameter iamUrl: The URL for the IAM service.
      */
     public init(version: String, apiKey: String, iamUrl: String? = nil) {
-        self.version = version
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -71,8 +73,9 @@ public class LanguageTranslator {
      - parameter accessToken: An access token for the service.
      */
     public init(version: String, accessToken: String) {
-        self.version = version
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/LanguageTranslatorV3/Shared.swift
+++ b/Source/LanguageTranslatorV3/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -43,6 +43,7 @@ public class NaturalLanguageClassifier {
      */
     public init(username: String, password: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
+        Shared.configureRestRequest()
     }
 
     /**
@@ -53,6 +54,7 @@ public class NaturalLanguageClassifier {
      */
     public init(apiKey: String, iamUrl: String? = nil) {
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        Shared.configureRestRequest()
     }
 
     /**
@@ -62,6 +64,7 @@ public class NaturalLanguageClassifier {
      */
     public init(accessToken: String) {
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/NaturalLanguageClassifierV1/Shared.swift
+++ b/Source/NaturalLanguageClassifierV1/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -51,6 +51,7 @@ public class NaturalLanguageUnderstanding {
     public init(username: String, password: String, version: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
         self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -62,8 +63,9 @@ public class NaturalLanguageUnderstanding {
      - parameter iamUrl: The URL for the IAM service.
      */
     public init(version: String, apiKey: String, iamUrl: String? = nil) {
-        self.version = version
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -74,8 +76,9 @@ public class NaturalLanguageUnderstanding {
      - parameter accessToken: An access token for the service.
      */
     public init(version: String, accessToken: String) {
-        self.version = version
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/NaturalLanguageUnderstandingV1/Shared.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -57,6 +57,7 @@ public class PersonalityInsights {
     public init(username: String, password: String, version: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
         self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -68,8 +69,9 @@ public class PersonalityInsights {
      - parameter iamUrl: The URL for the IAM service.
      */
     public init(version: String, apiKey: String, iamUrl: String? = nil) {
-        self.version = version
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -80,8 +82,9 @@ public class PersonalityInsights {
      - parameter accessToken: An access token for the service.
      */
     public init(version: String, accessToken: String) {
-        self.version = version
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/PersonalityInsightsV3/Shared.swift
+++ b/Source/PersonalityInsightsV3/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/SpeechToTextV1/Shared.swift
+++ b/Source/SpeechToTextV1/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -88,6 +88,7 @@ public class SpeechToText {
      */
     public init(username: String, password: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
+        Shared.configureRestRequest()
     }
 
     /**
@@ -98,6 +99,7 @@ public class SpeechToText {
      */
     public init(apiKey: String, iamUrl: String? = nil) {
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        Shared.configureRestRequest()
     }
 
     /**
@@ -107,6 +109,7 @@ public class SpeechToText {
      */
     public init(accessToken: String) {
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/SupportingFiles/Shared.swift
+++ b/Source/SupportingFiles/Shared.swift
@@ -1,10 +1,18 @@
-//
-//  Shared.swift
-//  WatsonDeveloperCloud
-//
-//  Created by Anthony Oliveri on 9/4/18.
-//  Copyright © 2018 Glenn R. Fisher. All rights reserved.
-//
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
 
 import Foundation
 import RestKit

--- a/Source/SupportingFiles/Shared.swift
+++ b/Source/SupportingFiles/Shared.swift
@@ -24,6 +24,30 @@ struct Shared {
     static let sdkVersion = "0.33.0"
 
     static func configureRestRequest() {
-        RestRequest.sdkVersion = sdkVersion
+        RestRequest.userAgent = {
+            let sdk = "watson-apis-swift-sdk"
+
+            let operatingSystem: String = {
+                #if os(iOS)
+                return "iOS"
+                #elseif os(watchOS)
+                return "watchOS"
+                #elseif os(tvOS)
+                return "tvOS"
+                #elseif os(macOS)
+                return "macOS"
+                #elseif os(Linux)
+                return "Linux"
+                #else
+                return "Unknown"
+                #endif
+            }()
+            let operatingSystemVersion: String = {
+                // swiftlint:disable:next identifier_name
+                let os = ProcessInfo.processInfo.operatingSystemVersion
+                return "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
+            }()
+            return "\(sdk)/\(sdkVersion) \(operatingSystem)/\(operatingSystemVersion)"
+        }()
     }
 }

--- a/Source/SupportingFiles/Shared.swift
+++ b/Source/SupportingFiles/Shared.swift
@@ -21,7 +21,7 @@ import RestKit
 /// Contains functionality and information common to all of the services
 struct Shared {
 
-    static let sdkVersion = "0.33.0"
+    static let sdkVersion = "0.33.1"
 
     static func configureRestRequest() {
         RestRequest.userAgent = {

--- a/Source/SupportingFiles/Shared.swift
+++ b/Source/SupportingFiles/Shared.swift
@@ -1,0 +1,21 @@
+//
+//  Shared.swift
+//  WatsonDeveloperCloud
+//
+//  Created by Anthony Oliveri on 9/4/18.
+//  Copyright © 2018 Glenn R. Fisher. All rights reserved.
+//
+
+import Foundation
+import RestKit
+
+
+/// Contains functionality and information common to all of the services
+struct Shared {
+
+    static let sdkVersion = "0.33.0"
+
+    static func configureRestRequest() {
+        RestRequest.sdkVersion = sdkVersion
+    }
+}

--- a/Source/TextToSpeechV1/Shared.swift
+++ b/Source/TextToSpeechV1/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -76,6 +76,7 @@ public class TextToSpeech {
      */
     public init(username: String, password: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
+        Shared.configureRestRequest()
     }
 
     /**
@@ -86,6 +87,7 @@ public class TextToSpeech {
      */
     public init(apiKey: String, iamUrl: String? = nil) {
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        Shared.configureRestRequest()
     }
 
     /**
@@ -95,6 +97,7 @@ public class TextToSpeech {
      */
     public init(accessToken: String) {
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/ToneAnalyzerV3/Shared.swift
+++ b/Source/ToneAnalyzerV3/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -51,6 +51,7 @@ public class ToneAnalyzer {
     public init(username: String, password: String, version: String) {
         self.authMethod = BasicAuthentication(username: username, password: password)
         self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -62,8 +63,9 @@ public class ToneAnalyzer {
      - parameter iamUrl: The URL for the IAM service.
      */
     public init(version: String, apiKey: String, iamUrl: String? = nil) {
-        self.version = version
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -74,8 +76,9 @@ public class ToneAnalyzer {
      - parameter accessToken: An access token for the service.
      */
     public init(version: String, accessToken: String) {
-        self.version = version
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/Source/VisualRecognitionV3/Shared.swift
+++ b/Source/VisualRecognitionV3/Shared.swift
@@ -1,0 +1,1 @@
+../SupportingFiles/Shared.swift

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -47,6 +47,7 @@ public class VisualRecognition {
         self.authMethod = APIKeyAuthentication(name: "api_key", key: apiKey, location: .query)
         self.version = version
         self.serviceURL = "https://gateway-a.watsonplatform.net/visual-recognition/api"
+        Shared.configureRestRequest()
     }
 
     /**
@@ -58,8 +59,9 @@ public class VisualRecognition {
      - parameter iamUrl: The URL for the IAM service.
      */
     public init(version: String, apiKey: String, iamUrl: String? = nil) {
-        self.version = version
         self.authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     /**
@@ -70,8 +72,9 @@ public class VisualRecognition {
      - parameter accessToken: An access token for the service.
      */
     public init(version: String, accessToken: String) {
-        self.version = version
         self.authMethod = IAMAccessToken(accessToken: accessToken)
+        self.version = version
+        Shared.configureRestRequest()
     }
 
     public func accessToken(_ newToken: String) {

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -497,6 +497,18 @@
 		929DB9AE212F7E6800356EDC /* RestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92048D8F212F7C16004FD822 /* RestKit.framework */; };
 		929DB9AF212F7E6D00356EDC /* RestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92048D8F212F7C16004FD822 /* RestKit.framework */; };
 		929DB9B0212F7E7100356EDC /* RestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92048D8F212F7C16004FD822 /* RestKit.framework */; };
+		92BF69AE213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69AF213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B0213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B1213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B2213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B3213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B4213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B5213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B6213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B7213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B8213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
+		92BF69B9213F129A00FE6325 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
 		CA151FA2200EE23F00DBA44F /* carz.zip in Resources */ = {isa = PBXBuildFile; fileRef = CA151FA0200EE0CF00DBA44F /* carz.zip */; };
 		CA28815D20CB07D600FC992C /* WatsonCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6C7B3C1D8C960300CD97FA /* WatsonCredentials.swift */; };
 		CA28817620CB095100FC992C /* glossary.tmx in Resources */ = {isa = PBXBuildFile; fileRef = CA28817420CB095100FC992C /* glossary.tmx */; };
@@ -1186,6 +1198,7 @@
 		928204C42124BC1F0013315B /* MetricAggregation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricAggregation.swift; sourceTree = "<group>"; };
 		928204C52124BC200013315B /* MetricTokenAggregation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricTokenAggregation.swift; sourceTree = "<group>"; };
 		928204C62124BC200013315B /* LogQueryResponseResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogQueryResponseResult.swift; sourceTree = "<group>"; };
+		92BF69AD213F129A00FE6325 /* Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Shared.swift; path = Source/SupportingFiles/Shared.swift; sourceTree = "<group>"; };
 		B1F21DF21CE2461800393146 /* SentenceAnalysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentenceAnalysis.swift; sourceTree = "<group>"; };
 		B1F21DF31CE2461800393146 /* ToneAnalysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneAnalysis.swift; sourceTree = "<group>"; };
 		B1F21DF41CE2461800393146 /* ToneCategory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneCategory.swift; sourceTree = "<group>"; };
@@ -1972,6 +1985,7 @@
 				7AAAF5B51CEEA62C00B74848 /* ToneAnalyzerV3.h */,
 				7AAAF5B61CEEA62C00B74848 /* VisualRecognitionV3.h */,
 				7A6C7B3C1D8C960300CD97FA /* WatsonCredentials.swift */,
+				92BF69AD213F129A00FE6325 /* Shared.swift */,
 			);
 			name = SupportingFiles;
 			sourceTree = "<group>";
@@ -3883,6 +3897,7 @@
 				683947E2202CF4F7007E3CF3 /* EntityMention.swift in Sources */,
 				683947DD202CF4F7007E3CF3 /* KeywordsOptions.swift in Sources */,
 				68394801202D141F007E3CF3 /* DeleteModelResults.swift in Sources */,
+				92BF69B4213F129A00FE6325 /* Shared.swift in Sources */,
 				683947F6202CF4F7007E3CF3 /* SentimentOptions.swift in Sources */,
 				683947F7202CF4F7007E3CF3 /* ConceptsOptions.swift in Sources */,
 				683947DC202CF4F7007E3CF3 /* Feed.swift in Sources */,
@@ -3932,6 +3947,7 @@
 				689A1711203CCDA9002CFC66 /* VoiceModels.swift in Sources */,
 				689A170B203CCDA9002CFC66 /* VoiceModel.swift in Sources */,
 				689A170D203CCDA9002CFC66 /* Words.swift in Sources */,
+				92BF69B7213F129A00FE6325 /* Shared.swift in Sources */,
 				682ED52F204F348100B17B06 /* WAVRepair.swift in Sources */,
 				689A1707203CCDA9002CFC66 /* Voices.swift in Sources */,
 				689A1709203CCDA9002CFC66 /* UpdateVoiceModel.swift in Sources */,
@@ -4006,6 +4022,7 @@
 				CADA959F20FCD66600B5BD84 /* CredentialDetails.swift in Sources */,
 				68AF8F522069690300D552E3 /* ListCollectionFieldsResponse.swift in Sources */,
 				928204D12124BC200013315B /* MetricAggregation.swift in Sources */,
+				92BF69B0213F129A00FE6325 /* Shared.swift in Sources */,
 				68AF8F782069690300D552E3 /* QueryEvidenceEntity.swift in Sources */,
 				68BF6A5A206999BB00B6BD30 /* QueryAggregation.swift in Sources */,
 				68D97E2B206989010087432F /* GenericQueryAggregation.swift in Sources */,
@@ -4147,6 +4164,7 @@
 				6800FC9F2056D8CB0078788A /* Assistant.swift in Sources */,
 				6800FCD52056D8D50078788A /* WorkspaceExport.swift in Sources */,
 				6800FCC72056D8D50078788A /* SystemResponse.swift in Sources */,
+				92BF69AE213F129A00FE6325 /* Shared.swift in Sources */,
 				6800FCB22056D8D50078788A /* EntityCollection.swift in Sources */,
 				CADA96992110ABB500B5BD84 /* DialogNodeOutputTextValuesElement.swift in Sources */,
 				6800FCA22056D8D50078788A /* Counterexample.swift in Sources */,
@@ -4186,6 +4204,7 @@
 				689A16AF203C9946002CFC66 /* ConsumptionPreferencesCategory.swift in Sources */,
 				689A16B2203C9946002CFC66 /* Content.swift in Sources */,
 				7A6711A01DD0F1790070CA9D /* PersonalityInsights.swift in Sources */,
+				92BF69B5213F129A00FE6325 /* Shared.swift in Sources */,
 				689A16B5203C9946002CFC66 /* Behavior.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4203,6 +4222,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92BF69B9213F129A00FE6325 /* Shared.swift in Sources */,
 				689A1693203C88C7002CFC66 /* ErrorInfo.swift in Sources */,
 				689A168F203C88C7002CFC66 /* FaceGender.swift in Sources */,
 				689A16A5203C9358002CFC66 /* VisualRecognition+UIImage.swift in Sources */,
@@ -4242,6 +4262,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92BF69B8213F129A00FE6325 /* Shared.swift in Sources */,
 				68D09C21200D61870087ADE5 /* ToneChatScore.swift in Sources */,
 				7AAAF4101CEE9D5300B74848 /* SentenceAnalysis.swift in Sources */,
 				CA35CD4720E3234900FACB2B /* ToneContent.swift in Sources */,
@@ -4313,6 +4334,7 @@
 				68F7FF00207D458900E84DBF /* AcousticModels.swift in Sources */,
 				68F7FF08207D458900E84DBF /* SpeechRecognitionAlternative.swift in Sources */,
 				68F7FF03207D458900E84DBF /* AcousticModel.swift in Sources */,
+				92BF69B6213F129A00FE6325 /* Shared.swift in Sources */,
 				6832BBEE2009CE8800BA50A8 /* SpeechToText+Recognize.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4331,6 +4353,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92BF69B3213F129A00FE6325 /* Shared.swift in Sources */,
 				68A6A9AF202A38490069585F /* ClassifierList.swift in Sources */,
 				68A6A9AD202A38490069585F /* ClassifyInput.swift in Sources */,
 				68438EA0208A987400FD7DB9 /* ClassifyCollectionInput.swift in Sources */,
@@ -4362,6 +4385,7 @@
 				68A6A9A5202A0EE90069585F /* IdentifiedLanguage.swift in Sources */,
 				68A6A9A4202A0EE90069585F /* IdentifiableLanguages.swift in Sources */,
 				68A6A99F202A0EE90069585F /* IdentifiableLanguage.swift in Sources */,
+				92BF69B1213F129A00FE6325 /* Shared.swift in Sources */,
 				68A6A9A2202A0EE90069585F /* IdentifiedLanguages.swift in Sources */,
 				68A6A9A3202A0EE90069585F /* Translation.swift in Sources */,
 				7AAAF4FA1CEEA17600B74848 /* LanguageTranslator.swift in Sources */,
@@ -4439,6 +4463,7 @@
 				CADA96B12110ABDE00B5BD84 /* WorkspaceSystemSettingsTooling.swift in Sources */,
 				6823CED31F8EA0F700A388EC /* ExampleCollection.swift in Sources */,
 				6823CEDA1F8EA0F700A388EC /* LogMessage.swift in Sources */,
+				92BF69AF213F129A00FE6325 /* Shared.swift in Sources */,
 				68C974AC200D52F6002DCFA3 /* CaptureGroup.swift in Sources */,
 				6823CEC61F8EA0F700A388EC /* CreateExample.swift in Sources */,
 				CADA96B42110ABDE00B5BD84 /* DialogNodeOutputModifiers.swift in Sources */,
@@ -4475,6 +4500,7 @@
 				CAD2686E20CAF919002BA2C4 /* LanguageTranslator.swift in Sources */,
 				CA28817A20CB099D00FC992C /* IdentifiableLanguage.swift in Sources */,
 				CA28817920CB099D00FC992C /* DeleteModelResult.swift in Sources */,
+				92BF69B2213F129A00FE6325 /* Shared.swift in Sources */,
 				CA28818220CB099D00FC992C /* IdentifiableLanguages.swift in Sources */,
 				CA28817F20CB099D00FC992C /* IdentifiedLanguage.swift in Sources */,
 				CA28818120CB099D00FC992C /* TranslateRequest.swift in Sources */,


### PR DESCRIPTION
Full context given here: https://github.com/watson-developer-cloud/restkit/pull/2

The `RestRequest` struct in the RestKit framework needs to know which version of the Swift SDK is being used. `RestRequest` was updated to have a new settable property to specify the SDK version. This PR updates all initializers for all services to set the value for the new `sdkVersion` property indirectly using the new `Shared` struct. The purpose of the `Shared` struct is to keep miscellaneous shared functionality that is used by some or all of the services.