### PR TITLE
Fix deserialization error in getCoreMlModel

### DIFF
--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -677,7 +677,7 @@ public class VisualRecognition {
         classifierID: String,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
-        success: @escaping (URL) -> Void)
+        success: @escaping (Data) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -707,8 +707,8 @@ public class VisualRecognition {
         )
 
         // execute REST request
-        request.responseObject {
-            (response: RestResponse<URL>) in
+        request.responseData {
+            (response: RestResponse<Data>) in
             switch response.result {
             case .success(let retval): success(retval)
             case .failure(let error): failure?(error)

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -135,7 +135,7 @@ class VisualRecognitionTests: XCTestCase {
         }
     }
 
-    // MARK: - Positive Tests
+    // MARK: - Classifiers CRUD
 
     /** Retrieve a list of user-trained classifiers. */
     func testListClassifiers() {
@@ -445,6 +445,19 @@ class VisualRecognitionTests: XCTestCase {
             }
         }
     }
+
+    /** Get the Core ML model for a trained classifier. */
+    func testGetCoreMlModel() {
+        let expectation = self.expectation(description: "Get the Core ML model for a trained classifier.")
+        visualRecognition.getCoreMlModel(classifierID: classifierID, failure: failWithError) {
+            coreMLModel in
+            XCTAssertNotNil(coreMLModel)
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+
+    // MARK: - Classify
 
     /** Classify an image by URL using the default classifier and all default parameters. */
     func testClassifyByURL1() {
@@ -953,6 +966,8 @@ class VisualRecognitionTests: XCTestCase {
         }
         waitForExpectations(timeout: 60)
     }
+
+    // MARK: - Detect faces
 
     /** Detect faces by URL. */
     func testDetectFacesByURL() {


### PR DESCRIPTION
This PR fixes the VR getCoreMlModel method to correctly handle the response data as a byte stream (the model) rather than a JSON object.  A test was included to recreate the original problem and also verify the fix.

The change to getCoreMlModel is new hand edit that must be done as part of the post generation changes. I've updated the Wiki to include this so that it doesn't get lost in future releases.

This was my first experience using `git cz`.  Hopefully I did it right but please check and let me know if changes are needed.