### PR TITLE
Fix copyrights

### DIFF
--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionWithIAMTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionWithIAMTests.swift
@@ -3,7 +3,7 @@
 //  AssistantV1Tests
 //
 //  Created by Mike Kistler on 5/24/18.
-//  Copyright © 2018 Glenn R. Fisher. All rights reserved.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 
 import XCTest

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -3032,7 +3032,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0940;
 				LastUpgradeCheck = 0930;
-				ORGANIZATIONNAME = "Glenn R. Fisher";
+				ORGANIZATIONNAME = "IBM Corporation";
 				TargetAttributes = {
 					1241DFAD1E380F0A00B8B33E = {
 						CreatedOnToolsVersion = 8.2.1;


### PR DESCRIPTION
This PR fixes the copyright in `VisualRecognitionWithIAMTests` and updates the "Organization Name" for the project so that new files get a proper copyright inserted by Xcode.