### PR TITLE
Fix uploading of prebuilt frameworks to Github release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -21,7 +21,7 @@
     {
       "path": "@semantic-release/github",
       "assets": [
-        {"path": "IBMWatsonSwiftSDK.zip", "label": "IBMWatsonSwiftSDK.zip"}
+        {"path": "IBMWatsonSDK.framework.zip", "label": "IBMWatsonSDK.framework.zip"}
       ]
     }
   ]


### PR DESCRIPTION
Used the wrong name for the .zip file.