### PR TITLE
Release 0.36.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "daltoniam/Starscream" ~> 3.0
-github "watson-developer-cloud/restkit" ~> 1.2
+github "watson-developer-cloud/restkit" ~> 1.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "daltoniam/Starscream" "3.0.5"
-github "watson-developer-cloud/restkit" "1.2.0"
+github "daltoniam/Starscream" "3.0.6"
+github "watson-developer-cloud/restkit" "1.3.0"

--- a/IBMWatsonAssistantV1.podspec
+++ b/IBMWatsonAssistantV1.podspec
@@ -20,6 +20,6 @@ natural-language input and uses machine learning to respond to customers in a wa
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/AssistantV1/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   
 end

--- a/IBMWatsonAssistantV2.podspec
+++ b/IBMWatsonAssistantV2.podspec
@@ -20,6 +20,6 @@ natural-language input and uses machine learning to respond to customers in a wa
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/AssistantV2/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   
 end

--- a/IBMWatsonConversationV1.podspec
+++ b/IBMWatsonConversationV1.podspec
@@ -21,6 +21,6 @@ IMPORTANT: The Conversation service is deprecated, and will be removed in the ne
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/ConversationV1/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   
 end

--- a/IBMWatsonDiscoveryV1.podspec
+++ b/IBMWatsonDiscoveryV1.podspec
@@ -21,6 +21,6 @@ as well as public and third-party data.
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/DiscoveryV1/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   
 end

--- a/IBMWatsonLanguageTranslatorV3.podspec
+++ b/IBMWatsonLanguageTranslatorV3.podspec
@@ -19,6 +19,6 @@ IBM Watson™ Language Translator can identify the language of text and translat
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/LanguageTranslatorV3/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
 
 end

--- a/IBMWatsonNaturalLanguageClassifierV1.podspec
+++ b/IBMWatsonNaturalLanguageClassifierV1.podspec
@@ -21,6 +21,6 @@ return information for texts that it is not trained on.
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/NaturalLanguageClassifierV1/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   
 end

--- a/IBMWatsonNaturalLanguageUnderstandingV1.podspec
+++ b/IBMWatsonNaturalLanguageUnderstandingV1.podspec
@@ -20,6 +20,6 @@ including categories, concepts, emotion, entities, keywords, metadata, relations
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/NaturalLanguageUnderstandingV1/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   
 end

--- a/IBMWatsonPersonalityInsightsV3.podspec
+++ b/IBMWatsonPersonalityInsightsV3.podspec
@@ -20,6 +20,6 @@ from digital communications such as email, text messages, tweets, and forum post
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/PersonalityInsightsV3/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   
 end

--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -25,7 +25,7 @@ of the audio signal. It continuously returns and retroactively updates a transcr
                             '**/opus_header.h',
                             '**/opus_header.c'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   s.dependency              'Starscream', '~> 3.0'
   s.vendored_libraries    = 'Source/SupportingFiles/Dependencies/Libraries/*.a'
 

--- a/IBMWatsonTextToSpeechV1.podspec
+++ b/IBMWatsonTextToSpeechV1.podspec
@@ -22,7 +22,7 @@ The service streams the results back to the client with minimal delay.
   s.exclude_files         = 'Source/TextToSpeechV1/Shared.swift',
                             '**/config_types.h'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   s.vendored_libraries    = 'Source/SupportingFiles/Dependencies/Libraries/*.a'
 
   # The renaming of libogg.a and libopus.a is done to avoid duplicate library name errors

--- a/IBMWatsonToneAnalyzerV3.podspec
+++ b/IBMWatsonToneAnalyzerV3.podspec
@@ -20,6 +20,6 @@ The service can analyze tone at both the document and sentence levels.
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/ToneAnalyzerV3/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
 
 end

--- a/IBMWatsonVisualRecognitionV3.podspec
+++ b/IBMWatsonVisualRecognitionV3.podspec
@@ -20,6 +20,6 @@ scenes, objects, faces, and other content. The response includes keywords that p
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/VisualRecognitionV3/Shared.swift'
 
-  s.dependency              'IBMWatsonRestKit', '1.2.0'
+  s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
   
 end

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -89,7 +89,7 @@ public class Assistant {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/AssistantV1/Models/OutputData.swift
+++ b/Source/AssistantV1/Models/OutputData.swift
@@ -52,11 +52,6 @@ public struct OutputData: Codable {
      */
     public var nodesVisitedDetails: [DialogNodeVisitedDetails]?
 
-    /**
-     An array of objects describing any actions requested by the dialog node.
-     */
-    public var actions: [DialogNodeAction]?
-
     /// Additional properties associated with this model.
     public var additionalProperties: [String: JSON]
 
@@ -67,8 +62,7 @@ public struct OutputData: Codable {
         case generic = "generic"
         case nodesVisited = "nodes_visited"
         case nodesVisitedDetails = "nodes_visited_details"
-        case actions = "actions"
-        static let allValues = [logMessages, text, generic, nodesVisited, nodesVisitedDetails, actions]
+        static let allValues = [logMessages, text, generic, nodesVisited, nodesVisitedDetails]
     }
 
     /**
@@ -84,7 +78,6 @@ public struct OutputData: Codable {
      - parameter nodesVisitedDetails: An array of objects containing detailed diagnostic information about the nodes
        that were triggered during processing of the input message. Included only if **nodes_visited_details** is set to
        `true` in the message request.
-     - parameter actions: An array of objects describing any actions requested by the dialog node.
 
      - returns: An initialized `OutputData`.
     */
@@ -94,7 +87,6 @@ public struct OutputData: Codable {
         generic: [DialogRuntimeResponseGeneric]? = nil,
         nodesVisited: [String]? = nil,
         nodesVisitedDetails: [DialogNodeVisitedDetails]? = nil,
-        actions: [DialogNodeAction]? = nil,
         additionalProperties: [String: JSON] = [:]
     )
     {
@@ -103,7 +95,6 @@ public struct OutputData: Codable {
         self.generic = generic
         self.nodesVisited = nodesVisited
         self.nodesVisitedDetails = nodesVisitedDetails
-        self.actions = actions
         self.additionalProperties = additionalProperties
     }
 
@@ -114,7 +105,6 @@ public struct OutputData: Codable {
         generic = try container.decodeIfPresent([DialogRuntimeResponseGeneric].self, forKey: .generic)
         nodesVisited = try container.decodeIfPresent([String].self, forKey: .nodesVisited)
         nodesVisitedDetails = try container.decodeIfPresent([DialogNodeVisitedDetails].self, forKey: .nodesVisitedDetails)
-        actions = try container.decodeIfPresent([DialogNodeAction].self, forKey: .actions)
         let dynamicContainer = try decoder.container(keyedBy: DynamicKeys.self)
         additionalProperties = try dynamicContainer.decode([String: JSON].self, excluding: CodingKeys.allValues)
     }
@@ -126,7 +116,6 @@ public struct OutputData: Codable {
         try container.encodeIfPresent(generic, forKey: .generic)
         try container.encodeIfPresent(nodesVisited, forKey: .nodesVisited)
         try container.encodeIfPresent(nodesVisitedDetails, forKey: .nodesVisitedDetails)
-        try container.encodeIfPresent(actions, forKey: .actions)
         var dynamicContainer = encoder.container(keyedBy: DynamicKeys.self)
         try dynamicContainer.encodeIfPresent(additionalProperties)
     }

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -89,7 +89,7 @@ public class Assistant {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/AssistantV2/Models/MessageContextGlobalSystem.swift
+++ b/Source/AssistantV2/Models/MessageContextGlobalSystem.swift
@@ -27,16 +27,15 @@ public struct MessageContextGlobalSystem: Codable {
     public var timezone: String?
 
     /**
-     String value provided by the API client that should be unique per each distinct end user of the service powered by
-     Assistant.
+     A string value that identifies the user who is interacting with the assistant. The client must provide a unique
+     identifier for each individual end user who accesses the application. This user ID may be used for billing and
+     other purposes.
      */
     public var userID: String?
 
     /**
-     This property is normally set by the Assistant which sets this to 1 during the first conversation turn and then
-     increments it by 1 with every subsequent turn. A turn count equal to 0 (or > 0) informs the Assistant that this is
-     (or is not) the first turn in a conversation which influences the behavior of some skills. The Conversation skill
-     uses this to evaluate its `welcome` and `conversation_start` conditions.
+     A counter that is automatically incremented with each turn of the conversation. A value of 1 indicates that this is
+     the the first turn of a new conversation, which can affect the behavior of some skills.
      */
     public var turnCount: Int?
 
@@ -52,12 +51,12 @@ public struct MessageContextGlobalSystem: Codable {
 
      - parameter timezone: The user time zone. The assistant uses the time zone to correctly resolve relative time
        references.
-     - parameter userID: String value provided by the API client that should be unique per each distinct end user of
-       the service powered by Assistant.
-     - parameter turnCount: This property is normally set by the Assistant which sets this to 1 during the first
-       conversation turn and then increments it by 1 with every subsequent turn. A turn count equal to 0 (or > 0)
-       informs the Assistant that this is (or is not) the first turn in a conversation which influences the behavior of
-       some skills. The Conversation skill uses this to evaluate its `welcome` and `conversation_start` conditions.
+     - parameter userID: A string value that identifies the user who is interacting with the assistant. The client
+       must provide a unique identifier for each individual end user who accesses the application. This user ID may be
+       used for billing and other purposes.
+     - parameter turnCount: A counter that is automatically incremented with each turn of the conversation. A value
+       of 1 indicates that this is the the first turn of a new conversation, which can affect the behavior of some
+       skills.
 
      - returns: An initialized `MessageContextGlobalSystem`.
     */

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -22,7 +22,7 @@ import RestKit
  The IBM Watson&trade; Conversation service combines machine learning, natural language understanding, and integrated
  dialog tools to create conversation flows between your apps and your users.
  */
-@available(*, deprecated, message: "The IBM Watson Conversation service has been renamed to Assistant. Please use the `Assistant` class instead of `Conversation`. The `Conversation` class will be removed in a future release.")
+@available(*, deprecated, message: "The IBM Watson Conversation service has been renamed to Assistant. Please use the `Assistant` class from AssistantV1 or AssistantV2 instead of `Conversation`. `Conversation` will be removed in version 1.0.0.")
 public class Conversation {
 
     /// The base URL to use when contacting the service.

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -90,7 +90,7 @@ public class Conversation {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -2175,6 +2175,7 @@ public class Discovery {
         let returnFieldsJoined = returnFields?.joined(separator: ",")
         let sortJoined = sort?.joined(separator: ",")
         let passagesFieldsJoined = passagesFields?.joined(separator: ",")
+        let collectionIdsJoined = collectionIds.joined(separator: ",")
         let similarDocumentIdsJoined = similarDocumentIds?.joined(separator: ",")
         let similarFieldsJoined = similarFields?.joined(separator: ",")
         let queryLong = QueryLarge(
@@ -2193,7 +2194,7 @@ public class Discovery {
             passagesCharacters: passagesCharacters,
             deduplicate: deduplicate,
             deduplicateField: deduplicateField,
-            collectionIds: collectionIds,
+            collectionIds: collectionIdsJoined,
             similar: similar,
             similarDocumentIds: similarDocumentIdsJoined,
             similarFields: similarFieldsJoined,

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -821,21 +821,22 @@ public class Discovery {
         // construct body
         let multipartFormData = MultipartFormData()
         if let configuration = configuration {
-            guard let configurationData = configuration.data(using: .utf8) else {
-                failure?(RestError.serializationError)
-                return
+            if let configurationData = configuration.data(using: .utf8) {
+                multipartFormData.append(configurationData, withName: "configuration")
             }
-            multipartFormData.append(configurationData, withName: "configuration")
         }
         if let file = file {
-            multipartFormData.append(file, withName: "file")
-        }
-        if let metadata = metadata {
-            guard let metadataData = metadata.data(using: .utf8) else {
-                failure?(RestError.serializationError)
+            do {
+                try multipartFormData.append(file: file, withName: "file")
+            } catch {
+                failure?(error)
                 return
             }
-            multipartFormData.append(metadataData, withName: "metadata")
+        }
+        if let metadata = metadata {
+            if let metadataData = metadata.data(using: .utf8) {
+                multipartFormData.append(metadataData, withName: "metadata")
+            }
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)
@@ -1472,14 +1473,17 @@ public class Discovery {
         // construct body
         let multipartFormData = MultipartFormData()
         if let file = file {
-            multipartFormData.append(file, withName: "file")
-        }
-        if let metadata = metadata {
-            guard let metadataData = metadata.data(using: .utf8) else {
-                failure?(RestError.serializationError)
+            do {
+                try multipartFormData.append(file: file, withName: "file")
+            } catch {
+                failure?(error)
                 return
             }
-            multipartFormData.append(metadataData, withName: "metadata")
+        }
+        if let metadata = metadata {
+            if let metadataData = metadata.data(using: .utf8) {
+                multipartFormData.append(metadataData, withName: "metadata")
+            }
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)
@@ -1620,14 +1624,17 @@ public class Discovery {
         // construct body
         let multipartFormData = MultipartFormData()
         if let file = file {
-            multipartFormData.append(file, withName: "file")
-        }
-        if let metadata = metadata {
-            guard let metadataData = metadata.data(using: .utf8) else {
-                failure?(RestError.serializationError)
+            do {
+                try multipartFormData.append(file: file, withName: "file")
+            } catch {
+                failure?(error)
                 return
             }
-            multipartFormData.append(metadataData, withName: "metadata")
+        }
+        if let metadata = metadata {
+            if let metadataData = metadata.data(using: .utf8) {
+                multipartFormData.append(metadataData, withName: "metadata")
+            }
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -1943,9 +1943,8 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter collectionID: The ID of the collection.
-     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't
-       mention the query content. Filter searches are better for metadata type searches and when you are trying to get a
-       sense of concepts in the data set.
+     - parameter filter: A cacheable query that excludes documents that don't mention the query content. Filter
+       searches are better for metadata-type searches and for assessing the concepts in the data set.
      - parameter query: A query search returns all documents in your data set with full enrichments and full text, but
        with the most relevant documents listed first. Use a query search when you want to find the most relevant search
        results. You cannot use **natural_language_query** and **query** at the same time.
@@ -1953,35 +1952,33 @@ public class Discovery {
        data and natural language understanding. You cannot use **natural_language_query** and **query** at the same
        time.
      - parameter passages: A passages query that returns the most relevant passages from the results.
-     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact
-       answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and
-       time series. For a full list of possible aggregrations, see the Query reference.
+     - parameter aggregation: An aggregation search that returns an exact answer by combining query search with
+       filters. Useful for applications to build lists, tables, and time series. For a full list of possible
+       aggregations, see the Query reference.
      - parameter count: Number of results to return.
-     - parameter returnFields: A comma separated list of the portion of the document hierarchy to return.
+     - parameter returnFields: A comma-separated list of the portion of the document hierarchy to return.
      - parameter offset: The number of query results to skip at the beginning. For example, if the total number of
-       results that are returned is 10, and the offset is 8, it returns the last two results.
-     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort
+       results that are returned is 10 and the offset is 8, it returns the last two results.
+     - parameter sort: A comma-separated list of fields in the document to sort on. You can optionally specify a sort
        direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort
        direction if no prefix is specified.
-     - parameter highlight: When true a highlight field is returned for each result which contains the fields that
-       match the query with `<em></em>` tags around the matching query terms. Defaults to false.
+     - parameter highlight: When true, a highlight field is returned for each result which contains the fields which
+       match the query with `<em></em>` tags around the matching query terms.
      - parameter passagesFields: A comma-separated list of fields that passages are drawn from. If this parameter not
        specified, then all top-level fields are included.
      - parameter passagesCount: The maximum number of passages to return. The search returns fewer passages if the
-       requested total is not found. The default is `10`. The maximum is `100`.
-     - parameter passagesCharacters: The approximate number of characters that any one passage will have. The default
-       is `400`. The minimum is `50`. The maximum is `2000`.
+       requested total is not found.
+     - parameter passagesCharacters: The approximate number of characters that any one passage will have.
      - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the
        returned results. Duplicate comparison is limited to the current query only, **offset** is not considered. This
        parameter is currently Beta functionality.
      - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in
        the **similar.document_ids** parameter.
-     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar
-       documents.
-       **Note:** If the **natural_language_query** parameter is also specified, it will be used to expand the scope of
-       the document similarity search to include the natural language query. Other query parameters, such as **filter**
-       and **query** are subsequently applied and reduce the query scope.
-     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to
+     - parameter similarDocumentIds: A comma-separated list of document IDs to find similar documents.
+       **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
+       with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently
+       applied and reduce the scope.
+     - parameter similarFields: A comma-separated list of field names that are used as a basis for comparison to
        identify similar documents. If not specified, the entire document is used for comparison.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -2316,38 +2313,36 @@ public class Discovery {
 
      - parameter environmentID: The ID of the environment.
      - parameter collectionIds: A comma-separated list of collection IDs to be queried against.
-     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't
-       mention the query content. Filter searches are better for metadata type searches and when you are trying to get a
-       sense of concepts in the data set.
+     - parameter filter: A cacheable query that excludes documents that don't mention the query content. Filter
+       searches are better for metadata-type searches and for assessing the concepts in the data set.
      - parameter query: A query search returns all documents in your data set with full enrichments and full text, but
        with the most relevant documents listed first. Use a query search when you want to find the most relevant search
        results. You cannot use **natural_language_query** and **query** at the same time.
      - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training
        data and natural language understanding. You cannot use **natural_language_query** and **query** at the same
        time.
-     - parameter aggregation: An aggregation search uses combinations of filters and query search to return an exact
-       answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and
-       time series. For a full list of possible aggregrations, see the Query reference.
+     - parameter aggregation: An aggregation search that returns an exact answer by combining query search with
+       filters. Useful for applications to build lists, tables, and time series. For a full list of possible
+       aggregations, see the Query reference.
      - parameter count: Number of results to return.
-     - parameter returnFields: A comma separated list of the portion of the document hierarchy to return.
+     - parameter returnFields: A comma-separated list of the portion of the document hierarchy to return.
      - parameter offset: The number of query results to skip at the beginning. For example, if the total number of
-       results that are returned is 10, and the offset is 8, it returns the last two results.
-     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort
+       results that are returned is 10 and the offset is 8, it returns the last two results.
+     - parameter sort: A comma-separated list of fields in the document to sort on. You can optionally specify a sort
        direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort
        direction if no prefix is specified.
-     - parameter highlight: When true a highlight field is returned for each result which contains the fields that
-       match the query with `<em></em>` tags around the matching query terms. Defaults to false.
+     - parameter highlight: When true, a highlight field is returned for each result which contains the fields which
+       match the query with `<em></em>` tags around the matching query terms.
      - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from the
        returned results. Duplicate comparison is limited to the current query only, **offset** is not considered. This
        parameter is currently Beta functionality.
      - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified in
        the **similar.document_ids** parameter.
-     - parameter similarDocumentIds: A comma-separated list of document IDs that will be used to find similar
-       documents.
-       **Note:** If the **natural_language_query** parameter is also specified, it will be used to expand the scope of
-       the document similarity search to include the natural language query. Other query parameters, such as **filter**
-       and **query** are subsequently applied and reduce the query scope.
-     - parameter similarFields: A comma-separated list of field names that will be used as a basis for comparison to
+     - parameter similarDocumentIds: A comma-separated list of document IDs to find similar documents.
+       **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
+       with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently
+       applied and reduce the scope.
+     - parameter similarFields: A comma-separated list of field names that are used as a basis for comparison to
        identify similar documents. If not specified, the entire document is used for comparison.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -3329,16 +3324,15 @@ public class Discovery {
      Searches the query and event log to find query sessions that match the specified criteria. Searching the **logs**
      endpoint uses the standard Discovery query syntax for the parameters that are supported.
 
-     - parameter filter: A cacheable query that limits the documents returned to exclude any documents that don't
-       mention the query content. Filter searches are better for metadata type searches and when you are trying to get a
-       sense of concepts in the data set.
+     - parameter filter: A cacheable query that excludes documents that don't mention the query content. Filter
+       searches are better for metadata-type searches and for assessing the concepts in the data set.
      - parameter query: A query search returns all documents in your data set with full enrichments and full text, but
        with the most relevant documents listed first. Use a query search when you want to find the most relevant search
        results. You cannot use **natural_language_query** and **query** at the same time.
      - parameter count: Number of results to return.
      - parameter offset: The number of query results to skip at the beginning. For example, if the total number of
-       results that are returned is 10, and the offset is 8, it returns the last two results.
-     - parameter sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort
+       results that are returned is 10 and the offset is 8, it returns the last two results.
+     - parameter sort: A comma-separated list of fields in the document to sort on. You can optionally specify a sort
        direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort
        direction if no prefix is specified.
      - parameter headers: A dictionary of request headers to be sent with this request.

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -91,7 +91,7 @@ public class Discovery {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -118,7 +118,8 @@ public class Discovery {
 
      - parameter name: Name that identifies the environment.
      - parameter description: Description of the environment.
-     - parameter size: Size of the environment.
+     - parameter size: Size of the environment. In the Lite plan the default and only accepted value is `LT`, in all
+       other plans the default is `S`.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -284,6 +285,8 @@ public class Discovery {
      - parameter environmentID: The ID of the environment.
      - parameter name: Name that identifies the environment.
      - parameter description: Description of the environment.
+     - parameter size: Size that the environment should be increased to. Environment size cannot be modified when
+       using a Lite plan. Environment size can only increased and not decreased.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -292,12 +295,13 @@ public class Discovery {
         environmentID: String,
         name: String? = nil,
         description: String? = nil,
+        size: String? = nil,
         headers: [String: String]? = nil,
         failure: ((Error) -> Void)? = nil,
         success: @escaping (Environment) -> Void)
     {
         // construct body
-        let updateEnvironmentRequest = UpdateEnvironmentRequest(name: name, description: description)
+        let updateEnvironmentRequest = UpdateEnvironmentRequest(name: name, description: description, size: size)
         guard let body = try? JSONEncoder().encode(updateEnvironmentRequest) else {
             failure?(RestError.serializationError)
             return

--- a/Source/DiscoveryV1/Models/CreateEnvironmentRequest.swift
+++ b/Source/DiscoveryV1/Models/CreateEnvironmentRequest.swift
@@ -20,9 +20,11 @@ import Foundation
 internal struct CreateEnvironmentRequest: Encodable {
 
     /**
-     Size of the environment.
+     Size of the environment. In the Lite plan the default and only accepted value is `LT`, in all other plans the
+     default is `S`.
      */
     public enum Size: String {
+        case lt = "LT"
         case xs = "XS"
         case s = "S"
         case ms = "MS"
@@ -45,7 +47,8 @@ internal struct CreateEnvironmentRequest: Encodable {
     public var description: String?
 
     /**
-     Size of the environment.
+     Size of the environment. In the Lite plan the default and only accepted value is `LT`, in all other plans the
+     default is `S`.
      */
     public var size: String?
 
@@ -61,7 +64,8 @@ internal struct CreateEnvironmentRequest: Encodable {
 
      - parameter name: Name that identifies the environment.
      - parameter description: Description of the environment.
-     - parameter size: Size of the environment.
+     - parameter size: Size of the environment. In the Lite plan the default and only accepted value is `LT`, in all
+       other plans the default is `S`.
 
      - returns: An initialized `CreateEnvironmentRequest`.
     */

--- a/Source/DiscoveryV1/Models/Environment.swift
+++ b/Source/DiscoveryV1/Models/Environment.swift
@@ -22,12 +22,14 @@ import Foundation
 public struct Environment: Decodable {
 
     /**
-     Status of the environment.
+     Current status of the environment. `resizing` is displayed when a request to increase the environment size has been
+     made, but is still in the process of being completed.
      */
     public enum Status: String {
         case active = "active"
         case pending = "pending"
         case maintenance = "maintenance"
+        case resizing = "resizing"
     }
 
     /**
@@ -72,7 +74,8 @@ public struct Environment: Decodable {
     public var updated: String?
 
     /**
-     Status of the environment.
+     Current status of the environment. `resizing` is displayed when a request to increase the environment size has been
+     made, but is still in the process of being completed.
      */
     public var status: String?
 
@@ -82,14 +85,25 @@ public struct Environment: Decodable {
     public var readOnly: Bool?
 
     /**
-     Size of the environment.
+     Current size of the environment.
      */
     public var size: String?
+
+    /**
+     The new size requested for this environment. Only returned when the environment *status* is `resizing`.
+     *Note:* Querying and indexing can still be performed during an environment upsize.
+     */
+    public var requestedSize: String?
 
     /**
      Details about the resource usage and capacity of the environment.
      */
     public var indexCapacity: IndexCapacity?
+
+    /**
+     Information about Continuous Relevancy Training for this environment.
+     */
+    public var searchStatus: SearchStatus?
 
     // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
@@ -101,7 +115,9 @@ public struct Environment: Decodable {
         case status = "status"
         case readOnly = "read_only"
         case size = "size"
+        case requestedSize = "requested_size"
         case indexCapacity = "index_capacity"
+        case searchStatus = "search_status"
     }
 
 }

--- a/Source/DiscoveryV1/Models/Environment.swift
+++ b/Source/DiscoveryV1/Models/Environment.swift
@@ -31,9 +31,10 @@ public struct Environment: Decodable {
     }
 
     /**
-     Size of the environment.
+     Current size of the environment.
      */
     public enum Size: String {
+        case lt = "LT"
         case xs = "XS"
         case s = "S"
         case ms = "MS"

--- a/Source/DiscoveryV1/Models/QueryLarge.swift
+++ b/Source/DiscoveryV1/Models/QueryLarge.swift
@@ -1,0 +1,269 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/**
+ Object that describes a long query.
+ */
+public struct QueryLarge: Encodable {
+
+    /**
+     A cacheable query that excludes documents that don't mention the query content. Filter searches are better for
+     metadata-type searches and for assessing the concepts in the data set.
+     */
+    public var filter: String?
+
+    /**
+     A query search returns all documents in your data set with full enrichments and full text, but with the most
+     relevant documents listed first. Use a query search when you want to find the most relevant search results. You
+     cannot use **natural_language_query** and **query** at the same time.
+     */
+    public var query: String?
+
+    /**
+     A natural language query that returns relevant documents by utilizing training data and natural language
+     understanding. You cannot use **natural_language_query** and **query** at the same time.
+     */
+    public var naturalLanguageQuery: String?
+
+    /**
+     A passages query that returns the most relevant passages from the results.
+     */
+    public var passages: Bool?
+
+    /**
+     An aggregation search that returns an exact answer by combining query search with filters. Useful for applications
+     to build lists, tables, and time series. For a full list of possible aggregations, see the Query reference.
+     */
+    public var aggregation: String?
+
+    /**
+     Number of results to return.
+     */
+    public var count: Int?
+
+    /**
+     A comma-separated list of the portion of the document hierarchy to return.
+     */
+    public var returnFields: String?
+
+    /**
+     The number of query results to skip at the beginning. For example, if the total number of results that are returned
+     is 10 and the offset is 8, it returns the last two results.
+     */
+    public var offset: Int?
+
+    /**
+     A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by
+     prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no
+     prefix is specified. This parameter cannot be used in the same query as the **bias** parameter.
+     */
+    public var sort: String?
+
+    /**
+     When true, a highlight field is returned for each result which contains the fields which match the query with
+     `<em></em>` tags around the matching query terms.
+     */
+    public var highlight: Bool?
+
+    /**
+     A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all top-level
+     fields are included.
+     */
+    public var passagesFields: String?
+
+    /**
+     The maximum number of passages to return. The search returns fewer passages if the requested total is not found.
+     The default is `10`. The maximum is `100`.
+     */
+    public var passagesCount: Int?
+
+    /**
+     The approximate number of characters that any one passage will have.
+     */
+    public var passagesCharacters: Int?
+
+    /**
+     When `true` and used with a Watson Discovery News collection, duplicate results (based on the contents of the
+     **title** field) are removed. Duplicate comparison is limited to the current query only; **offset** is not
+     considered. This parameter is currently Beta functionality.
+     */
+    public var deduplicate: Bool?
+
+    /**
+     When specified, duplicate results based on the field specified are removed from the returned results. Duplicate
+     comparison is limited to the current query only, **offset** is not considered. This parameter is currently Beta
+     functionality.
+     */
+    public var deduplicateField: String?
+
+    /**
+     A comma-separated list of collection IDs to be queried against. Required when querying multiple collections,
+     invalid when performing a single collection query.
+     */
+    public var collectionIds: [String]?
+
+    /**
+     When `true`, results are returned based on their similarity to the document IDs specified in the
+     **similar.document_ids** parameter.
+     */
+    public var similar: Bool?
+
+    /**
+     A comma-separated list of document IDs to find similar documents.
+     **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
+     with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied
+     and reduce the scope.
+     */
+    public var similarDocumentIds: String?
+
+    /**
+     A comma-separated list of field names that are used as a basis for comparison to identify similar documents. If not
+     specified, the entire document is used for comparison.
+     */
+    public var similarFields: String?
+
+    /**
+     Field which the returned results will be biased against. The specified field must be either a **date** or
+     **number** format. When a **date** type field is specified returned results are biased towards field values closer
+     to the current date. When a **number** type field is specified, returned results are biased towards higher field
+     values. This parameter cannot be used in the same query as the **sort** parameter.
+     */
+    public var bias: String?
+
+    // Map each property name to the key that shall be used for encoding/decoding.
+    private enum CodingKeys: String, CodingKey {
+        case filter = "filter"
+        case query = "query"
+        case naturalLanguageQuery = "natural_language_query"
+        case passages = "passages"
+        case aggregation = "aggregation"
+        case count = "count"
+        case returnFields = "return"
+        case offset = "offset"
+        case sort = "sort"
+        case highlight = "highlight"
+        case passagesFields = "passages.fields"
+        case passagesCount = "passages.count"
+        case passagesCharacters = "passages.characters"
+        case deduplicate = "deduplicate"
+        case deduplicateField = "deduplicate.field"
+        case collectionIds = "collection_ids"
+        case similar = "similar"
+        case similarDocumentIds = "similar.document_ids"
+        case similarFields = "similar.fields"
+        case bias = "bias"
+    }
+
+    /**
+     Initialize a `QueryLarge` with member variables.
+
+     - parameter filter: A cacheable query that excludes documents that don't mention the query content. Filter
+       searches are better for metadata-type searches and for assessing the concepts in the data set.
+     - parameter query: A query search returns all documents in your data set with full enrichments and full text,
+       but with the most relevant documents listed first. Use a query search when you want to find the most relevant
+       search results. You cannot use **natural_language_query** and **query** at the same time.
+     - parameter naturalLanguageQuery: A natural language query that returns relevant documents by utilizing training
+       data and natural language understanding. You cannot use **natural_language_query** and **query** at the same
+       time.
+     - parameter passages: A passages query that returns the most relevant passages from the results.
+     - parameter aggregation: An aggregation search that returns an exact answer by combining query search with
+       filters. Useful for applications to build lists, tables, and time series. For a full list of possible
+       aggregations, see the Query reference.
+     - parameter count: Number of results to return.
+     - parameter returnFields: A comma-separated list of the portion of the document hierarchy to return.
+     - parameter offset: The number of query results to skip at the beginning. For example, if the total number of
+       results that are returned is 10 and the offset is 8, it returns the last two results.
+     - parameter sort: A comma-separated list of fields in the document to sort on. You can optionally specify a sort
+       direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort
+       direction if no prefix is specified. This parameter cannot be used in the same query as the **bias** parameter.
+     - parameter highlight: When true, a highlight field is returned for each result which contains the fields which
+       match the query with `<em></em>` tags around the matching query terms.
+     - parameter passagesFields: A comma-separated list of fields that passages are drawn from. If this parameter not
+       specified, then all top-level fields are included.
+     - parameter passagesCount: The maximum number of passages to return. The search returns fewer passages if the
+       requested total is not found. The default is `10`. The maximum is `100`.
+     - parameter passagesCharacters: The approximate number of characters that any one passage will have.
+     - parameter deduplicate: When `true` and used with a Watson Discovery News collection, duplicate results (based
+       on the contents of the **title** field) are removed. Duplicate comparison is limited to the current query only;
+       **offset** is not considered. This parameter is currently Beta functionality.
+     - parameter deduplicateField: When specified, duplicate results based on the field specified are removed from
+       the returned results. Duplicate comparison is limited to the current query only, **offset** is not considered.
+       This parameter is currently Beta functionality.
+     - parameter collectionIds: A comma-separated list of collection IDs to be queried against. Required when
+       querying multiple collections, invalid when performing a single collection query.
+     - parameter similar: When `true`, results are returned based on their similarity to the document IDs specified
+       in the **similar.document_ids** parameter.
+     - parameter similarDocumentIds: A comma-separated list of document IDs to find similar documents.
+       **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
+       with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently
+       applied and reduce the scope.
+     - parameter similarFields: A comma-separated list of field names that are used as a basis for comparison to
+       identify similar documents. If not specified, the entire document is used for comparison.
+     - parameter bias: Field which the returned results will be biased against. The specified field must be either a
+       **date** or **number** format. When a **date** type field is specified returned results are biased towards field
+       values closer to the current date. When a **number** type field is specified, returned results are biased towards
+       higher field values. This parameter cannot be used in the same query as the **sort** parameter.
+
+     - returns: An initialized `QueryLarge`.
+    */
+    public init(
+        filter: String? = nil,
+        query: String? = nil,
+        naturalLanguageQuery: String? = nil,
+        passages: Bool? = nil,
+        aggregation: String? = nil,
+        count: Int? = nil,
+        returnFields: String? = nil,
+        offset: Int? = nil,
+        sort: String? = nil,
+        highlight: Bool? = nil,
+        passagesFields: String? = nil,
+        passagesCount: Int? = nil,
+        passagesCharacters: Int? = nil,
+        deduplicate: Bool? = nil,
+        deduplicateField: String? = nil,
+        collectionIds: [String]? = nil,
+        similar: Bool? = nil,
+        similarDocumentIds: String? = nil,
+        similarFields: String? = nil,
+        bias: String? = nil
+    )
+    {
+        self.filter = filter
+        self.query = query
+        self.naturalLanguageQuery = naturalLanguageQuery
+        self.passages = passages
+        self.aggregation = aggregation
+        self.count = count
+        self.returnFields = returnFields
+        self.offset = offset
+        self.sort = sort
+        self.highlight = highlight
+        self.passagesFields = passagesFields
+        self.passagesCount = passagesCount
+        self.passagesCharacters = passagesCharacters
+        self.deduplicate = deduplicate
+        self.deduplicateField = deduplicateField
+        self.collectionIds = collectionIds
+        self.similar = similar
+        self.similarDocumentIds = similarDocumentIds
+        self.similarFields = similarFields
+        self.bias = bias
+    }
+
+}

--- a/Source/DiscoveryV1/Models/QueryLarge.swift
+++ b/Source/DiscoveryV1/Models/QueryLarge.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Object that describes a long query.
  */
-public struct QueryLarge: Encodable {
+internal struct QueryLarge: Encodable {
 
     /**
      A cacheable query that excludes documents that don't mention the query content. Filter searches are better for

--- a/Source/DiscoveryV1/Models/QueryLarge.swift
+++ b/Source/DiscoveryV1/Models/QueryLarge.swift
@@ -115,7 +115,7 @@ internal struct QueryLarge: Encodable {
      A comma-separated list of collection IDs to be queried against. Required when querying multiple collections,
      invalid when performing a single collection query.
      */
-    public var collectionIds: [String]?
+    public var collectionIds: String?
 
     /**
      When `true`, results are returned based on their similarity to the document IDs specified in the
@@ -237,7 +237,7 @@ internal struct QueryLarge: Encodable {
         passagesCharacters: Int? = nil,
         deduplicate: Bool? = nil,
         deduplicateField: String? = nil,
-        collectionIds: [String]? = nil,
+        collectionIds: String? = nil,
         similar: Bool? = nil,
         similarDocumentIds: String? = nil,
         similarFields: String? = nil,

--- a/Source/DiscoveryV1/Models/QueryRelations.swift
+++ b/Source/DiscoveryV1/Models/QueryRelations.swift
@@ -23,7 +23,8 @@ public struct QueryRelations: Encodable {
 
     /**
      The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the number of unique times
-     each entity is identified. The default is `score`.
+     each entity is identified. The default is `score`. This parameter cannot be used in the same query as the **bias**
+     parameter.
      */
     public enum Sort: String {
         case score = "score"
@@ -43,7 +44,8 @@ public struct QueryRelations: Encodable {
 
     /**
      The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the number of unique times
-     each entity is identified. The default is `score`.
+     each entity is identified. The default is `score`. This parameter cannot be used in the same query as the **bias**
+     parameter.
      */
     public var sort: String?
 
@@ -81,7 +83,8 @@ public struct QueryRelations: Encodable {
        For example, if you wanted to query the city of London in England your query would look for `London` with the
        context of `England`.
      - parameter sort: The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the
-       number of unique times each entity is identified. The default is `score`.
+       number of unique times each entity is identified. The default is `score`. This parameter cannot be used in the
+       same query as the **bias** parameter.
      - parameter filter: Filters to apply to the relationship query.
      - parameter count: The number of results to return. The default is `10`. The maximum is `1000`.
      - parameter evidenceCount: The number of evidence items to return for each result. The default is `0`. The

--- a/Source/DiscoveryV1/Models/SearchStatus.swift
+++ b/Source/DiscoveryV1/Models/SearchStatus.swift
@@ -1,0 +1,63 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+/**
+ Information about the Continuous Relevancy Training for this environment.
+ */
+public struct SearchStatus: Decodable {
+
+    /**
+     The current status of Continuous Relevancy Training for this environment.
+     */
+    public enum Status: String {
+        case noData = "NO_DATA"
+        case insufficentData = "INSUFFICENT_DATA"
+        case training = "TRAINING"
+        case trained = "TRAINED"
+        case notApplicable = "NOT_APPLICABLE"
+    }
+
+    /**
+     Current scope of the training. Always returned as `environment`.
+     */
+    public var scope: String?
+
+    /**
+     The current status of Continuous Relevancy Training for this environment.
+     */
+    public var status: String?
+
+    /**
+     Long description of the current Continuous Relevancy Training status.
+     */
+    public var statusDescription: String?
+
+    /**
+     The date stamp of the most recent completed training for this environment.
+     */
+    public var lastTrained: String?
+
+    // Map each property name to the key that shall be used for encoding/decoding.
+    private enum CodingKeys: String, CodingKey {
+        case scope = "scope"
+        case status = "status"
+        case statusDescription = "status_description"
+        case lastTrained = "last_trained"
+    }
+
+}

--- a/Source/DiscoveryV1/Models/UpdateEnvironmentRequest.swift
+++ b/Source/DiscoveryV1/Models/UpdateEnvironmentRequest.swift
@@ -20,6 +20,21 @@ import Foundation
 internal struct UpdateEnvironmentRequest: Encodable {
 
     /**
+     Size that the environment should be increased to. Environment size cannot be modified when using a Lite plan.
+     Environment size can only increased and not decreased.
+     */
+    public enum Size: String {
+        case s = "S"
+        case ms = "MS"
+        case m = "M"
+        case ml = "ML"
+        case l = "L"
+        case xl = "XL"
+        case xxl = "XXL"
+        case xxxl = "XXXL"
+    }
+
+    /**
      Name that identifies the environment.
      */
     public var name: String?
@@ -29,10 +44,17 @@ internal struct UpdateEnvironmentRequest: Encodable {
      */
     public var description: String?
 
+    /**
+     Size that the environment should be increased to. Environment size cannot be modified when using a Lite plan.
+     Environment size can only increased and not decreased.
+     */
+    public var size: String?
+
     // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case name = "name"
         case description = "description"
+        case size = "size"
     }
 
     /**
@@ -40,16 +62,20 @@ internal struct UpdateEnvironmentRequest: Encodable {
 
      - parameter name: Name that identifies the environment.
      - parameter description: Description of the environment.
+     - parameter size: Size that the environment should be increased to. Environment size cannot be modified when
+       using a Lite plan. Environment size can only increased and not decreased.
 
      - returns: An initialized `UpdateEnvironmentRequest`.
     */
     public init(
         name: String? = nil,
-        description: String? = nil
+        description: String? = nil,
+        size: String? = nil
     )
     {
         self.name = name
         self.description = description
+        self.size = size
     }
 
 }

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -352,13 +352,28 @@ public class LanguageTranslator {
         // construct body
         let multipartFormData = MultipartFormData()
         if let forcedGlossary = forcedGlossary {
-            multipartFormData.append(forcedGlossary, withName: "forced_glossary")
+            do {
+                try multipartFormData.append(file: forcedGlossary, withName: "forced_glossary")
+            } catch {
+                failure?(error)
+                return
+            }
         }
         if let parallelCorpus = parallelCorpus {
-            multipartFormData.append(parallelCorpus, withName: "parallel_corpus")
+            do {
+                try multipartFormData.append(file: parallelCorpus, withName: "parallel_corpus")
+            } catch {
+                failure?(error)
+                return
+            }
         }
         if let monolingualCorpus = monolingualCorpus {
-            multipartFormData.append(monolingualCorpus, withName: "monolingual_corpus")
+            do {
+                try multipartFormData.append(file: monolingualCorpus, withName: "monolingual_corpus")
+            } catch {
+                failure?(error)
+                return
+            }
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)

--- a/Source/LanguageTranslatorV2/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV2/LanguageTranslator.swift
@@ -87,7 +87,7 @@ public class LanguageTranslator {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -91,7 +91,7 @@ public class LanguageTranslator {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -379,10 +379,20 @@ public class LanguageTranslator {
         // construct body
         let multipartFormData = MultipartFormData()
         if let forcedGlossary = forcedGlossary {
-            multipartFormData.append(forcedGlossary, withName: "forced_glossary")
+            do {
+                try multipartFormData.append(file: forcedGlossary, withName: "forced_glossary")
+            } catch {
+                failure?(error)
+                return
+            }
         }
         if let parallelCorpus = parallelCorpus {
-            multipartFormData.append(parallelCorpus, withName: "parallel_corpus")
+            do {
+                try multipartFormData.append(file: parallelCorpus, withName: "parallel_corpus")
+            } catch {
+                failure?(error)
+                return
+            }
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -245,8 +245,18 @@ public class NaturalLanguageClassifier {
     {
         // construct body
         let multipartFormData = MultipartFormData()
-        multipartFormData.append(metadata, withName: "training_metadata")
-        multipartFormData.append(trainingData, withName: "training_data")
+        do {
+            try multipartFormData.append(file: metadata, withName: "training_metadata")
+        } catch {
+            failure?(error)
+            return
+        }
+        do {
+            try multipartFormData.append(file: trainingData, withName: "training_data")
+        } catch {
+            failure?(error)
+            return
+        }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)
             return

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -80,7 +80,7 @@ public class NaturalLanguageClassifier {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -94,7 +94,7 @@ public class NaturalLanguageUnderstanding {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/PersonalityInsightsV3/Models/ProfileContent.swift
+++ b/Source/PersonalityInsightsV3/Models/ProfileContent.swift
@@ -15,7 +15,6 @@
  **/
 
 import Foundation
-import RestKit
 
 /**
  A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -132,10 +132,10 @@ public class PersonalityInsights {
      HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
      set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
      character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`.
-     For detailed information about calling the service and the responses it can generate, see [Requesting a
-     profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON
-     profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
-     profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
+     **See also:**
+     * [Requesting a profile](https://console.bluemix.net/docs/services/personality-insights/input.html)
+     * [Understanding a JSON profile](https://console.bluemix.net/docs/services/personality-insights/output.html)
+     * [Understanding a CSV profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
 
      - parameter profileContent: A maximum of 20 MB of content to analyze, though the service requires much less text;
        for more information, see [Providing sufficient
@@ -239,10 +239,10 @@ public class PersonalityInsights {
      HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
      set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
      character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`.
-     For detailed information about calling the service and the responses it can generate, see [Requesting a
-     profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON
-     profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
-     profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
+     **See also:**
+     * [Requesting a profile](https://console.bluemix.net/docs/services/personality-insights/input.html)
+     * [Understanding a JSON profile](https://console.bluemix.net/docs/services/personality-insights/output.html)
+     * [Understanding a CSV profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
 
      - parameter profileContent: A maximum of 20 MB of content to analyze, though the service requires much less text;
        for more information, see [Providing sufficient

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -100,7 +100,7 @@ public class PersonalityInsights {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -1540,7 +1540,12 @@ public class SpeechToText {
     {
         // construct body
         let multipartFormData = MultipartFormData()
-        multipartFormData.append(corpusFile, withName: "corpus_file")
+        do {
+            try multipartFormData.append(file: corpusFile, withName: "corpus_file")
+        } catch {
+            failure?(error)
+            return
+        }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)
             return

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -19,44 +19,18 @@ import Foundation
 import RestKit
 
 /**
- The IBM&reg; Speech to Text service provides an API that uses IBM's speech-recognition capabilities to produce
- transcripts of spoken audio. The service can transcribe speech from various languages and audio formats. It addition to
- basic transcription, the service can produce detailed information about many different aspects of the audio. For most
+ The IBM&reg; Speech to Text service provides APIs that use IBM's speech-recognition capabilities to produce transcripts
+ of spoken audio. The service can transcribe speech from various languages and audio formats. It addition to basic
+ transcription, the service can produce detailed information about many different aspects of the audio. For most
  languages, the service supports two sampling rates, broadband and narrowband. It returns all JSON response content in
  the UTF-8 character set.
-  For more information about the service, see the [IBM&reg; Cloud
- documentation](https://console.bluemix.net/docs/services/speech-to-text/index.html).
- ### API usage guidelines
- * **Audio formats:** The service accepts audio in many formats (MIME types). See [Audio
- formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
- * **HTTP interfaces:** The service provides two HTTP Representational State Transfer (REST) interfaces for speech
- recognition. The basic interface includes a single synchronous method. The asynchronous interface provides multiple
- methods that use registered callbacks and polling for non-blocking recognition. See [The HTTP
- interface](https://console.bluemix.net/docs/services/speech-to-text/http.html) and [The asynchronous HTTP
- interface](https://console.bluemix.net/docs/services/speech-to-text/async.html).
- * **WebSocket interface:** The service also offers a WebSocket interface for speech recognition. The WebSocket
- interface provides a full-duplex, low-latency communication channel. Clients send requests and audio to the service and
- receive results over a single connection in an asynchronous fashion. See [The WebSocket
- interface](https://console.bluemix.net/docs/services/speech-to-text/websockets.html).
- * **Customization:** The service offers two customization interfaces. Use language model customization to expand the
- vocabulary of a base model with domain-specific terminology. Use acoustic model customization to adapt a base model for
- the acoustic characteristics of your audio. Language model customization is generally available for production use by
- most supported languages; acoustic model customization is beta functionality that is available for all supported
- languages. See [The customization interface](https://console.bluemix.net/docs/services/speech-to-text/custom.html).
- * **Customization IDs:** Many methods accept a customization ID to identify a custom language or custom acoustic model.
- Customization IDs are Globally Unique Identifiers (GUIDs). They are hexadecimal strings that have the format
- `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
- * **`X-Watson-Learning-Opt-Out`:** By default, all Watson services log requests and their results. Logging is done only
- to improve the services for future users. The logged data is not shared or made public. To prevent IBM from accessing
- your data for general service improvements, set the `X-Watson-Learning-Opt-Out` request header to `true` for all
- requests. You must set the header on each request that you do not want IBM to access for general service improvements.
-   Methods of the customization interface do not log corpora, words, and audio resources that you use to build custom
- models. Your training data is never used to improve the service's base models. However, the service does log such data
- when a custom model is used with a recognition request. You must set the `X-Watson-Learning-Opt-Out` request header to
- `true` to prevent IBM from accessing the data to improve the service.
- * **`X-Watson-Metadata`**: This header allows you to associate a customer ID with data that is passed with a request.
- If necessary, you can use the **Delete labeled data** method to delete the data for a customer ID. See [Information
- security](https://console.bluemix.net/docs/services/speech-to-text/information-security.html).
+ For speech recognition, the service supports synchronous and asynchronous HTTP Representational State Transfer (REST)
+ interfaces. It also supports a WebSocket interface that provides a full-duplex, low-latency communication channel:
+ Clients send requests and audio to the service and receive results over a single connection in an asynchronous fashion.
+ The service also offers two customization interfaces. Use language model customization to expand the vocabulary of a
+ base model with domain-specific terminology. Use acoustic model customization to adapt a base model for the acoustic
+ characteristics of your audio. Language model customization is generally available for production use with most
+ supported languages; acoustic model customization is beta functionality that is available for all supported languages.
  */
 public class SpeechToText {
 
@@ -144,6 +118,7 @@ public class SpeechToText {
 
      Lists all language models that are available for use with the service. The information includes the name of the
      model and its minimum sampling rate in Hertz, among other things.
+     **See also:** [Languages and models](https://console.bluemix.net/docs/services/speech-to-text/input.html#models).
 
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -186,6 +161,7 @@ public class SpeechToText {
 
      Gets information for a single specified language model that is available for use with the service. The information
      includes the name of the model and its minimum sampling rate in Hertz, among other things.
+     **See also:** [Languages and models](https://console.bluemix.net/docs/services/speech-to-text/input.html#models).
 
      - parameter modelID: The identifier of the model in the form of its name from the output of the **Get models**
        method.
@@ -238,15 +214,20 @@ public class SpeechToText {
      interim results, use the WebSocket API. The service imposes a data size limit of 100 MB. It automatically detects
      the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to
      one-channel mono during transcoding. (For the `audio/l16` format, you can specify the endianness.)
+     **See also:** [Making a basic HTTP
+     request](https://console.bluemix.net/docs/services/speech-to-text/http.html#HTTP-basic).
      ### Streaming mode
       For requests to transcribe live audio as it becomes available, you must set the `Transfer-Encoding` header to
      `chunked` to use streaming mode. In streaming mode, the server closes the connection (status code 408) if the
      service receives no data chunk for 30 seconds and it has no audio to transcribe for 30 seconds. The server also
      closes the connection (status code 400) if no speech is detected for `inactivity_timeout` seconds of audio (not
      processing time); use the `inactivity_timeout` parameter to change the default of 30 seconds.
+     **See also:**
+     * [Audio transmission](https://console.bluemix.net/docs/services/speech-to-text/input.html#transmission)
+     * [Timeouts](https://console.bluemix.net/docs/services/speech-to-text/input.html#timeouts).
      ### Audio formats (content types)
       Use the `Content-Type` header to specify the audio format (MIME type) of the audio. The service accepts the
-     following formats:
+     following formats, including specifying the sampling rate, channels, and endianness where indicated.
      * `audio/basic` (Use only with narrowband models.)
      * `audio/flac`
      * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of channels (`channels`) and endianness
@@ -261,9 +242,7 @@ public class SpeechToText {
      * `audio/webm` (The service automatically detects the codec of the input audio.)
      * `audio/webm;codecs=opus`
      * `audio/webm;codecs=vorbis`
-     For information about the supported audio formats, including specifying the sampling rate, channels, and endianness
-     for the indicated formats, see [Audio
-     formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
+     **See also:** [Audio formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
      ### Multipart speech recognition
       The method also supports multipart recognition requests. With multipart requests, you pass all audio data as
      multipart form data. You specify some parameters as request headers and query parameters, but you pass JSON
@@ -271,7 +250,7 @@ public class SpeechToText {
      The multipart approach is intended for use with browsers for which JavaScript is disabled or when the parameters
      used with the request are greater than the 8 KB limit imposed by most HTTP servers and proxies. You can encounter
      this limit, for example, if you want to spot a very large number of keywords.
-     For information about submitting a multipart request, see [Making a multipart HTTP
+     **See also:** [Making a multipart HTTP
      request](https://console.bluemix.net/docs/services/speech-to-text/http.html#HTTP-multi).
 
      - parameter audio: The audio to transcribe in the format specified by the `Content-Type` header.
@@ -280,16 +259,18 @@ public class SpeechToText {
      - parameter customizationID: The customization ID (GUID) of a custom language model that is to be used with the
        recognition request. The base model of the specified custom language model must match the model specified with
        the `model` parameter. You must make the request with service credentials created for the instance of the service
-       that owns the custom model. By default, no custom language model is used.
+       that owns the custom model. By default, no custom language model is used. See [Custom
+       models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model that is to be used
        with the recognition request. The base model of the specified custom acoustic model must match the model
        specified with the `model` parameter. You must make the request with service credentials created for the instance
-       of the service that owns the custom model. By default, no custom acoustic model is used.
+       of the service that owns the custom model. By default, no custom acoustic model is used. See [Custom
+       models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter baseModelVersion: The version of the specified base model that is to be used with recognition
        request. Multiple versions of a base model can exist when a model is updated for internal improvements. The
        parameter is intended primarily for use with custom models that have been upgraded for a new base model. The
-       default value depends on whether the parameter is used with or without a custom model. For more information, see
-       [Base model version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
+       default value depends on whether the parameter is used with or without a custom model. See [Base model
+       version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
      - parameter customizationWeight: If you specify the customization ID (GUID) of a custom language model with the
        recognition request, the customization weight tells the service how much weight to give to words from the custom
        language model compared to those from the base model for the current request.
@@ -299,41 +280,50 @@ public class SpeechToText {
        The default value yields the best performance in general. Assign a higher value if your audio makes frequent use
        of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy
        of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.
+       See [Custom models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter inactivityTimeout: The time in seconds after which, if only silence (no speech) is detected in
        submitted audio, the connection is closed with a 400 error. The parameter is useful for stopping audio submission
-       from a live microphone when a user simply walks away. Use `-1` for infinity.
+       from a live microphone when a user simply walks away. Use `-1` for infinity. See
+       [Timeouts](https://console.bluemix.net/docs/services/speech-to-text/input.html#timeouts).
      - parameter keywords: An array of keyword strings to spot in the audio. Each keyword string can include one or
        more string tokens. Keywords are spotted only in the final results, not in interim hypotheses. If you specify any
        keywords, you must also specify a keywords threshold. You can spot a maximum of 1000 keywords. Omit the parameter
-       or specify an empty array if you do not need to spot keywords.
+       or specify an empty array if you do not need to spot keywords. See [Keyword
+       spotting](https://console.bluemix.net/docs/services/speech-to-text/output.html#keyword_spotting).
      - parameter keywordsThreshold: A confidence value that is the lower bound for spotting a keyword. A word is
        considered to match a keyword if its confidence is greater than or equal to the threshold. Specify a probability
        between 0.0 and 1.0. No keyword spotting is performed if you omit the parameter. If you specify a threshold, you
-       must also specify one or more keywords.
+       must also specify one or more keywords. See [Keyword
+       spotting](https://console.bluemix.net/docs/services/speech-to-text/output.html#keyword_spotting).
      - parameter maxAlternatives: The maximum number of alternative transcripts that the service is to return. By
-       default, a single transcription is returned.
+       default, a single transcription is returned. See [Maximum
+       alternatives](https://console.bluemix.net/docs/services/speech-to-text/output.html#max_alternatives).
      - parameter wordAlternativesThreshold: A confidence value that is the lower bound for identifying a hypothesis as
        a possible word alternative (also known as \"Confusion Networks\"). An alternative word is considered if its
        confidence is greater than or equal to the threshold. Specify a probability between 0.0 and 1.0. No alternative
-       words are computed if you omit the parameter.
+       words are computed if you omit the parameter. See [Word
+       alternatives](https://console.bluemix.net/docs/services/speech-to-text/output.html#word_alternatives).
      - parameter wordConfidence: If `true`, the service returns a confidence measure in the range of 0.0 to 1.0 for
-       each word. By default, no word confidence measures are returned.
+       each word. By default, no word confidence measures are returned. See [Word
+       confidence](https://console.bluemix.net/docs/services/speech-to-text/output.html#word_confidence).
      - parameter timestamps: If `true`, the service returns time alignment for each word. By default, no timestamps
-       are returned.
+       are returned. See [Word
+       timestamps](https://console.bluemix.net/docs/services/speech-to-text/output.html#word_timestamps).
      - parameter profanityFilter: If `true`, the service filters profanity from all output except for keyword results
        by replacing inappropriate words with a series of asterisks. Set the parameter to `false` to return results with
-       no censoring. Applies to US English transcription only.
+       no censoring. Applies to US English transcription only. See [Profanity
+       filtering](https://console.bluemix.net/docs/services/speech-to-text/output.html#profanity_filter).
      - parameter smartFormatting: If `true`, the service converts dates, times, series of digits and numbers, phone
        numbers, currency values, and internet addresses into more readable, conventional representations in the final
        transcript of a recognition request. For US English, the service also converts certain keyword strings to
        punctuation symbols. By default, no smart formatting is performed. Applies to US English and Spanish
-       transcription only.
+       transcription only. See [Smart
+       formatting](https://console.bluemix.net/docs/services/speech-to-text/output.html#smart_formatting).
      - parameter speakerLabels: If `true`, the response includes labels that identify which words were spoken by which
        participants in a multi-person exchange. By default, no speaker labels are returned. Setting `speaker_labels` to
        `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the
-       parameter.
-        To determine whether a language model supports speaker labels, use the **Get models** method and check that the
-       attribute `speaker_labels` is set to `true`. You can also refer to [Speaker
+       parameter. To determine whether a language model supports speaker labels, use the **Get models** method and check
+       that the attribute `speaker_labels` is set to `true`. See [Speaker
        labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -479,8 +469,9 @@ public class SpeechToText {
      the payload of every callback notification that uses the URL. The signature provides authentication and data
      integrity for HTTP communications.
      After you successfully register a callback URL, you can use it with an indefinite number of recognition requests.
-     You can register a maximum of 20 callback URLS in a one-hour span of time. For more information, see [Registering a
-     callback URL](https://console.bluemix.net/docs/services/speech-to-text/async.html#register).
+     You can register a maximum of 20 callback URLS in a one-hour span of time.
+     **See also:** [Registering a callback
+     URL](https://console.bluemix.net/docs/services/speech-to-text/async.html#register).
 
      - parameter callbackUrl: An HTTP or HTTPS URL to which callback notifications are to be sent. To be white-listed,
        the URL must successfully echo the challenge string during URL verification. During verification, the client can
@@ -542,6 +533,8 @@ public class SpeechToText {
 
      Unregisters a callback URL that was previously white-listed with a **Register a callback** request for use with the
      asynchronous interface. Once unregistered, the URL can no longer be used with asynchronous recognition requests.
+     **See also:** [Unregistering a callback
+     URL](https://console.bluemix.net/docs/services/speech-to-text/async.html#unregister).
 
      - parameter callbackUrl: The callback URL that is to be unregistered.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -601,9 +594,7 @@ public class SpeechToText {
      when the job is complete.
      The two approaches are not mutually exclusive. You can poll the service for job status or obtain results from the
      service manually even if you include a callback URL. In both cases, you can include the `results_ttl` parameter to
-     specify how long the results are to remain available after the job is complete. For detailed usage information
-     about the two approaches, including callback notifications, see [Creating a
-     job](https://console.bluemix.net/docs/services/speech-to-text/async.html#create). Using the HTTPS **Check a job**
+     specify how long the results are to remain available after the job is complete. Using the HTTPS **Check a job**
      method to retrieve results is more secure than receiving them via callback notification over HTTP because it
      provides confidentiality in addition to authentication and data integrity.
      The method supports the same basic parameters as other HTTP and WebSocket recognition requests. It also supports
@@ -613,10 +604,20 @@ public class SpeechToText {
      * `user_token`
      * `results_ttl`
      The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming audio and,
-     for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding. (For the
-     `audio/l16` format, you can specify the endianness.)
+     for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding.
+     **See also:** [Creating a job](https://console.bluemix.net/docs/services/speech-to-text/async.html#create).
+     ### Streaming mode
+      For requests to transcribe live audio as it becomes available, you must set the `Transfer-Encoding` header to
+     `chunked` to use streaming mode. In streaming mode, the server closes the connection (status code 408) if the
+     service receives no data chunk for 30 seconds and it has no audio to transcribe for 30 seconds. The server also
+     closes the connection (status code 400) if no speech is detected for `inactivity_timeout` seconds of audio (not
+     processing time); use the `inactivity_timeout` parameter to change the default of 30 seconds.
+     **See also:**
+     * [Audio transmission](https://console.bluemix.net/docs/services/speech-to-text/input.html#transmission)
+     * [Timeouts](https://console.bluemix.net/docs/services/speech-to-text/input.html#timeouts)
      ### Audio formats (content types)
-      Use the `Content-Type` parameter to specify the audio format (MIME type) of the audio:
+      Use the `Content-Type` header to specify the audio format (MIME type) of the audio. The service accepts the
+     following formats, including specifying the sampling rate, channels, and endianness where indicated.
      * `audio/basic` (Use only with narrowband models.)
      * `audio/flac`
      * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of channels (`channels`) and endianness
@@ -631,9 +632,7 @@ public class SpeechToText {
      * `audio/webm` (The service automatically detects the codec of the input audio.)
      * `audio/webm;codecs=opus`
      * `audio/webm;codecs=vorbis`
-     For information about the supported audio formats, including specifying the sampling rate, channels, and endianness
-     for the indicated formats, see [Audio
-     formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
+     **See also:** [Audio formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
 
      - parameter audio: The audio to transcribe in the format specified by the `Content-Type` header.
      - parameter contentType: The type of the input.
@@ -666,16 +665,18 @@ public class SpeechToText {
      - parameter customizationID: The customization ID (GUID) of a custom language model that is to be used with the
        recognition request. The base model of the specified custom language model must match the model specified with
        the `model` parameter. You must make the request with service credentials created for the instance of the service
-       that owns the custom model. By default, no custom language model is used.
+       that owns the custom model. By default, no custom language model is used. See [Custom
+       models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model that is to be used
        with the recognition request. The base model of the specified custom acoustic model must match the model
        specified with the `model` parameter. You must make the request with service credentials created for the instance
-       of the service that owns the custom model. By default, no custom acoustic model is used.
+       of the service that owns the custom model. By default, no custom acoustic model is used. See [Custom
+       models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter baseModelVersion: The version of the specified base model that is to be used with recognition
        request. Multiple versions of a base model can exist when a model is updated for internal improvements. The
        parameter is intended primarily for use with custom models that have been upgraded for a new base model. The
-       default value depends on whether the parameter is used with or without a custom model. For more information, see
-       [Base model version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
+       default value depends on whether the parameter is used with or without a custom model. See [Base model
+       version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
      - parameter customizationWeight: If you specify the customization ID (GUID) of a custom language model with the
        recognition request, the customization weight tells the service how much weight to give to words from the custom
        language model compared to those from the base model for the current request.
@@ -685,41 +686,50 @@ public class SpeechToText {
        The default value yields the best performance in general. Assign a higher value if your audio makes frequent use
        of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy
        of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.
+       See [Custom models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter inactivityTimeout: The time in seconds after which, if only silence (no speech) is detected in
        submitted audio, the connection is closed with a 400 error. The parameter is useful for stopping audio submission
-       from a live microphone when a user simply walks away. Use `-1` for infinity.
+       from a live microphone when a user simply walks away. Use `-1` for infinity. See
+       [Timeouts](https://console.bluemix.net/docs/services/speech-to-text/input.html#timeouts).
      - parameter keywords: An array of keyword strings to spot in the audio. Each keyword string can include one or
        more string tokens. Keywords are spotted only in the final results, not in interim hypotheses. If you specify any
        keywords, you must also specify a keywords threshold. You can spot a maximum of 1000 keywords. Omit the parameter
-       or specify an empty array if you do not need to spot keywords.
+       or specify an empty array if you do not need to spot keywords. See [Keyword
+       spotting](https://console.bluemix.net/docs/services/speech-to-text/output.html#keyword_spotting).
      - parameter keywordsThreshold: A confidence value that is the lower bound for spotting a keyword. A word is
        considered to match a keyword if its confidence is greater than or equal to the threshold. Specify a probability
        between 0.0 and 1.0. No keyword spotting is performed if you omit the parameter. If you specify a threshold, you
-       must also specify one or more keywords.
+       must also specify one or more keywords. See [Keyword
+       spotting](https://console.bluemix.net/docs/services/speech-to-text/output.html#keyword_spotting).
      - parameter maxAlternatives: The maximum number of alternative transcripts that the service is to return. By
-       default, a single transcription is returned.
+       default, a single transcription is returned. See [Maximum
+       alternatives](https://console.bluemix.net/docs/services/speech-to-text/output.html#max_alternatives).
      - parameter wordAlternativesThreshold: A confidence value that is the lower bound for identifying a hypothesis as
        a possible word alternative (also known as \"Confusion Networks\"). An alternative word is considered if its
        confidence is greater than or equal to the threshold. Specify a probability between 0.0 and 1.0. No alternative
-       words are computed if you omit the parameter.
+       words are computed if you omit the parameter. See [Word
+       alternatives](https://console.bluemix.net/docs/services/speech-to-text/output.html#word_alternatives).
      - parameter wordConfidence: If `true`, the service returns a confidence measure in the range of 0.0 to 1.0 for
-       each word. By default, no word confidence measures are returned.
+       each word. By default, no word confidence measures are returned. See [Word
+       confidence](https://console.bluemix.net/docs/services/speech-to-text/output.html#word_confidence).
      - parameter timestamps: If `true`, the service returns time alignment for each word. By default, no timestamps
-       are returned.
+       are returned. See [Word
+       timestamps](https://console.bluemix.net/docs/services/speech-to-text/output.html#word_timestamps).
      - parameter profanityFilter: If `true`, the service filters profanity from all output except for keyword results
        by replacing inappropriate words with a series of asterisks. Set the parameter to `false` to return results with
-       no censoring. Applies to US English transcription only.
+       no censoring. Applies to US English transcription only. See [Profanity
+       filtering](https://console.bluemix.net/docs/services/speech-to-text/output.html#profanity_filter).
      - parameter smartFormatting: If `true`, the service converts dates, times, series of digits and numbers, phone
        numbers, currency values, and internet addresses into more readable, conventional representations in the final
        transcript of a recognition request. For US English, the service also converts certain keyword strings to
        punctuation symbols. By default, no smart formatting is performed. Applies to US English and Spanish
-       transcription only.
+       transcription only. See [Smart
+       formatting](https://console.bluemix.net/docs/services/speech-to-text/output.html#smart_formatting).
      - parameter speakerLabels: If `true`, the response includes labels that identify which words were spoken by which
        participants in a multi-person exchange. By default, no speaker labels are returned. Setting `speaker_labels` to
        `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the
-       parameter.
-        To determine whether a language model supports speaker labels, use the **Get models** method and check that the
-       attribute `speaker_labels` is set to `true`. You can also refer to [Speaker
+       parameter. To determine whether a language model supports speaker labels, use the **Get models** method and check
+       that the attribute `speaker_labels` is set to `true`. See [Speaker
        labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -872,6 +882,8 @@ public class SpeechToText {
      `completed` or not one of the latest 100 outstanding jobs, use the **Check a job** method. A job and its results
      remain available until you delete them with the **Delete a job** method or until the job's time to live expires,
      whichever comes first.
+     **See also:** [Checking the status of the latest
+     jobs](https://console.bluemix.net/docs/services/speech-to-text/async.html#jobs).
 
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -918,7 +930,9 @@ public class SpeechToText {
      You can use the method to retrieve the results of any job, regardless of whether it was submitted with a callback
      URL and the `recognitions.completed_with_results` event, and you can retrieve the results multiple times for as
      long as they remain available. Use the **Check jobs** method to request information about the most recent jobs
-     associated with the calling user.
+     associated with the caller.
+     **See also:** [Checking the status and retrieving the results of a
+     job](https://console.bluemix.net/docs/services/speech-to-text/async.html#job).
 
      - parameter id: The ID of the asynchronous job.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -969,6 +983,7 @@ public class SpeechToText {
      Deletes the specified job. You cannot delete a job that the service is actively processing. Once you delete a job,
      its results are no longer available. The service automatically deletes a job and its results when the time to live
      for the results expires. You must submit the request with the service credentials of the user who created the job.
+     **See also:** [Deleting a job](https://console.bluemix.net/docs/services/speech-to-text/async.html#delete).
 
      - parameter id: The ID of the asynchronous job.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -1019,6 +1034,8 @@ public class SpeechToText {
      Creates a new custom language model for a specified base model. The custom language model can be used only with the
      base model for which it is created. The model is owned by the instance of the service whose credentials are used to
      create it.
+     **See also:** [Create a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-create.html#createModel).
 
      - parameter createLanguageModel: A `CreateLanguageModel` object that provides basic information about the new
        custom language model.
@@ -1074,6 +1091,8 @@ public class SpeechToText {
      parameter to see all custom language models for the specified language. Omit the parameter to see all custom
      language models for all languages. You must use credentials for the instance of the service that owns a model to
      list information about it.
+     **See also:** [Listing custom language
+     models](https://console.bluemix.net/docs/services/speech-to-text/language-models.html#listModels).
 
      - parameter language: The identifier of the language for which custom language or custom acoustic models are to
        be returned (for example, `en-US`). Omit the parameter to see all custom language or custom acoustic models owned
@@ -1128,6 +1147,8 @@ public class SpeechToText {
 
      Gets information about a specified custom language model. You must use credentials for the instance of the service
      that owns a model to list information about it.
+     **See also:** [Listing custom language
+     models](https://console.bluemix.net/docs/services/speech-to-text/language-models.html#listModels).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1179,6 +1200,8 @@ public class SpeechToText {
      Deletes an existing custom language model. The custom model cannot be deleted if another request, such as adding a
      corpus to the model, is currently being processed. You must use credentials for the instance of the service that
      owns a model to delete it.
+     **See also:** [Deleting a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-models.html#deleteModel).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1245,6 +1268,8 @@ public class SpeechToText {
      request to add a corpus or words to the model.
      * No training data (corpora or words) have been added to the custom model.
      * One or more words that were added to the custom model have invalid sounds-like pronunciations that you must fix.
+     **See also:** [Train the custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-create.html#trainModel).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1325,6 +1350,8 @@ public class SpeechToText {
      initializes the model to its state when it was first created. Metadata such as the name and language of the model
      are preserved, but the model's words resource is removed and must be re-created. You must use credentials for the
      instance of the service that owns a model to reset it.
+     **See also:** [Resetting a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-models.html#resetModel).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1383,8 +1410,8 @@ public class SpeechToText {
      status every 10 seconds. While it is being upgraded, the custom model has the status `upgrading`. When the upgrade
      is complete, the model resumes the status that it had prior to upgrade. The service cannot accept subsequent
      requests for the model until the upgrade completes.
-     For more information, see [Upgrading custom
-     models](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html).
+     **See also:** [Upgrading a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html#upgradeLanguage).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1436,6 +1463,8 @@ public class SpeechToText {
      Lists information about all corpora from a custom language model. The information includes the total number of
      words and out-of-vocabulary (OOV) words, name, and status of each corpus. You must use credentials for the instance
      of the service that owns a model to list its corpora.
+     **See also:** [Listing corpora for a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-corpora.html#listCorpora).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1490,9 +1519,7 @@ public class SpeechToText {
      by using the **Train a custom language model** method.
      Submit a plain text file that contains sample sentences from the domain of interest to enable the service to
      extract words in context. The more sentences you add that represent the context in which speakers use words from
-     the domain, the better the service's recognition accuracy. For guidelines about adding a corpus text file and for
-     information about how the service parses a corpus file, see [Preparing a corpus text
-     file](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#prepareCorpus).
+     the domain, the better the service's recognition accuracy.
      The call returns an HTTP 201 response code if the corpus is valid. The service then asynchronously processes the
      contents of the corpus and automatically extracts new words that it finds. This can take on the order of a minute
      or two to complete depending on the total number of words and the number of new words in the corpus, as well as the
@@ -1510,12 +1537,21 @@ public class SpeechToText {
      The service limits the overall amount of data that you can add to a custom model to a maximum of 10 million total
      words from all corpora combined. Also, you can add no more than 30 thousand custom (OOV) words to a model; this
      includes words that the service extracts from corpora and words that you add directly.
+     **See also:**
+     * [Working with
+     corpora](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#workingCorpora)
+     * [Add corpora to the custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-create.html#addCorpora).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
-     - parameter corpusName: The name of the corpus for the custom language model. When adding a corpus, do not
-       include spaces in the name; use a localized name that matches the language of the custom model; and do not use
-       the name `user`, which is reserved by the service to denote custom words added or modified by the user.
+     - parameter corpusName: The name of the new corpus for the custom language model. Use a localized name that
+       matches the language of the custom model and reflects the contents of the corpus.
+       * Include a maximum of 128 characters in the name.
+       * Do not include spaces, slashes, or backslashes in the name.
+       * Do not use the name of a corpus that has already been added to the custom model.
+       * Do not use the name `user`, which is reserved by the service to denote custom words that are added or modified
+       by the user.
      - parameter corpusFile: A plain text file that contains the training data for the corpus. Encode the file in
        UTF-8 if it contains non-ASCII characters; the service assumes UTF-8 encoding if it encounters non-ASCII
        characters. With cURL, use the `--data-binary` option to upload the file for the request.
@@ -1599,12 +1635,12 @@ public class SpeechToText {
      Gets information about a corpus from a custom language model. The information includes the total number of words
      and out-of-vocabulary (OOV) words, name, and status of the corpus. You must use credentials for the instance of the
      service that owns a model to list its corpora.
+     **See also:** [Listing corpora for a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-corpora.html#listCorpora).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
-     - parameter corpusName: The name of the corpus for the custom language model. When adding a corpus, do not
-       include spaces in the name; use a localized name that matches the language of the custom model; and do not use
-       the name `user`, which is reserved by the service to denote custom words added or modified by the user.
+     - parameter corpusName: The name of the corpus for the custom language model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1656,12 +1692,12 @@ public class SpeechToText {
      they have been modified in some way with the **Add custom words** or **Add a custom word** method. Removing a
      corpus does not affect the custom model until you train the model with the **Train a custom language model**
      method. You must use credentials for the instance of the service that owns a model to delete its corpora.
+     **See also:** [Deleting a corpus from a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-corpora.html#deleteCorpus).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
-     - parameter corpusName: The name of the corpus for the custom language model. When adding a corpus, do not
-       include spaces in the name; use a localized name that matches the language of the custom model; and do not use
-       the name `user`, which is reserved by the service to denote custom words added or modified by the user.
+     - parameter corpusName: The name of the corpus for the custom language model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -1713,6 +1749,8 @@ public class SpeechToText {
      that were extracted from corpora. You can also indicate the order in which the service is to return words; by
      default, words are listed in ascending alphabetical order. You must use credentials for the instance of the service
      that owns a model to query information about its words.
+     **See also:** [Listing words from a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-words.html#listWords).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1798,14 +1836,10 @@ public class SpeechToText {
      * The `sounds_like` field provides an array of one or more pronunciations for the word. Use the parameter to
      specify how the word can be pronounced by users. Use the parameter for words that are difficult to pronounce,
      foreign words, acronyms, and so on. For example, you might specify that the word `IEEE` can sound like `i triple
-     e`. You can specify a maximum of five sounds-like pronunciations for a word. For information about pronunciation
-     rules, see [Using the sounds_like
-     field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#soundsLike).
+     e`. You can specify a maximum of five sounds-like pronunciations for a word.
      * The `display_as` field provides a different way of spelling the word in a transcript. Use the parameter when you
      want the word to appear different from its usual representation or from its spelling in corpora training data. For
-     example, you might indicate that the word `IBM(trademark)` is to be displayed as `IBM&trade;`. For more
-     information, see [Using the display_as
-     field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#displayAs).
+     example, you might indicate that the word `IBM(trademark)` is to be displayed as `IBM&trade;`.
      If you add a custom word that already exists in the words resource for the custom model, the new definition
      overwrites the existing data for the word. If the service encounters an error with the input data, it returns a
      failure code and does not add any of the words to the words resource.
@@ -1819,6 +1853,11 @@ public class SpeechToText {
      You can use the **List custom words** or **List a custom word** method to review the words that you add. Words with
      an invalid `sounds_like` field include an `error` field that describes the problem. You can use other words-related
      methods to correct errors, eliminate typos, and modify how words are pronounced as needed.
+     **See also:**
+     * [Working with custom
+     words](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#workingWords)
+     * [Add words to the custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-create.html#addWords).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1891,17 +1930,18 @@ public class SpeechToText {
      * The `sounds_like` field provides an array of one or more pronunciations for the word. Use the parameter to
      specify how the word can be pronounced by users. Use the parameter for words that are difficult to pronounce,
      foreign words, acronyms, and so on. For example, you might specify that the word `IEEE` can sound like `i triple
-     e`. You can specify a maximum of five sounds-like pronunciations for a word. For information about pronunciation
-     rules, see [Using the sounds_like
-     field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#soundsLike).
+     e`. You can specify a maximum of five sounds-like pronunciations for a word.
      * The `display_as` field provides a different way of spelling the word in a transcript. Use the parameter when you
      want the word to appear different from its usual representation or from its spelling in corpora training data. For
-     example, you might indicate that the word `IBM(trademark)` is to be displayed as `IBM&trade;`. For more
-     information, see [Using the display_as
-     field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#displayAs).
+     example, you might indicate that the word `IBM(trademark)` is to be displayed as `IBM&trade;`.
      If you add a custom word that already exists in the words resource for the custom model, the new definition
      overwrites the existing data for the word. If the service encounters an error, it does not add the word to the
      words resource. Use the **List a custom word** method to review the word that you add.
+     **See also:**
+     * [Working with custom
+     words](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#workingWords)
+     * [Add words to the custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-create.html#addWords).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1984,6 +2024,8 @@ public class SpeechToText {
 
      Gets information about a custom word from a custom language model. You must use credentials for the instance of the
      service that owns a model to query information about its words.
+     **See also:** [Listing words from a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-words.html#listWords).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -2041,6 +2083,8 @@ public class SpeechToText {
      removes only the custom pronunciation for the word; the word remains in the base vocabulary. Removing a custom word
      does not affect the custom model until you train the model with the **Train a custom language model** method. You
      must use credentials for the instance of the service that owns a model to delete its words.
+     **See also:** [Deleting a word from a custom language
+     model](https://console.bluemix.net/docs/services/speech-to-text/language-words.html#deleteWord).
 
      - parameter customizationID: The customization ID (GUID) of the custom language model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -2096,6 +2140,8 @@ public class SpeechToText {
      Creates a new custom acoustic model for a specified base model. The custom acoustic model can be used only with the
      base model for which it is created. The model is owned by the instance of the service whose credentials are used to
      create it.
+     **See also:** [Create a custom acoustic
+     model](https://console.bluemix.net/docs/services/speech-to-text/acoustic-create.html#createModel).
 
      - parameter name: A user-defined name for the new custom acoustic model. Use a name that is unique among all
        custom acoustic models that you own. Use a localized name that matches the language of the custom model. Use a
@@ -2162,6 +2208,8 @@ public class SpeechToText {
      parameter to see all custom acoustic models for the specified language. Omit the parameter to see all custom
      acoustic models for all languages. You must use credentials for the instance of the service that owns a model to
      list information about it.
+     **See also:** [Listing custom acoustic
+     models](https://console.bluemix.net/docs/services/speech-to-text/acoustic-models.html#listModels).
 
      - parameter language: The identifier of the language for which custom language or custom acoustic models are to
        be returned (for example, `en-US`). Omit the parameter to see all custom language or custom acoustic models owned
@@ -2216,6 +2264,8 @@ public class SpeechToText {
 
      Gets information about a specified custom acoustic model. You must use credentials for the instance of the service
      that owns a model to list information about it.
+     **See also:** [Listing custom acoustic
+     models](https://console.bluemix.net/docs/services/speech-to-text/acoustic-models.html#listModels).
 
      - parameter customizationID: The customization ID (GUID) of the custom acoustic model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -2267,6 +2317,8 @@ public class SpeechToText {
      Deletes an existing custom acoustic model. The custom model cannot be deleted if another request, such as adding an
      audio resource to the model, is currently being processed. You must use credentials for the instance of the service
      that owns a model to delete it.
+     **See also:** [Deleting a custom acoustic
+     model](https://console.bluemix.net/docs/services/speech-to-text/acoustic-models.html#deleteModel).
 
      - parameter customizationID: The customization ID (GUID) of the custom acoustic model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -2332,14 +2384,15 @@ public class SpeechToText {
      You can use the optional `custom_language_model_id` parameter to specify the GUID of a separately created custom
      language model that is to be used during training. Specify a custom language model if you have verbatim
      transcriptions of the audio files that you have added to the custom model or you have either corpora (text files)
-     or a list of words that are relevant to the contents of the audio files. For information about creating a separate
-     custom language model, see [Creating a custom language
-     model](https://console.bluemix.net/docs/services/speech-to-text/language-create.html).
+     or a list of words that are relevant to the contents of the audio files. For more information, see the **Create a
+     custom language model** method.
      Training can fail to start for the following reasons:
      * The service is currently handling another request for the custom model, such as another training request or a
      request to add audio resources to the model.
      * The custom model contains less than 10 minutes or more than 50 hours of audio data.
      * One or more of the custom model's audio resources is invalid.
+     **See also:** [Train the custom acoustic
+     model](https://console.bluemix.net/docs/services/speech-to-text/acoustic-create.html#trainModel).
 
      - parameter customizationID: The customization ID (GUID) of the custom acoustic model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -2405,6 +2458,8 @@ public class SpeechToText {
      initializes the model to its state when it was first created. Metadata such as the name and language of the model
      are preserved, but the model's audio resources are removed and must be re-created. You must use credentials for the
      instance of the service that owns a model to reset it.
+     **See also:** [Resetting a custom acoustic
+     model](https://console.bluemix.net/docs/services/speech-to-text/acoustic-models.html#resetModel).
 
      - parameter customizationID: The customization ID (GUID) of the custom acoustic model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -2468,8 +2523,8 @@ public class SpeechToText {
      `custom_language_model_id` parameter to specify the GUID of that custom language model. The custom language model
      must be upgraded before the custom acoustic model can be upgraded. Omit the parameter if the custom acoustic model
      was not trained with a custom language model.
-     For more information, see [Upgrading custom
-     models](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html).
+     **See also:** [Upgrading a custom acoustic
+     model](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html#upgradeAcoustic).
 
      - parameter customizationID: The customization ID (GUID) of the custom acoustic model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -2535,6 +2590,8 @@ public class SpeechToText {
      resource, which is important for checking the service's analysis of the resource in response to a request to add it
      to the custom acoustic model. You must use credentials for the instance of the service that owns a model to list
      its audio resources.
+     **See also:** [Listing audio resources for a custom acoustic
+     model](https://console.bluemix.net/docs/services/speech-to-text/acoustic-audio.html#listAudio).
 
      - parameter customizationID: The customization ID (GUID) of the custom acoustic model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -2606,9 +2663,12 @@ public class SpeechToText {
      the status of the audio. The method accepts the customization ID of the custom model and the name of the audio
      resource, and it returns the status of the resource. Use a loop to check the status of the audio every few seconds
      until it becomes `ok`.
+     **See also:** [Add audio to the custom acoustic
+     model](https://console.bluemix.net/docs/services/speech-to-text/acoustic-create.html#addAudio).
      ### Content types for audio-type resources
       You can add an individual audio file in any format that the service supports for speech recognition. For an
-     audio-type resource, use the `Content-Type` parameter to specify the audio format (MIME type) of the audio file:
+     audio-type resource, use the `Content-Type` parameter to specify the audio format (MIME type) of the audio file,
+     including specifying the sampling rate, channels, and endianness where indicated.
      * `audio/basic` (Use only with narrowband models.)
      * `audio/flac`
      * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of channels (`channels`) and endianness
@@ -2623,9 +2683,7 @@ public class SpeechToText {
      * `audio/webm` (The service automatically detects the codec of the input audio.)
      * `audio/webm;codecs=opus`
      * `audio/webm;codecs=vorbis`
-     For information about the supported audio formats, including specifying the sampling rate, channels, and endianness
-     for the indicated formats, see [Audio
-     formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
+     **See also:** [Audio formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
      **Note:** The sampling rate of an audio file must match the sampling rate of the base model for the custom model:
      for broadband models, at least 16 kHz; for narrowband models, at least 8 kHz. If the sampling rate of the audio is
      higher than the minimum required rate, the service down-samples the audio to the appropriate rate. If the sampling
@@ -2640,11 +2698,20 @@ public class SpeechToText {
      parameter to specify the format of the contained audio files. The parameter accepts all of the audio formats
      supported for use with speech recognition and with the `Content-Type` header, including the `rate`, `channels`, and
      `endianness` parameters that are used with some formats. The default contained audio format is `audio/wav`.
+     ### Naming restrictions for embedded audio files
+      The name of an audio file that is embedded within an archive-type resource must meet the following restrictions:
+     * Include a maximum of 128 characters in the file name; this includes the file extension.
+     * Do not include spaces, slashes, or backslashes in the file name.
+     * Do not use the name of an audio file that has already been added to the custom model as part of an archive-type
+     resource.
 
      - parameter customizationID: The customization ID (GUID) of the custom acoustic model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
-     - parameter audioName: The name of the audio resource for the custom acoustic model. When adding an audio
-       resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
+     - parameter audioName: The name of the new audio resource for the custom acoustic model. Use a localized name
+       that matches the language of the custom model and reflects the contents of the resource.
+       * Include a maximum of 128 characters in the name.
+       * Do not include spaces, slashes, or backslashes in the name.
+       * Do not use the name of an audio resource that has already been added to the custom model.
      - parameter audioResource: The audio resource that is to be added to the custom acoustic model, an individual
        audio file or an archive file.
      - parameter contentType: The type of the input.
@@ -2735,11 +2802,12 @@ public class SpeechToText {
      * For an archive-type resource, the `status` field is located in the `AudioResource` object that is returned in the
      `container` field.
      You must use credentials for the instance of the service that owns a model to list its audio resources.
+     **See also:** [Listing audio resources for a custom acoustic
+     model](https://console.bluemix.net/docs/services/speech-to-text/acoustic-audio.html#listAudio).
 
      - parameter customizationID: The customization ID (GUID) of the custom acoustic model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
-     - parameter audioName: The name of the audio resource for the custom acoustic model. When adding an audio
-       resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
+     - parameter audioName: The name of the audio resource for the custom acoustic model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2791,11 +2859,12 @@ public class SpeechToText {
      resource. Removing an audio resource does not affect the custom model until you train the model on its updated data
      by using the **Train a custom acoustic model** method. You must use credentials for the instance of the service
      that owns a model to delete its audio resources.
+     **See also:** [Deleting an audio resource from a custom acoustic
+     model](https://console.bluemix.net/docs/services/speech-to-text/acoustic-audio.html#deleteAudio).
 
      - parameter customizationID: The customization ID (GUID) of the custom acoustic model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
-     - parameter audioName: The name of the audio resource for the custom acoustic model. When adding an audio
-       resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
+     - parameter audioName: The name of the audio resource for the custom acoustic model.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
      - parameter success: A function executed with the successful result.
@@ -2847,7 +2916,8 @@ public class SpeechToText {
      the customer ID. You must issue the request with credentials for the same instance of the service that was used to
      associate the customer ID with the data.
      You associate a customer ID with data by passing the `X-Watson-Metadata` header with a request that passes the
-     data. For more information about customer IDs and about using this method, see [Information
+     data.
+     **See also:** [Information
      security](https://console.bluemix.net/docs/services/speech-to-text/information-security.html).
 
      - parameter customerID: The customer ID for which all data is to be deleted.

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -121,7 +121,7 @@ public class SpeechToText {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -20,41 +20,17 @@ import RestKit
 
 /**
  ### Service Overview
- The IBM&reg; Text to Speech service provides an API that uses IBM's speech-synthesis capabilities to synthesize text
- into natural-sounding speech in a variety of languages, dialects, and voices. The service supports at least one male or
- female voice, sometimes both, for each language. The audio is streamed back to the client with minimal delay. For more
- information about the service, see the [IBM&reg; Cloud
- documentation](https://console.bluemix.net/docs/services/text-to-speech/index.html).
- ### API usage guidelines
- * **Audio formats:** The service can produce audio in many formats (MIME types). See [Specifying an audio
- format](https://console.bluemix.net/docs/services/text-to-speech/http.html#format).
- * **SSML:** Many methods refer to the Speech Synthesis Markup Language (SSML). SSML is an XML-based markup language
- that provides text annotation for speech-synthesis applications. See [Using
- SSML](https://console.bluemix.net/docs/services/text-to-speech/SSML.html) and [Using IBM
- SPR](https://console.bluemix.net/docs/services/text-to-speech/SPRs.html).
- * **Word translations:** Many customization methods accept sounds-like or phonetic translations for words. Phonetic
- translations are based on the SSML phoneme format for representing a word. You can specify them in standard
- International Phonetic Alphabet (IPA) representation
-   &lt;phoneme alphabet="ipa" ph="t&#601;m&#712;&#593;to"&gt;&lt;/phoneme&gt;
-   or in the proprietary IBM Symbolic Phonetic Representation (SPR)
-   &lt;phoneme alphabet="ibm" ph="1gAstroEntxrYFXs"&gt;&lt;/phoneme&gt;
-   See [Understanding customization](https://console.bluemix.net/docs/services/text-to-speech/custom-intro.html).
- * **WebSocket interface:** The service also offers a WebSocket interface for speech synthesis. The WebSocket interface
- supports both plain text and SSML input, including the SSML &lt;mark&gt; element and word timings. See [The WebSocket
- interface](https://console.bluemix.net/docs/services/text-to-speech/websockets.html).
- * **Customization IDs:** Many methods accept a customization ID, which is a Globally Unique Identifier (GUID).
- Customization IDs are hexadecimal strings that have the format `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
- * **`X-Watson-Learning-Opt-Out`:** By default, all Watson services log requests and their results. Logging is done only
- to improve the services for future users. The logged data is not shared or made public. To prevent IBM from accessing
- your data for general service improvements, set the `X-Watson-Learning-Opt-Out` request header to `true` for all
- requests. You must set the header on each request that you do not want IBM to access for general service improvements.
-   Methods of the customization interface do not log words and translations that you use to build custom voice models.
- Your training data is never used to improve the service's base models. However, the service does log such data when a
- custom model is used with a synthesize request. You must set the `X-Watson-Learning-Opt-Out` request header to `true`
- to prevent IBM from accessing the data to improve the service.
- * **`X-Watson-Metadata`:** This header allows you to associate a customer ID with data that is passed with a request.
- If necessary, you can use the **Delete labeled data** method to delete the data for a customer ID. See [Information
- security](https://console.bluemix.net/docs/services/text-to-speech/information-security.html).
+ The IBM&reg; Text to Speech service provides APIs that use IBM's speech-synthesis capabilities to synthesize text into
+ natural-sounding speech in a variety of languages, dialects, and voices. The service supports at least one male or
+ female voice, sometimes both, for each language. The audio is streamed back to the client with minimal delay.
+ For speech synthesis, the service supports a synchronous HTTP Representational State Transfer (REST) interface. It also
+ supports a WebSocket interface that provides both plain text and SSML input, including the SSML &lt;mark&gt; element
+ and word timings. SSML is an XML-based markup language that provides text annotation for speech-synthesis applications.
+ The service also offers a customization interface. You can use the interface to define sounds-like or phonetic
+ translations for words. A sounds-like translation consists of one or more words that, when combined, sound like the
+ word. A phonetic translation is based on the SSML phoneme format for representing a word. You can specify a phonetic
+ translation in standard International Phonetic Alphabet (IPA) representation or in the proprietary IBM Symbolic
+ Phonetic Representation (SPR).
  */
 public class TextToSpeech {
 
@@ -136,6 +112,7 @@ public class TextToSpeech {
 
      Lists all voices available for use with the service. The information includes the name, language, gender, and other
      details about the voice. To see information about a specific voice, use the **Get a voice** method.
+     **See also:** [Specifying a voice](https://console.bluemix.net/docs/services/text-to-speech/http.html#voices).
 
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed if an error occurs.
@@ -179,6 +156,7 @@ public class TextToSpeech {
      Gets information about the specified voice. The information includes the name, language, gender, and other details
      about the voice. Specify a customization ID to obtain information for that custom voice model of the specified
      voice. To list information about all available voices, use the **List voices** method.
+     **See also:** [Specifying a voice](https://console.bluemix.net/docs/services/text-to-speech/http.html#voices).
 
      - parameter voice: The voice for which information is to be returned.
      - parameter customizationID: The customization ID (GUID) of a custom voice model for which information is to be
@@ -240,13 +218,13 @@ public class TextToSpeech {
 
      Synthesizes text to spoken audio, returning the synthesized audio stream as an array of bytes. You can pass a
      maximum of 5 KB of text.  Use the `Accept` header or the `accept` query parameter to specify the requested format
-     (MIME type) of the response audio. By default, the service uses `audio/ogg;codecs=opus`. For detailed information
-     about the supported audio formats and sampling rates, see [Specifying an audio
-     format](https://console.bluemix.net/docs/services/text-to-speech/http.html#format).
+     (MIME type) of the response audio. By default, the service uses `audio/ogg;codecs=opus`.
      If a request includes invalid query parameters, the service returns a `Warnings` response header that provides
      messages about the invalid parameters. The warning includes a descriptive message and a list of invalid argument
      strings. For example, a message such as `\"Unknown arguments:\"` or `\"Unknown url query arguments:\"` followed by
      a list of the form `\"invalid_arg_1, invalid_arg_2.\"` The request succeeds despite the warnings.
+     **See also:** [Synthesizing text to
+     audio](https://console.bluemix.net/docs/services/text-to-speech/http.html#synthesize).
 
      - parameter text: The text to synthesize.
      - parameter accept: The requested audio format (MIME type) of the audio. You can use the `Accept` header or the
@@ -356,6 +334,8 @@ public class TextToSpeech {
      You can also request the pronunciation for a specific voice to see the default translation for the language of that
      voice or for a specific custom voice model to see the translation for that voice model.
      **Note:** This method is currently a beta release.
+     **See also:** [Querying a word from a
+     language](https://console.bluemix.net/docs/services/text-to-speech/custom-entries.html#cuWordsQueryLanguage).
 
      - parameter text: The word for which the pronunciation is requested.
      - parameter voice: A voice that specifies the language in which the pronunciation is to be returned. All voices
@@ -431,6 +411,8 @@ public class TextToSpeech {
      specify the language and a description for the new model. The model is owned by the instance of the service whose
      credentials are used to create it.
      **Note:** This method is currently a beta release.
+     **See also:** [Creating a custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-models.html#cuModelsCreate).
 
      - parameter name: The name of the new custom voice model.
      - parameter language: The language of the new custom voice model. Omit the parameter to use the the default
@@ -492,6 +474,8 @@ public class TextToSpeech {
      metadata for a specific voice model, use the **List a custom model** method. You must use credentials for the
      instance of the service that owns a model to list information about it.
      **Note:** This method is currently a beta release.
+     **See also:** [Querying all custom
+     models](https://console.bluemix.net/docs/services/text-to-speech/custom-models.html#cuModelsQueryAll).
 
      - parameter language: The language for which custom voice models that are owned by the requesting service
        credentials are to be returned. Omit the parameter to see all custom voice models that are owned by the
@@ -549,7 +533,19 @@ public class TextToSpeech {
      a word that already exists in a custom model overwrites the word's existing translation. A custom model can contain
      no more than 20,000 entries. You must use credentials for the instance of the service that owns a model to update
      it.
+     You can define sounds-like or phonetic translations for words. A sounds-like translation consists of one or more
+     words that, when combined, sound like the word. Phonetic translations are based on the SSML phoneme format for
+     representing a word. You can specify them in standard International Phonetic Alphabet (IPA) representation
+       <code>&lt;phoneme alphabet=\"ipa\" ph=\"t&#601;m&#712;&#593;to\"&gt;&lt;/phoneme&gt;</code>
+       or in the proprietary IBM Symbolic Phonetic Representation (SPR)
+       <code>&lt;phoneme alphabet=\"ibm\" ph=\"1gAstroEntxrYFXs\"&gt;&lt;/phoneme&gt;</code>
      **Note:** This method is currently a beta release.
+     **See also:**
+     * [Updating a custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-models.html#cuModelsUpdate)
+     * [Adding words to a Japanese custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-entries.html#cuJapaneseAdd)
+     * [Understanding customization](https://console.bluemix.net/docs/services/text-to-speech/custom-intro.html).
 
      - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -618,6 +614,8 @@ public class TextToSpeech {
      of the voice model, the output includes the words and their translations as defined in the model. To see just the
      metadata for a voice model, use the **List custom models** method.
      **Note:** This method is currently a beta release.
+     **See also:** [Querying a custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-models.html#cuModelsQuery).
 
      - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -669,6 +667,8 @@ public class TextToSpeech {
      Deletes the specified custom voice model. You must use credentials for the instance of the service that owns a
      model to delete it.
      **Note:** This method is currently a beta release.
+     **See also:** [Deleting a custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-models.html#cuModelsDelete).
 
      - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -720,7 +720,19 @@ public class TextToSpeech {
      word that already exists in a custom model overwrites the word's existing translation. A custom model can contain
      no more than 20,000 entries. You must use credentials for the instance of the service that owns a model to add
      words to it.
+     You can define sounds-like or phonetic translations for words. A sounds-like translation consists of one or more
+     words that, when combined, sound like the word. Phonetic translations are based on the SSML phoneme format for
+     representing a word. You can specify them in standard International Phonetic Alphabet (IPA) representation
+       <code>&lt;phoneme alphabet=\"ipa\" ph=\"t&#601;m&#712;&#593;to\"&gt;&lt;/phoneme&gt;</code>
+       or in the proprietary IBM Symbolic Phonetic Representation (SPR)
+       <code>&lt;phoneme alphabet=\"ibm\" ph=\"1gAstroEntxrYFXs\"&gt;&lt;/phoneme&gt;</code>
      **Note:** This method is currently a beta release.
+     **See also:**
+     * [Adding multiple words to a custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-entries.html#cuWordsAdd)
+     * [Adding words to a Japanese custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-entries.html#cuJapaneseAdd)
+     * [Understanding customization](https://console.bluemix.net/docs/services/text-to-speech/custom-intro.html).
 
      - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -788,6 +800,8 @@ public class TextToSpeech {
      translations as they are defined in the model. You must use credentials for the instance of the service that owns a
      model to list its words.
      **Note:** This method is currently a beta release.
+     **See also:** [Querying all words from a custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-entries.html#cuWordsQueryModel).
 
      - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -840,7 +854,19 @@ public class TextToSpeech {
      that already exists in a custom model overwrites the word's existing translation. A custom model can contain no
      more than 20,000 entries. You must use credentials for the instance of the service that owns a model to add a word
      to it.
+     You can define sounds-like or phonetic translations for words. A sounds-like translation consists of one or more
+     words that, when combined, sound like the word. Phonetic translations are based on the SSML phoneme format for
+     representing a word. You can specify them in standard International Phonetic Alphabet (IPA) representation
+       <code>&lt;phoneme alphabet=\"ipa\" ph=\"t&#601;m&#712;&#593;to\"&gt;&lt;/phoneme&gt;</code>
+       or in the proprietary IBM Symbolic Phonetic Representation (SPR)
+       <code>&lt;phoneme alphabet=\"ibm\" ph=\"1gAstroEntxrYFXs\"&gt;&lt;/phoneme&gt;</code>
      **Note:** This method is currently a beta release.
+     **See also:**
+     * [Adding a single word to a custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-entries.html#cuWordAdd)
+     * [Adding words to a Japanese custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-entries.html#cuJapaneseAdd)
+     * [Understanding customization](https://console.bluemix.net/docs/services/text-to-speech/custom-intro.html).
 
      - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -912,6 +938,8 @@ public class TextToSpeech {
      Gets the translation for a single word from the specified custom model. The output shows the translation as it is
      defined in the model. You must use credentials for the instance of the service that owns a model to list its words.
      **Note:** This method is currently a beta release.
+     **See also:** [Querying a single word from a custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-entries.html#cuWordQueryModel).
 
      - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -965,6 +993,8 @@ public class TextToSpeech {
      Deletes a single word from the specified custom voice model. You must use credentials for the instance of the
      service that owns a model to delete its words.
      **Note:** This method is currently a beta release.
+     **See also:** [Deleting a word from a custom
+     model](https://console.bluemix.net/docs/services/text-to-speech/custom-entries.html#cuWordDelete).
 
      - parameter customizationID: The customization ID (GUID) of the custom voice model. You must make the request
        with service credentials created for the instance of the service that owns the custom model.
@@ -1019,7 +1049,8 @@ public class TextToSpeech {
      the customer ID. You must issue the request with credentials for the same instance of the service that was used to
      associate the customer ID with the data.
      You associate a customer ID with data by passing the `X-Watson-Metadata` header with a request that passes the
-     data. For more information about customer IDs and about using this method, see [Information
+     data.
+     **See also:** [Information
      security](https://console.bluemix.net/docs/services/text-to-speech/information-security.html).
 
      - parameter customerID: The customer ID for which all data is to be deleted.

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -113,7 +113,7 @@ public class TextToSpeech {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
@@ -20,6 +20,20 @@ import Foundation
 public struct ToneChatScore: Decodable {
 
     /**
+     The unique, non-localized identifier of the tone for the results. The service returns results only for tones whose
+     scores meet a minimum threshold of 0.5.
+     */
+    public enum ToneID: String {
+        case excited = "excited"
+        case frustrated = "frustrated"
+        case impolite = "impolite"
+        case polite = "polite"
+        case sad = "sad"
+        case satisfied = "satisfied"
+        case sympathetic = "sympathetic"
+    }
+
+    /**
      The score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the
      tone is perceived in the utterance.
      */

--- a/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
@@ -26,9 +26,8 @@ public struct ToneChatScore: Decodable {
     public var score: Double
 
     /**
-     The unique, non-localized identifier of the tone for the results. The service can return results for the following
-     tone IDs: `sad`, `frustrated`, `satisfied`, `excited`, `polite`, `impolite`, and `sympathetic`. The service returns
-     results only for tones whose scores meet a minimum threshold of 0.5.
+     The unique, non-localized identifier of the tone for the results. The service returns results only for tones whose
+     scores meet a minimum threshold of 0.5.
      */
     public var toneID: String
 

--- a/Source/ToneAnalyzerV3/Models/ToneContent.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneContent.swift
@@ -15,7 +15,6 @@
  **/
 
 import Foundation
-import RestKit
 
 /**
  JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -94,7 +94,7 @@ public class ToneAnalyzer {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    private func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -123,6 +123,8 @@ public class ToneAnalyzer {
      set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the
      character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the
      service removes HTML tags and analyzes only the textual content.
+     **See also:** [Using the general-purpose
+     endpoint](https://console.bluemix.net/docs/services/tone-analyzer/using-tone.html#using-the-general-purpose-endpoint).
 
      - parameter toneContent: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON
        input, provide an object of type `ToneInput`.
@@ -220,8 +222,10 @@ public class ToneAnalyzer {
      If you submit more than 50 utterances, the service returns a warning for the overall content and analyzes only the
      first 50 utterances. If you submit a single utterance that contains more than 500 characters, the service returns
      an error for that utterance and does not analyze the utterance. The request fails if all utterances have more than
-     500 characters.
-     Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8.
+     500 characters. Per the JSON specification, the default character encoding for JSON content is effectively always
+     UTF-8.
+     **See also:** [Using the customer-engagement
+     endpoint](https://console.bluemix.net/docs/services/tone-analyzer/using-tone-chat.html#using-the-customer-engagement-endpoint).
 
      - parameter utterances: An array of `Utterance` objects that provides the input content that the service is to
        analyze.

--- a/Source/VisualRecognitionV3/Models/Classifier.swift
+++ b/Source/VisualRecognitionV3/Models/Classifier.swift
@@ -58,7 +58,7 @@ public struct Classifier: Decodable {
     public var coreMlEnabled: Bool?
 
     /**
-     If classifier training has failed, this field may explain why.
+     If classifier training has failed, this field might explain why.
      */
     public var explanation: String?
 

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -43,6 +43,7 @@ public class VisualRecognition {
      - parameter version: The release date of the version of the API to use. Specify the date
        in "YYYY-MM-DD" format.
      */
+    @available(*, deprecated, message: "This method has been deprecated. It will be removed in a future release.")
     public init(apiKey: String, version: String) {
         self.authMethod = APIKeyAuthentication(name: "api_key", key: apiKey, location: .query)
         self.version = version

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -90,7 +90,7 @@ public class VisualRecognition {
      - parameter data: Raw data returned from the service that may represent an error.
      - parameter response: the URL response returned from the service.
      */
-    internal func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
 
         let code = response.statusCode
         do {

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -176,35 +176,32 @@ public class VisualRecognition {
         // construct body
         let multipartFormData = MultipartFormData()
         if let imagesFile = imagesFile {
-            multipartFormData.append(imagesFile, withName: "images_file")
+            do {
+                try multipartFormData.append(file: imagesFile, withName: "images_file")
+            } catch {
+                failure?(error)
+                return
+            }
         }
         if let url = url {
-            guard let urlData = url.data(using: .utf8) else {
-                failure?(RestError.serializationError)
-                return
+            if let urlData = url.data(using: .utf8) {
+                multipartFormData.append(urlData, withName: "url")
             }
-            multipartFormData.append(urlData, withName: "url")
         }
         if let threshold = threshold {
-            guard let thresholdData = "\(threshold)".data(using: .utf8) else {
-                failure?(RestError.serializationError)
-                return
+            if let thresholdData = "\(threshold)".data(using: .utf8) {
+                multipartFormData.append(thresholdData, withName: "threshold")
             }
-            multipartFormData.append(thresholdData, withName: "threshold")
         }
         if let owners = owners {
-            guard let ownersData = owners.joined(separator: ",").data(using: .utf8) else {
-                failure?(RestError.serializationError)
-                return
+            if let ownersData = owners.joined(separator: ",").data(using: .utf8) {
+                multipartFormData.append(ownersData, withName: "owners")
             }
-            multipartFormData.append(ownersData, withName: "owners")
         }
         if let classifierIDs = classifierIDs {
-            guard let classifierIDsData = classifierIDs.joined(separator: ",").data(using: .utf8) else {
-                failure?(RestError.serializationError)
-                return
+            if let classifierIDsData = classifierIDs.joined(separator: ",").data(using: .utf8) {
+                multipartFormData.append(classifierIDsData, withName: "classifier_ids")
             }
-            multipartFormData.append(classifierIDsData, withName: "classifier_ids")
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)
@@ -285,14 +282,17 @@ public class VisualRecognition {
         // construct body
         let multipartFormData = MultipartFormData()
         if let imagesFile = imagesFile {
-            multipartFormData.append(imagesFile, withName: "images_file", mimeType: "application/octet-stream")
-        }
-        if let url = url {
-            guard let urlData = url.data(using: .utf8) else {
-                failure?(RestError.serializationError)
+            do {
+                try multipartFormData.append(file: imagesFile, withName: "images_file")
+            } catch {
+                failure?(error)
                 return
             }
-            multipartFormData.append(urlData, withName: "url")
+        }
+        if let url = url {
+            if let urlData = url.data(using: .utf8) {
+                multipartFormData.append(urlData, withName: "url")
+            }
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)
@@ -366,16 +366,24 @@ public class VisualRecognition {
     {
         // construct body
         let multipartFormData = MultipartFormData()
-        guard let nameData = name.data(using: .utf8) else {
-            failure?(RestError.serializationError)
-            return
+        if let nameData = name.data(using: .utf8) {
+            multipartFormData.append(nameData, withName: "name")
         }
-        multipartFormData.append(nameData, withName: "name")
         positiveExamples.forEach { example in
-            multipartFormData.append(example.examples, withName: example.name + "_positive_examples")
+            do {
+                try multipartFormData.append(file: example.examples, withName: example.name + "_positive_examples")
+            } catch {
+                failure?(error)
+                return
+            }
         }
         if let negativeExamples = negativeExamples {
-            multipartFormData.append(negativeExamples, withName: "negative_examples")
+            do {
+                try multipartFormData.append(file: negativeExamples, withName: "negative_examples")
+            } catch {
+                failure?(error)
+                return
+            }
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)
@@ -561,11 +569,21 @@ public class VisualRecognition {
         let multipartFormData = MultipartFormData()
         if let positiveExamples = positiveExamples {
             positiveExamples.forEach { example in
-                multipartFormData.append(example.examples, withName: example.name + "_positive_examples")
+                do {
+                    try multipartFormData.append(file: example.examples, withName: example.name + "_positive_examples")
+                } catch {
+                    failure?(error)
+                    return
+                }
             }
         }
         if let negativeExamples = negativeExamples {
-            multipartFormData.append(negativeExamples, withName: "negative_examples")
+            do {
+                try multipartFormData.append(file: negativeExamples, withName: "negative_examples")
+            } catch {
+                failure?(error)
+                return
+            }
         }
         guard let body = try? multipartFormData.toData() else {
             failure?(RestError.encodingError)

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -97,7 +97,7 @@ class AssistantTests: XCTestCase {
 
     /** Instantiate Assistant. */
     func instantiateAssistant() {
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.AssistantAPIKey {
             assistant = Assistant(version: version, apiKey: apiKey)
         } else {

--- a/Tests/AssistantV2Tests/AssistantV2Tests.swift
+++ b/Tests/AssistantV2Tests/AssistantV2Tests.swift
@@ -48,7 +48,7 @@ class AssistantV2Tests: XCTestCase {
 
     /** Instantiate Assistant. */
     func instantiateAssistant() {
-        let version = "2018-09-19"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.AssistantAPIKey {
             assistant = Assistant(version: version, apiKey: apiKey)
         } else {

--- a/Tests/ConversationV1Tests/ConversationTests.swift
+++ b/Tests/ConversationV1Tests/ConversationTests.swift
@@ -98,7 +98,7 @@ class ConversationTests: XCTestCase {
     func instantiateConversation() {
         let username = WatsonCredentials.ConversationUsername
         let password = WatsonCredentials.ConversationPassword
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         conversation = Conversation(username: username, password: password, version: version)
         conversation.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         conversation.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/DiscoveryV1Tests/DiscoveryTests.swift
+++ b/Tests/DiscoveryV1Tests/DiscoveryTests.swift
@@ -41,7 +41,7 @@ class DiscoveryTests: XCTestCase {
     }
 
     func instantiateDiscovery() {
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.DiscoveryAPIKey {
             discovery = Discovery(version: version, apiKey: apiKey)
         } else {

--- a/Tests/LanguageTranslatorV3Tests/LanguageTranslatorTests.swift
+++ b/Tests/LanguageTranslatorV3Tests/LanguageTranslatorTests.swift
@@ -52,7 +52,7 @@ class LanguageTranslatorTests: XCTestCase {
 
     /** Instantiate Language Translator. */
     func instantiateLanguageTranslator() {
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.LanguageTranslatorV3APIKey {
             languageTranslator = LanguageTranslator(version: version, apiKey: apiKey)
         } else {

--- a/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
+++ b/Tests/NaturalLanguageUnderstandingV1Tests/NaturalLanguageUnderstandingV1Tests.swift
@@ -59,7 +59,7 @@ class NaturalLanguageUnderstandingTests: XCTestCase {
 
     /** Instantiate Natural Language Understanding instance. */
     func instantiateNaturalLanguageUnderstanding() {
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.NaturalLanguageUnderstandingAPIKey {
             naturalLanguageUnderstanding = NaturalLanguageUnderstanding(version: version, apiKey: apiKey)
         } else {

--- a/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
+++ b/Tests/PersonalityInsightsV3Tests/PersonalityInsightsTests.swift
@@ -49,7 +49,7 @@ class PersonalityInsightsTests: XCTestCase {
     }
 
     func instantiatePersonalityInsights() {
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.PersonalityInsightsV3APIKey {
             personalityInsights = PersonalityInsights(version: version, apiKey: apiKey)
         } else {

--- a/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
+++ b/Tests/ToneAnalyzerV3Tests/ToneAnalyzerTests.swift
@@ -61,7 +61,7 @@ class ToneAnalyzerTests: XCTestCase {
 
     /** Instantiate Tone Analyzer. */
     func instantiateToneAnalyzer() {
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.ToneAnalyzerAPIKey {
             toneAnalyzer = ToneAnalyzer(version: version, apiKey: apiKey)
         } else {

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+CoreMLTests.swift
@@ -36,7 +36,7 @@ class VisualRecognitionCoreMLTests: XCTestCase {
 
     /** Instantiate Visual Recognition */
     func instantiateVisualRecognition() {
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.VisualRecognitionAPIKey {
             visualRecognition = VisualRecognition(version: version, apiKey: apiKey)
         } else {

--- a/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognition+UIImageTests.swift
@@ -47,7 +47,7 @@ class VisualRecognitionUIImageTests: XCTestCase {
     }
 
     func instantiateVisualRecognition() {
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.VisualRecognitionAPIKey {
             visualRecognition = VisualRecognition(version: version, apiKey: apiKey)
         } else {

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -86,7 +86,7 @@ class VisualRecognitionTests: XCTestCase {
 
     /** Instantiate Visual Recognition. */
     func instantiateVisualRecognition() {
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         if let apiKey = WatsonCredentials.VisualRecognitionAPIKey {
             visualRecognition = VisualRecognition(version: version, apiKey: apiKey)
         } else {
@@ -1101,7 +1101,7 @@ class VisualRecognitionTests: XCTestCase {
     /** Invalid API Key. */
     func testAuthenticationError() {
         let apiKey = "let-me-in-let-me-in"
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         visualRecognition = VisualRecognition(apiKey: apiKey, version: version)
         visualRecognition.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         visualRecognition.defaultHeaders["X-Watson-Test"] = "true"

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionWithIAMTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionWithIAMTests.swift
@@ -80,7 +80,7 @@ class VisualRecognitionWithIAMTests: XCTestCase {
         guard let apiKey = WatsonCredentials.VisualRecognitionAPIKey else {
             return
         }
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         let visualRecognition = VisualRecognition(version: version, apiKey: apiKey)
         visualRecognition.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         visualRecognition.defaultHeaders["X-Watson-Test"] = "true"
@@ -128,7 +128,7 @@ class VisualRecognitionWithIAMTests: XCTestCase {
 
         // Pass the access token as the credentials when instantiating the service
 
-        let version = "2018-09-14"
+        let version = "2018-10-10"
         let visualRecognition = VisualRecognition(version: version, accessToken: accessToken)
         visualRecognition.defaultHeaders["X-Watson-Learning-Opt-Out"] = "true"
         visualRecognition.defaultHeaders["X-Watson-Test"] = "true"

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		924EE7DF21505D810048C0E5 /* AssistantV1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6877FA9A2056D4F100383B25 /* AssistantV1.framework */; };
 		924EE7E021505D810048C0E5 /* RestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92048D8F212F7C16004FD822 /* RestKit.framework */; };
 		924EE7EA21505E430048C0E5 /* AssistantV2.h in Headers */ = {isa = PBXBuildFile; fileRef = 924EE77D21505C2C0048C0E5 /* AssistantV2.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9254773A216D4710003C2829 /* QueryLarge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92547738216D470F003C2829 /* QueryLarge.swift */; };
 		9254773B216D4710003C2829 /* SearchStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92547739216D4710003C2829 /* SearchStatus.swift */; };
 		928204C72124BC200013315B /* CreateEventObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928204BA2124BC1B0013315B /* CreateEventObject.swift */; };
 		928204C82124BC200013315B /* MetricAggregationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928204BB2124BC1C0013315B /* MetricAggregationResult.swift */; };
@@ -1287,6 +1288,7 @@
 		924EE77D21505C2C0048C0E5 /* AssistantV2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AssistantV2.h; path = Source/SupportingFiles/AssistantV2.h; sourceTree = "<group>"; };
 		924EE7D321505D7A0048C0E5 /* AssistantV2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AssistantV2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		924EE7E721505D810048C0E5 /* AssistantV2Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AssistantV2Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		92547738216D470F003C2829 /* QueryLarge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryLarge.swift; sourceTree = "<group>"; };
 		92547739216D4710003C2829 /* SearchStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchStatus.swift; sourceTree = "<group>"; };
 		928204BA2124BC1B0013315B /* CreateEventObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateEventObject.swift; sourceTree = "<group>"; };
 		928204BB2124BC1C0013315B /* MetricAggregationResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricAggregationResult.swift; sourceTree = "<group>"; };
@@ -1980,6 +1982,7 @@
 				68AF8ECC206968CC00D552E3 /* QueryEvidence.swift */,
 				68AF8ED4206968CC00D552E3 /* QueryEvidenceEntity.swift */,
 				68AF8EE4206968CC00D552E3 /* QueryFilterType.swift */,
+				92547738216D470F003C2829 /* QueryLarge.swift */,
 				68AF8EC9206968CC00D552E3 /* QueryNoticesResponse.swift */,
 				68AF8EDA206968CC00D552E3 /* QueryNoticesResult.swift */,
 				68AF8EEB206968CC00D552E3 /* QueryPassages.swift */,
@@ -4310,6 +4313,7 @@
 				CADA959820FCD66600B5BD84 /* SourceSchedule.swift in Sources */,
 				CADA959F20FCD66600B5BD84 /* CredentialDetails.swift in Sources */,
 				68AF8F522069690300D552E3 /* ListCollectionFieldsResponse.swift in Sources */,
+				9254773A216D4710003C2829 /* QueryLarge.swift in Sources */,
 				928204D12124BC200013315B /* MetricAggregation.swift in Sources */,
 				92BF69B0213F129A00FE6325 /* Shared.swift in Sources */,
 				68AF8F782069690300D552E3 /* QueryEvidenceEntity.swift in Sources */,

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		924EE7DF21505D810048C0E5 /* AssistantV1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6877FA9A2056D4F100383B25 /* AssistantV1.framework */; };
 		924EE7E021505D810048C0E5 /* RestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92048D8F212F7C16004FD822 /* RestKit.framework */; };
 		924EE7EA21505E430048C0E5 /* AssistantV2.h in Headers */ = {isa = PBXBuildFile; fileRef = 924EE77D21505C2C0048C0E5 /* AssistantV2.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9254773B216D4710003C2829 /* SearchStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92547739216D4710003C2829 /* SearchStatus.swift */; };
 		928204C72124BC200013315B /* CreateEventObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928204BA2124BC1B0013315B /* CreateEventObject.swift */; };
 		928204C82124BC200013315B /* MetricAggregationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928204BB2124BC1C0013315B /* MetricAggregationResult.swift */; };
 		928204C92124BC200013315B /* MetricTokenAggregationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928204BC2124BC1C0013315B /* MetricTokenAggregationResult.swift */; };
@@ -1286,6 +1287,7 @@
 		924EE77D21505C2C0048C0E5 /* AssistantV2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AssistantV2.h; path = Source/SupportingFiles/AssistantV2.h; sourceTree = "<group>"; };
 		924EE7D321505D7A0048C0E5 /* AssistantV2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AssistantV2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		924EE7E721505D810048C0E5 /* AssistantV2Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AssistantV2Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		92547739216D4710003C2829 /* SearchStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchStatus.swift; sourceTree = "<group>"; };
 		928204BA2124BC1B0013315B /* CreateEventObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateEventObject.swift; sourceTree = "<group>"; };
 		928204BB2124BC1C0013315B /* MetricAggregationResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricAggregationResult.swift; sourceTree = "<group>"; };
 		928204BC2124BC1C0013315B /* MetricTokenAggregationResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricTokenAggregationResult.swift; sourceTree = "<group>"; };
@@ -1990,6 +1992,7 @@
 				68AF8ECE206968CC00D552E3 /* QueryResponse.swift */,
 				68AF8ECD206968CC00D552E3 /* QueryResult.swift */,
 				68AE2FD120697C2800330836 /* QueryResultMetadata.swift */,
+				92547739216D4710003C2829 /* SearchStatus.swift */,
 				682CBD2B209051B90049EE9F /* SegmentSettings.swift */,
 				CADA958F20FCD66500B5BD84 /* Source.swift */,
 				CADA959120FCD66500B5BD84 /* SourceOptions.swift */,
@@ -4328,6 +4331,7 @@
 				68AF8F552069690300D552E3 /* IndexCapacity.swift in Sources */,
 				68AF8F572069690300D552E3 /* TestDocument.swift in Sources */,
 				CADA959B20FCD66600B5BD84 /* CredentialsList.swift in Sources */,
+				9254773B216D4710003C2829 /* SearchStatus.swift in Sources */,
 				68AF8F852069690300D552E3 /* XPathPatterns.swift in Sources */,
 				683955072077E613009E1C8A /* Filter.swift in Sources */,
 				68AF8F872069690300D552E3 /* DeleteConfigurationResponse.swift in Sources */,


### PR DESCRIPTION
Regenerated the SDK using:
- API Definitions [5d64e0df520d5620ab7bfd6cae9da917734918d7](https://github.ibm.com/Watson/developer-cloud--api-definitions/tree/5d64e0df520d5620ab7bfd6cae9da917734918d7)
- Watson Swagger Codegen [8dc2602de0f9555623a4721e51c48622a14cfdf5](https://github.ibm.com/MIL/watson-swagger-codegen/tree/8dc2602de0f9555623a4721e51c48622a14cfdf5)

This will be the first release using semantic-release!

Rather than lumping all generated changes into a single generation commit, plus a single "hand-edit" commit, I added and committed code strategically so that I could have a separate commitizen message for each update. This will be necessary moving forward so that the CHANGELOG and release notes are generated properly.