### PR TITLE
Hard-code Starscream Cococapods dependency to 3.0.5

### DIFF
--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -26,7 +26,7 @@ of the audio signal. It continuously returns and retroactively updates a transcr
                             '**/opus_header.c'
 
   s.dependency              'IBMWatsonRestKit', '~> 1.3.0'
-  s.dependency              'Starscream', '~> 3.0'
+  s.dependency              'Starscream', '3.0.5'
   s.vendored_libraries    = 'Source/SupportingFiles/Dependencies/Libraries/*.a'
 
   # The renaming of libogg.a and libopus.a is done to avoid duplicate library name errors


### PR DESCRIPTION
I suspect that the new version of Starscream (3.0.6) is causing Travis to fail to publish
SpeechToText to Cocoapods.
