### PR TITLE
Temporarily comment out some services from Cocoapods deployment

### DIFF
--- a/Scripts/release-to-cocoapods.sh
+++ b/Scripts/release-to-cocoapods.sh
@@ -5,14 +5,14 @@
 set -e
 
 declare -a allPods=(
-  "IBMWatsonAssistantV1.podspec"
-  "IBMWatsonAssistantV2.podspec"
-  "IBMWatsonConversationV1.podspec"
-  "IBMWatsonDiscoveryV1.podspec"
-  "IBMWatsonLanguageTranslatorV3.podspec"
-  "IBMWatsonNaturalLanguageClassifierV1.podspec"
-  "IBMWatsonNaturalLanguageUnderstandingV1.podspec"
-  "IBMWatsonPersonalityInsightsV3.podspec"
+  # "IBMWatsonAssistantV1.podspec"
+  # "IBMWatsonAssistantV2.podspec"
+  # "IBMWatsonConversationV1.podspec"
+  # "IBMWatsonDiscoveryV1.podspec"
+  # "IBMWatsonLanguageTranslatorV3.podspec"
+  # "IBMWatsonNaturalLanguageClassifierV1.podspec"
+  # "IBMWatsonNaturalLanguageUnderstandingV1.podspec"
+  # "IBMWatsonPersonalityInsightsV3.podspec"
   "IBMWatsonSpeechToTextV1.podspec"
   "IBMWatsonTextToSpeechV1.podspec"
   "IBMWatsonToneAnalyzerV3.podspec"


### PR DESCRIPTION
The automated Cocoapods deployment failed on SpeechToTextV1, so the remaining pods need to be
published. The pods already published must be commented out to prevent failing the Travis script and
skipping the remaining deployments.
