### PR TITLE
Error handling

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "daltoniam/Starscream" "3.0.5"
-github "watson-developer-cloud/restkit" "095e7e19e3c7618d52218db4a418752e3526795f"
+github "watson-developer-cloud/restkit" "359a00838a5da64ed44d50d90d82da7e8288b35f"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "daltoniam/Starscream" "3.0.5"
-github "watson-developer-cloud/restkit" "48569b275bc031a904ea9cbd4f7b5643ab288a5b"
+github "watson-developer-cloud/restkit" "64209594199a8710730f6d738b98384ec142101b"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "daltoniam/Starscream" "3.0.5"
-github "watson-developer-cloud/restkit" "64209594199a8710730f6d738b98384ec142101b"
+github "watson-developer-cloud/restkit" "095e7e19e3c7618d52218db4a418752e3526795f"

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -89,7 +89,7 @@ public class Assistant {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -101,10 +101,10 @@ public class Assistant {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -141,12 +141,12 @@ public class Assistant {
         output: OutputData? = nil,
         nodesVisitedDetails: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MessageResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MessageResponse>?, WatsonError?) -> Void)
     {
         // construct body
         let messageRequest = MessageRequest(input: input, alternateIntents: alternateIntents, context: context, entities: entities, intents: intents, output: output)
         guard let body = try? JSONEncoder().encodeIfPresent(messageRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -169,7 +169,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/message"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -210,7 +210,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<WorkspaceCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<WorkspaceCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -294,7 +294,7 @@ public class Assistant {
         learningOptOut: Bool? = nil,
         systemSettings: WorkspaceSystemSettings? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Workspace>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Workspace>?, WatsonError?) -> Void)
     {
         // construct body
         let createWorkspaceRequest = CreateWorkspace(
@@ -309,7 +309,7 @@ public class Assistant {
             learningOptOut: learningOptOut,
             systemSettings: systemSettings)
         guard let body = try? JSONEncoder().encodeIfPresent(createWorkspaceRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -362,7 +362,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<WorkspaceExport>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<WorkspaceExport>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -386,7 +386,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -448,7 +448,7 @@ public class Assistant {
         systemSettings: WorkspaceSystemSettings? = nil,
         append: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Workspace>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Workspace>?, WatsonError?) -> Void)
     {
         // construct body
         let updateWorkspaceRequest = UpdateWorkspace(
@@ -463,7 +463,7 @@ public class Assistant {
             learningOptOut: learningOptOut,
             systemSettings: systemSettings)
         guard let body = try? JSONEncoder().encodeIfPresent(updateWorkspaceRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -486,7 +486,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -517,7 +517,7 @@ public class Assistant {
     public func deleteWorkspace(
         workspaceID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -533,7 +533,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -580,7 +580,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IntentCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IntentCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -620,7 +620,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -660,12 +660,12 @@ public class Assistant {
         description: String? = nil,
         examples: [CreateExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Intent>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Intent>?, WatsonError?) -> Void)
     {
         // construct body
         let createIntentRequest = CreateIntent(intent: intent, description: description, examples: examples)
         guard let body = try? JSONEncoder().encode(createIntentRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -684,7 +684,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -725,7 +725,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IntentExport>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IntentExport>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -749,7 +749,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -791,12 +791,12 @@ public class Assistant {
         newDescription: String? = nil,
         newExamples: [CreateExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Intent>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Intent>?, WatsonError?) -> Void)
     {
         // construct body
         let updateIntentRequest = UpdateIntent(intent: newIntent, description: newDescription, examples: newExamples)
         guard let body = try? JSONEncoder().encode(updateIntentRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -815,7 +815,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -848,7 +848,7 @@ public class Assistant {
         workspaceID: String,
         intent: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -864,7 +864,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -908,7 +908,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ExampleCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ExampleCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -944,7 +944,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -983,12 +983,12 @@ public class Assistant {
         text: String,
         mentions: [Mentions]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, WatsonError?) -> Void)
     {
         // construct body
         let createExampleRequest = CreateExample(text: text, mentions: mentions)
         guard let body = try? JSONEncoder().encode(createExampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1007,7 +1007,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1045,7 +1045,7 @@ public class Assistant {
         text: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1065,7 +1065,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1106,12 +1106,12 @@ public class Assistant {
         newText: String? = nil,
         newMentions: [Mentions]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, WatsonError?) -> Void)
     {
         // construct body
         let updateExampleRequest = UpdateExample(text: newText, mentions: newMentions)
         guard let body = try? JSONEncoder().encode(updateExampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1130,7 +1130,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1165,7 +1165,7 @@ public class Assistant {
         intent: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1181,7 +1181,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1223,7 +1223,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<CounterexampleCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<CounterexampleCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1259,7 +1259,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1295,12 +1295,12 @@ public class Assistant {
         workspaceID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, WatsonError?) -> Void)
     {
         // construct body
         let createCounterexampleRequest = CreateCounterexample(text: text)
         guard let body = try? JSONEncoder().encode(createCounterexampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1319,7 +1319,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1355,7 +1355,7 @@ public class Assistant {
         text: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1375,7 +1375,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1409,12 +1409,12 @@ public class Assistant {
         text: String,
         newText: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, WatsonError?) -> Void)
     {
         // construct body
         let updateCounterexampleRequest = UpdateCounterexample(text: newText)
         guard let body = try? JSONEncoder().encode(updateCounterexampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1433,7 +1433,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1466,7 +1466,7 @@ public class Assistant {
         workspaceID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1482,7 +1482,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1529,7 +1529,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1569,7 +1569,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1613,12 +1613,12 @@ public class Assistant {
         values: [CreateValue]? = nil,
         fuzzyMatch: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Entity>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Entity>?, WatsonError?) -> Void)
     {
         // construct body
         let createEntityRequest = CreateEntity(entity: entity, description: description, metadata: metadata, values: values, fuzzyMatch: fuzzyMatch)
         guard let body = try? JSONEncoder().encode(createEntityRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1637,7 +1637,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1678,7 +1678,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityExport>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityExport>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1702,7 +1702,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1749,12 +1749,12 @@ public class Assistant {
         newFuzzyMatch: Bool? = nil,
         newValues: [CreateValue]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Entity>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Entity>?, WatsonError?) -> Void)
     {
         // construct body
         let updateEntityRequest = UpdateEntity(entity: newEntity, description: newDescription, metadata: newMetadata, fuzzyMatch: newFuzzyMatch, values: newValues)
         guard let body = try? JSONEncoder().encode(updateEntityRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1773,7 +1773,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1806,7 +1806,7 @@ public class Assistant {
         workspaceID: String,
         entity: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1822,7 +1822,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1862,7 +1862,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityMentionCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityMentionCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1886,7 +1886,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/mentions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1934,7 +1934,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ValueCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ValueCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1974,7 +1974,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2026,12 +2026,12 @@ public class Assistant {
         patterns: [String]? = nil,
         valueType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Value>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Value>?, WatsonError?) -> Void)
     {
         // construct body
         let createValueRequest = CreateValue(value: value, metadata: metadata, synonyms: synonyms, patterns: patterns, valueType: valueType)
         guard let body = try? JSONEncoder().encode(createValueRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2050,7 +2050,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2092,7 +2092,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ValueExport>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ValueExport>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2116,7 +2116,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2171,12 +2171,12 @@ public class Assistant {
         newSynonyms: [String]? = nil,
         newPatterns: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Value>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Value>?, WatsonError?) -> Void)
     {
         // construct body
         let updateValueRequest = UpdateValue(value: newValue, metadata: newMetadata, valueType: newType, synonyms: newSynonyms, patterns: newPatterns)
         guard let body = try? JSONEncoder().encode(updateValueRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2195,7 +2195,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2230,7 +2230,7 @@ public class Assistant {
         entity: String,
         value: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2246,7 +2246,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2292,7 +2292,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SynonymCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SynonymCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2328,7 +2328,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2367,12 +2367,12 @@ public class Assistant {
         value: String,
         synonym: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, WatsonError?) -> Void)
     {
         // construct body
         let createSynonymRequest = CreateSynonym(synonym: synonym)
         guard let body = try? JSONEncoder().encode(createSynonymRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2391,7 +2391,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2431,7 +2431,7 @@ public class Assistant {
         synonym: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2451,7 +2451,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2492,12 +2492,12 @@ public class Assistant {
         synonym: String,
         newSynonym: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, WatsonError?) -> Void)
     {
         // construct body
         let updateSynonymRequest = UpdateSynonym(synonym: newSynonym)
         guard let body = try? JSONEncoder().encode(updateSynonymRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2516,7 +2516,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2553,7 +2553,7 @@ public class Assistant {
         value: String,
         synonym: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2569,7 +2569,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2611,7 +2611,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNodeCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNodeCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2647,7 +2647,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2721,7 +2721,7 @@ public class Assistant {
         digressOutSlots: String? = nil,
         userLabel: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, WatsonError?) -> Void)
     {
         // construct body
         let createDialogNodeRequest = CreateDialogNode(
@@ -2744,7 +2744,7 @@ public class Assistant {
             digressOutSlots: digressOutSlots,
             userLabel: userLabel)
         guard let body = try? JSONEncoder().encode(createDialogNodeRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2763,7 +2763,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2799,7 +2799,7 @@ public class Assistant {
         dialogNode: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2819,7 +2819,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2896,7 +2896,7 @@ public class Assistant {
         newDigressOutSlots: String? = nil,
         newUserLabel: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, WatsonError?) -> Void)
     {
         // construct body
         let updateDialogNodeRequest = UpdateDialogNode(
@@ -2919,7 +2919,7 @@ public class Assistant {
             digressOutSlots: newDigressOutSlots,
             userLabel: newUserLabel)
         guard let body = try? JSONEncoder().encode(updateDialogNodeRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2938,7 +2938,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2971,7 +2971,7 @@ public class Assistant {
         workspaceID: String,
         dialogNode: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2987,7 +2987,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3029,7 +3029,7 @@ public class Assistant {
         pageLimit: Int? = nil,
         cursor: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3061,7 +3061,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/logs"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3102,7 +3102,7 @@ public class Assistant {
         pageLimit: Int? = nil,
         cursor: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3159,7 +3159,7 @@ public class Assistant {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -145,7 +145,7 @@ public class Assistant {
         // construct body
         let messageRequest = MessageRequest(input: input, alternateIntents: alternateIntents, context: context, entities: entities, intents: intents, output: output)
         guard let body = try? JSONEncoder().encodeIfPresent(messageRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -168,7 +168,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/message"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -308,7 +308,7 @@ public class Assistant {
             learningOptOut: learningOptOut,
             systemSettings: systemSettings)
         guard let body = try? JSONEncoder().encodeIfPresent(createWorkspaceRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -385,7 +385,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -462,7 +462,7 @@ public class Assistant {
             learningOptOut: learningOptOut,
             systemSettings: systemSettings)
         guard let body = try? JSONEncoder().encodeIfPresent(updateWorkspaceRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -485,7 +485,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -532,7 +532,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -619,7 +619,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -664,7 +664,7 @@ public class Assistant {
         // construct body
         let createIntentRequest = CreateIntent(intent: intent, description: description, examples: examples)
         guard let body = try? JSONEncoder().encode(createIntentRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -683,7 +683,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -748,7 +748,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -795,7 +795,7 @@ public class Assistant {
         // construct body
         let updateIntentRequest = UpdateIntent(intent: newIntent, description: newDescription, examples: newExamples)
         guard let body = try? JSONEncoder().encode(updateIntentRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -814,7 +814,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -863,7 +863,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -943,7 +943,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -987,7 +987,7 @@ public class Assistant {
         // construct body
         let createExampleRequest = CreateExample(text: text, mentions: mentions)
         guard let body = try? JSONEncoder().encode(createExampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1006,7 +1006,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1064,7 +1064,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1110,7 +1110,7 @@ public class Assistant {
         // construct body
         let updateExampleRequest = UpdateExample(text: newText, mentions: newMentions)
         guard let body = try? JSONEncoder().encode(updateExampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1129,7 +1129,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1180,7 +1180,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1258,7 +1258,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1299,7 +1299,7 @@ public class Assistant {
         // construct body
         let createCounterexampleRequest = CreateCounterexample(text: text)
         guard let body = try? JSONEncoder().encode(createCounterexampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1318,7 +1318,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1374,7 +1374,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1413,7 +1413,7 @@ public class Assistant {
         // construct body
         let updateCounterexampleRequest = UpdateCounterexample(text: newText)
         guard let body = try? JSONEncoder().encode(updateCounterexampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1432,7 +1432,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1481,7 +1481,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1568,7 +1568,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1617,7 +1617,7 @@ public class Assistant {
         // construct body
         let createEntityRequest = CreateEntity(entity: entity, description: description, metadata: metadata, values: values, fuzzyMatch: fuzzyMatch)
         guard let body = try? JSONEncoder().encode(createEntityRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1636,7 +1636,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1701,7 +1701,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1753,7 +1753,7 @@ public class Assistant {
         // construct body
         let updateEntityRequest = UpdateEntity(entity: newEntity, description: newDescription, metadata: newMetadata, fuzzyMatch: newFuzzyMatch, values: newValues)
         guard let body = try? JSONEncoder().encode(updateEntityRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1772,7 +1772,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1821,7 +1821,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1885,7 +1885,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/mentions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1973,7 +1973,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2030,7 +2030,7 @@ public class Assistant {
         // construct body
         let createValueRequest = CreateValue(value: value, metadata: metadata, synonyms: synonyms, patterns: patterns, valueType: valueType)
         guard let body = try? JSONEncoder().encode(createValueRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2049,7 +2049,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2115,7 +2115,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2175,7 +2175,7 @@ public class Assistant {
         // construct body
         let updateValueRequest = UpdateValue(value: newValue, metadata: newMetadata, valueType: newType, synonyms: newSynonyms, patterns: newPatterns)
         guard let body = try? JSONEncoder().encode(updateValueRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2194,7 +2194,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2245,7 +2245,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2327,7 +2327,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2371,7 +2371,7 @@ public class Assistant {
         // construct body
         let createSynonymRequest = CreateSynonym(synonym: synonym)
         guard let body = try? JSONEncoder().encode(createSynonymRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2390,7 +2390,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2450,7 +2450,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2496,7 +2496,7 @@ public class Assistant {
         // construct body
         let updateSynonymRequest = UpdateSynonym(synonym: newSynonym)
         guard let body = try? JSONEncoder().encode(updateSynonymRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2515,7 +2515,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2568,7 +2568,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2646,7 +2646,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2743,7 +2743,7 @@ public class Assistant {
             digressOutSlots: digressOutSlots,
             userLabel: userLabel)
         guard let body = try? JSONEncoder().encode(createDialogNodeRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2762,7 +2762,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2818,7 +2818,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2918,7 +2918,7 @@ public class Assistant {
             digressOutSlots: newDigressOutSlots,
             userLabel: newUserLabel)
         guard let body = try? JSONEncoder().encode(updateDialogNodeRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2937,7 +2937,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2986,7 +2986,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3060,7 +3060,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/logs"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -141,7 +141,7 @@ public class Assistant {
         output: OutputData? = nil,
         nodesVisitedDetails: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MessageResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MessageResponse>?, RestError?) -> Void)
     {
         // construct body
         let messageRequest = MessageRequest(input: input, alternateIntents: alternateIntents, context: context, entities: entities, intents: intents, output: output)
@@ -210,7 +210,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<WorkspaceCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<WorkspaceCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -294,7 +294,7 @@ public class Assistant {
         learningOptOut: Bool? = nil,
         systemSettings: WorkspaceSystemSettings? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Workspace>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Workspace>?, RestError?) -> Void)
     {
         // construct body
         let createWorkspaceRequest = CreateWorkspace(
@@ -362,7 +362,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<WorkspaceExport>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<WorkspaceExport>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -448,7 +448,7 @@ public class Assistant {
         systemSettings: WorkspaceSystemSettings? = nil,
         append: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Workspace>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Workspace>?, RestError?) -> Void)
     {
         // construct body
         let updateWorkspaceRequest = UpdateWorkspace(
@@ -517,7 +517,7 @@ public class Assistant {
     public func deleteWorkspace(
         workspaceID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -580,7 +580,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IntentCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IntentCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -660,7 +660,7 @@ public class Assistant {
         description: String? = nil,
         examples: [CreateExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Intent>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Intent>?, RestError?) -> Void)
     {
         // construct body
         let createIntentRequest = CreateIntent(intent: intent, description: description, examples: examples)
@@ -725,7 +725,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IntentExport>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IntentExport>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -791,7 +791,7 @@ public class Assistant {
         newDescription: String? = nil,
         newExamples: [CreateExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Intent>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Intent>?, RestError?) -> Void)
     {
         // construct body
         let updateIntentRequest = UpdateIntent(intent: newIntent, description: newDescription, examples: newExamples)
@@ -848,7 +848,7 @@ public class Assistant {
         workspaceID: String,
         intent: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -908,7 +908,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ExampleCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ExampleCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -983,7 +983,7 @@ public class Assistant {
         text: String,
         mentions: [Mentions]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
     {
         // construct body
         let createExampleRequest = CreateExample(text: text, mentions: mentions)
@@ -1045,7 +1045,7 @@ public class Assistant {
         text: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1106,7 +1106,7 @@ public class Assistant {
         newText: String? = nil,
         newMentions: [Mentions]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
     {
         // construct body
         let updateExampleRequest = UpdateExample(text: newText, mentions: newMentions)
@@ -1165,7 +1165,7 @@ public class Assistant {
         intent: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1223,7 +1223,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<CounterexampleCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<CounterexampleCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1295,7 +1295,7 @@ public class Assistant {
         workspaceID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
     {
         // construct body
         let createCounterexampleRequest = CreateCounterexample(text: text)
@@ -1355,7 +1355,7 @@ public class Assistant {
         text: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1409,7 +1409,7 @@ public class Assistant {
         text: String,
         newText: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
     {
         // construct body
         let updateCounterexampleRequest = UpdateCounterexample(text: newText)
@@ -1466,7 +1466,7 @@ public class Assistant {
         workspaceID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1529,7 +1529,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1613,7 +1613,7 @@ public class Assistant {
         values: [CreateValue]? = nil,
         fuzzyMatch: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Entity>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Entity>?, RestError?) -> Void)
     {
         // construct body
         let createEntityRequest = CreateEntity(entity: entity, description: description, metadata: metadata, values: values, fuzzyMatch: fuzzyMatch)
@@ -1678,7 +1678,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityExport>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityExport>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1749,7 +1749,7 @@ public class Assistant {
         newFuzzyMatch: Bool? = nil,
         newValues: [CreateValue]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Entity>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Entity>?, RestError?) -> Void)
     {
         // construct body
         let updateEntityRequest = UpdateEntity(entity: newEntity, description: newDescription, metadata: newMetadata, fuzzyMatch: newFuzzyMatch, values: newValues)
@@ -1806,7 +1806,7 @@ public class Assistant {
         workspaceID: String,
         entity: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1862,7 +1862,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityMentionCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityMentionCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1934,7 +1934,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ValueCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ValueCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2026,7 +2026,7 @@ public class Assistant {
         patterns: [String]? = nil,
         valueType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Value>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Value>?, RestError?) -> Void)
     {
         // construct body
         let createValueRequest = CreateValue(value: value, metadata: metadata, synonyms: synonyms, patterns: patterns, valueType: valueType)
@@ -2092,7 +2092,7 @@ public class Assistant {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ValueExport>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ValueExport>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2171,7 +2171,7 @@ public class Assistant {
         newSynonyms: [String]? = nil,
         newPatterns: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Value>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Value>?, RestError?) -> Void)
     {
         // construct body
         let updateValueRequest = UpdateValue(value: newValue, metadata: newMetadata, valueType: newType, synonyms: newSynonyms, patterns: newPatterns)
@@ -2230,7 +2230,7 @@ public class Assistant {
         entity: String,
         value: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2292,7 +2292,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SynonymCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SynonymCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2367,7 +2367,7 @@ public class Assistant {
         value: String,
         synonym: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
     {
         // construct body
         let createSynonymRequest = CreateSynonym(synonym: synonym)
@@ -2431,7 +2431,7 @@ public class Assistant {
         synonym: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2492,7 +2492,7 @@ public class Assistant {
         synonym: String,
         newSynonym: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
     {
         // construct body
         let updateSynonymRequest = UpdateSynonym(synonym: newSynonym)
@@ -2553,7 +2553,7 @@ public class Assistant {
         value: String,
         synonym: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2611,7 +2611,7 @@ public class Assistant {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNodeCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNodeCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2721,7 +2721,7 @@ public class Assistant {
         digressOutSlots: String? = nil,
         userLabel: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
     {
         // construct body
         let createDialogNodeRequest = CreateDialogNode(
@@ -2799,7 +2799,7 @@ public class Assistant {
         dialogNode: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2896,7 +2896,7 @@ public class Assistant {
         newDigressOutSlots: String? = nil,
         newUserLabel: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
     {
         // construct body
         let updateDialogNodeRequest = UpdateDialogNode(
@@ -2971,7 +2971,7 @@ public class Assistant {
         workspaceID: String,
         dialogNode: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3029,7 +3029,7 @@ public class Assistant {
         pageLimit: Int? = nil,
         cursor: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3102,7 +3102,7 @@ public class Assistant {
         pageLimit: Int? = nil,
         cursor: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3159,7 +3159,7 @@ public class Assistant {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -93,15 +93,16 @@ public class Assistant {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -168,7 +169,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/message"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -385,7 +386,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -485,7 +486,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -532,7 +533,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -619,7 +620,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -683,7 +684,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -748,7 +749,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -814,7 +815,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -863,7 +864,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -943,7 +944,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1006,7 +1007,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1064,7 +1065,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1129,7 +1130,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1180,7 +1181,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1258,7 +1259,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1318,7 +1319,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1374,7 +1375,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1432,7 +1433,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1481,7 +1482,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1568,7 +1569,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1636,7 +1637,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1701,7 +1702,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1772,7 +1773,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1821,7 +1822,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1885,7 +1886,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/mentions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1973,7 +1974,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2049,7 +2050,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2115,7 +2116,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2194,7 +2195,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2245,7 +2246,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2327,7 +2328,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2390,7 +2391,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2450,7 +2451,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2515,7 +2516,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2568,7 +2569,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2646,7 +2647,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2762,7 +2763,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2818,7 +2819,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2937,7 +2938,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2986,7 +2987,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3060,7 +3061,7 @@ public class Assistant {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/logs"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -83,24 +83,27 @@ public class Assistant {
     }
 
     /**
-     If the response or data represents an error returned by the Watson Assistant service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Watson Assistant service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -93,15 +93,16 @@ public class Assistant {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -140,7 +141,7 @@ public class Assistant {
         // construct REST request
         let path = "/v2/assistants/\(assistantID)/sessions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -190,7 +191,7 @@ public class Assistant {
         // construct REST request
         let path = "/v2/assistants/\(assistantID)/sessions/\(sessionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -252,7 +253,7 @@ public class Assistant {
         // construct REST request
         let path = "/v2/assistants/\(assistantID)/sessions/\(sessionID)/message"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -140,7 +140,7 @@ public class Assistant {
         // construct REST request
         let path = "/v2/assistants/\(assistantID)/sessions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -190,7 +190,7 @@ public class Assistant {
         // construct REST request
         let path = "/v2/assistants/\(assistantID)/sessions/\(sessionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -233,7 +233,7 @@ public class Assistant {
         // construct body
         let messageRequest = MessageRequest(input: input, context: context)
         guard let body = try? JSONEncoder().encodeIfPresent(messageRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -252,7 +252,7 @@ public class Assistant {
         // construct REST request
         let path = "/v2/assistants/\(assistantID)/sessions/\(sessionID)/message"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -124,7 +124,7 @@ public class Assistant {
     public func createSession(
         assistantID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SessionResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SessionResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -175,7 +175,7 @@ public class Assistant {
         assistantID: String,
         sessionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -229,7 +229,7 @@ public class Assistant {
         input: MessageInput? = nil,
         context: MessageContext? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MessageResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MessageResponse>?, RestError?) -> Void)
     {
         // construct body
         let messageRequest = MessageRequest(input: input, context: context)

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -89,7 +89,7 @@ public class Assistant {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -101,10 +101,10 @@ public class Assistant {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -124,7 +124,7 @@ public class Assistant {
     public func createSession(
         assistantID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SessionResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SessionResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -141,7 +141,7 @@ public class Assistant {
         // construct REST request
         let path = "/v2/assistants/\(assistantID)/sessions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -175,7 +175,7 @@ public class Assistant {
         assistantID: String,
         sessionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -191,7 +191,7 @@ public class Assistant {
         // construct REST request
         let path = "/v2/assistants/\(assistantID)/sessions/\(sessionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -229,12 +229,12 @@ public class Assistant {
         input: MessageInput? = nil,
         context: MessageContext? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MessageResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MessageResponse>?, WatsonError?) -> Void)
     {
         // construct body
         let messageRequest = MessageRequest(input: input, context: context)
         guard let body = try? JSONEncoder().encodeIfPresent(messageRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -253,7 +253,7 @@ public class Assistant {
         // construct REST request
         let path = "/v2/assistants/\(assistantID)/sessions/\(sessionID)/message"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -83,24 +83,27 @@ public class Assistant {
     }
 
     /**
-     If the response or data represents an error returned by the Watson Assistant service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Watson Assistant service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -142,7 +142,7 @@ public class Conversation {
         output: OutputData? = nil,
         nodesVisitedDetails: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MessageResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MessageResponse>?, RestError?) -> Void)
     {
         // construct body
         let messageRequest = MessageRequest(input: input, alternateIntents: alternateIntents, context: context, entities: entities, intents: intents, output: output)
@@ -211,7 +211,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<WorkspaceCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<WorkspaceCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -295,7 +295,7 @@ public class Conversation {
         learningOptOut: Bool? = nil,
         systemSettings: WorkspaceSystemSettings? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Workspace>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Workspace>?, RestError?) -> Void)
     {
         // construct body
         let createWorkspaceRequest = CreateWorkspace(
@@ -363,7 +363,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<WorkspaceExport>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<WorkspaceExport>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -449,7 +449,7 @@ public class Conversation {
         systemSettings: WorkspaceSystemSettings? = nil,
         append: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Workspace>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Workspace>?, RestError?) -> Void)
     {
         // construct body
         let updateWorkspaceRequest = UpdateWorkspace(
@@ -518,7 +518,7 @@ public class Conversation {
     public func deleteWorkspace(
         workspaceID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -581,7 +581,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IntentCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IntentCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -661,7 +661,7 @@ public class Conversation {
         description: String? = nil,
         examples: [CreateExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Intent>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Intent>?, RestError?) -> Void)
     {
         // construct body
         let createIntentRequest = CreateIntent(intent: intent, description: description, examples: examples)
@@ -726,7 +726,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IntentExport>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IntentExport>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -792,7 +792,7 @@ public class Conversation {
         newDescription: String? = nil,
         newExamples: [CreateExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Intent>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Intent>?, RestError?) -> Void)
     {
         // construct body
         let updateIntentRequest = UpdateIntent(intent: newIntent, description: newDescription, examples: newExamples)
@@ -849,7 +849,7 @@ public class Conversation {
         workspaceID: String,
         intent: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -909,7 +909,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ExampleCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ExampleCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -984,7 +984,7 @@ public class Conversation {
         text: String,
         mentions: [Mentions]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
     {
         // construct body
         let createExampleRequest = CreateExample(text: text, mentions: mentions)
@@ -1046,7 +1046,7 @@ public class Conversation {
         text: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1107,7 +1107,7 @@ public class Conversation {
         newText: String? = nil,
         newMentions: [Mentions]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
     {
         // construct body
         let updateExampleRequest = UpdateExample(text: newText, mentions: newMentions)
@@ -1166,7 +1166,7 @@ public class Conversation {
         intent: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1224,7 +1224,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<CounterexampleCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<CounterexampleCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1296,7 +1296,7 @@ public class Conversation {
         workspaceID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
     {
         // construct body
         let createCounterexampleRequest = CreateCounterexample(text: text)
@@ -1356,7 +1356,7 @@ public class Conversation {
         text: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1410,7 +1410,7 @@ public class Conversation {
         text: String,
         newText: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
     {
         // construct body
         let updateCounterexampleRequest = UpdateCounterexample(text: newText)
@@ -1467,7 +1467,7 @@ public class Conversation {
         workspaceID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1530,7 +1530,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1614,7 +1614,7 @@ public class Conversation {
         values: [CreateValue]? = nil,
         fuzzyMatch: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Entity>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Entity>?, RestError?) -> Void)
     {
         // construct body
         let createEntityRequest = CreateEntity(entity: entity, description: description, metadata: metadata, values: values, fuzzyMatch: fuzzyMatch)
@@ -1679,7 +1679,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityExport>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityExport>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1750,7 +1750,7 @@ public class Conversation {
         newFuzzyMatch: Bool? = nil,
         newValues: [CreateValue]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Entity>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Entity>?, RestError?) -> Void)
     {
         // construct body
         let updateEntityRequest = UpdateEntity(entity: newEntity, description: newDescription, metadata: newMetadata, fuzzyMatch: newFuzzyMatch, values: newValues)
@@ -1807,7 +1807,7 @@ public class Conversation {
         workspaceID: String,
         entity: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1863,7 +1863,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityMentionCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityMentionCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1935,7 +1935,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ValueCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ValueCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2027,7 +2027,7 @@ public class Conversation {
         patterns: [String]? = nil,
         valueType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Value>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Value>?, RestError?) -> Void)
     {
         // construct body
         let createValueRequest = CreateValue(value: value, metadata: metadata, synonyms: synonyms, patterns: patterns, valueType: valueType)
@@ -2093,7 +2093,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ValueExport>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ValueExport>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2172,7 +2172,7 @@ public class Conversation {
         newSynonyms: [String]? = nil,
         newPatterns: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Value>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Value>?, RestError?) -> Void)
     {
         // construct body
         let updateValueRequest = UpdateValue(value: newValue, metadata: newMetadata, valueType: newType, synonyms: newSynonyms, patterns: newPatterns)
@@ -2231,7 +2231,7 @@ public class Conversation {
         entity: String,
         value: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2293,7 +2293,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SynonymCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SynonymCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2368,7 +2368,7 @@ public class Conversation {
         value: String,
         synonym: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
     {
         // construct body
         let createSynonymRequest = CreateSynonym(synonym: synonym)
@@ -2432,7 +2432,7 @@ public class Conversation {
         synonym: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2493,7 +2493,7 @@ public class Conversation {
         synonym: String,
         newSynonym: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
     {
         // construct body
         let updateSynonymRequest = UpdateSynonym(synonym: newSynonym)
@@ -2554,7 +2554,7 @@ public class Conversation {
         value: String,
         synonym: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2612,7 +2612,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNodeCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNodeCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2722,7 +2722,7 @@ public class Conversation {
         digressOutSlots: String? = nil,
         userLabel: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
     {
         // construct body
         let createDialogNodeRequest = CreateDialogNode(
@@ -2800,7 +2800,7 @@ public class Conversation {
         dialogNode: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2897,7 +2897,7 @@ public class Conversation {
         newDigressOutSlots: String? = nil,
         newUserLabel: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
     {
         // construct body
         let updateDialogNodeRequest = UpdateDialogNode(
@@ -2972,7 +2972,7 @@ public class Conversation {
         workspaceID: String,
         dialogNode: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3030,7 +3030,7 @@ public class Conversation {
         pageLimit: Int? = nil,
         cursor: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3103,7 +3103,7 @@ public class Conversation {
         pageLimit: Int? = nil,
         cursor: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogCollection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3160,7 +3160,7 @@ public class Conversation {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -84,24 +84,27 @@ public class Conversation {
     }
 
     /**
-     If the response or data represents an error returned by the Conversation service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Conversation service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -146,7 +146,7 @@ public class Conversation {
         // construct body
         let messageRequest = MessageRequest(input: input, alternateIntents: alternateIntents, context: context, entities: entities, intents: intents, output: output)
         guard let body = try? JSONEncoder().encodeIfPresent(messageRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -169,7 +169,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/message"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -309,7 +309,7 @@ public class Conversation {
             learningOptOut: learningOptOut,
             systemSettings: systemSettings)
         guard let body = try? JSONEncoder().encodeIfPresent(createWorkspaceRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -386,7 +386,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -463,7 +463,7 @@ public class Conversation {
             learningOptOut: learningOptOut,
             systemSettings: systemSettings)
         guard let body = try? JSONEncoder().encodeIfPresent(updateWorkspaceRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -486,7 +486,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -533,7 +533,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -620,7 +620,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -665,7 +665,7 @@ public class Conversation {
         // construct body
         let createIntentRequest = CreateIntent(intent: intent, description: description, examples: examples)
         guard let body = try? JSONEncoder().encode(createIntentRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -684,7 +684,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -749,7 +749,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -796,7 +796,7 @@ public class Conversation {
         // construct body
         let updateIntentRequest = UpdateIntent(intent: newIntent, description: newDescription, examples: newExamples)
         guard let body = try? JSONEncoder().encode(updateIntentRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -815,7 +815,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -864,7 +864,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -944,7 +944,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -988,7 +988,7 @@ public class Conversation {
         // construct body
         let createExampleRequest = CreateExample(text: text, mentions: mentions)
         guard let body = try? JSONEncoder().encode(createExampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1007,7 +1007,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1065,7 +1065,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1111,7 +1111,7 @@ public class Conversation {
         // construct body
         let updateExampleRequest = UpdateExample(text: newText, mentions: newMentions)
         guard let body = try? JSONEncoder().encode(updateExampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1130,7 +1130,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1181,7 +1181,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1259,7 +1259,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1300,7 +1300,7 @@ public class Conversation {
         // construct body
         let createCounterexampleRequest = CreateCounterexample(text: text)
         guard let body = try? JSONEncoder().encode(createCounterexampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1319,7 +1319,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1375,7 +1375,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1414,7 +1414,7 @@ public class Conversation {
         // construct body
         let updateCounterexampleRequest = UpdateCounterexample(text: newText)
         guard let body = try? JSONEncoder().encode(updateCounterexampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1433,7 +1433,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1482,7 +1482,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1569,7 +1569,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1618,7 +1618,7 @@ public class Conversation {
         // construct body
         let createEntityRequest = CreateEntity(entity: entity, description: description, metadata: metadata, values: values, fuzzyMatch: fuzzyMatch)
         guard let body = try? JSONEncoder().encode(createEntityRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1637,7 +1637,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1702,7 +1702,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1754,7 +1754,7 @@ public class Conversation {
         // construct body
         let updateEntityRequest = UpdateEntity(entity: newEntity, description: newDescription, metadata: newMetadata, fuzzyMatch: newFuzzyMatch, values: newValues)
         guard let body = try? JSONEncoder().encode(updateEntityRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1773,7 +1773,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1822,7 +1822,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1886,7 +1886,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/mentions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1974,7 +1974,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2031,7 +2031,7 @@ public class Conversation {
         // construct body
         let createValueRequest = CreateValue(value: value, metadata: metadata, synonyms: synonyms, patterns: patterns, valueType: valueType)
         guard let body = try? JSONEncoder().encode(createValueRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2050,7 +2050,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2116,7 +2116,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2176,7 +2176,7 @@ public class Conversation {
         // construct body
         let updateValueRequest = UpdateValue(value: newValue, metadata: newMetadata, valueType: newType, synonyms: newSynonyms, patterns: newPatterns)
         guard let body = try? JSONEncoder().encode(updateValueRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2195,7 +2195,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2246,7 +2246,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2328,7 +2328,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2372,7 +2372,7 @@ public class Conversation {
         // construct body
         let createSynonymRequest = CreateSynonym(synonym: synonym)
         guard let body = try? JSONEncoder().encode(createSynonymRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2391,7 +2391,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2451,7 +2451,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2497,7 +2497,7 @@ public class Conversation {
         // construct body
         let updateSynonymRequest = UpdateSynonym(synonym: newSynonym)
         guard let body = try? JSONEncoder().encode(updateSynonymRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2516,7 +2516,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2569,7 +2569,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2647,7 +2647,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2744,7 +2744,7 @@ public class Conversation {
             digressOutSlots: digressOutSlots,
             userLabel: userLabel)
         guard let body = try? JSONEncoder().encode(createDialogNodeRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2763,7 +2763,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2819,7 +2819,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2919,7 +2919,7 @@ public class Conversation {
             digressOutSlots: newDigressOutSlots,
             userLabel: newUserLabel)
         guard let body = try? JSONEncoder().encode(updateDialogNodeRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2938,7 +2938,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2987,7 +2987,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3061,7 +3061,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/logs"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -90,7 +90,7 @@ public class Conversation {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -102,10 +102,10 @@ public class Conversation {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -142,12 +142,12 @@ public class Conversation {
         output: OutputData? = nil,
         nodesVisitedDetails: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MessageResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MessageResponse>?, WatsonError?) -> Void)
     {
         // construct body
         let messageRequest = MessageRequest(input: input, alternateIntents: alternateIntents, context: context, entities: entities, intents: intents, output: output)
         guard let body = try? JSONEncoder().encodeIfPresent(messageRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -170,7 +170,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/message"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -211,7 +211,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<WorkspaceCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<WorkspaceCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -295,7 +295,7 @@ public class Conversation {
         learningOptOut: Bool? = nil,
         systemSettings: WorkspaceSystemSettings? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Workspace>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Workspace>?, WatsonError?) -> Void)
     {
         // construct body
         let createWorkspaceRequest = CreateWorkspace(
@@ -310,7 +310,7 @@ public class Conversation {
             learningOptOut: learningOptOut,
             systemSettings: systemSettings)
         guard let body = try? JSONEncoder().encodeIfPresent(createWorkspaceRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -363,7 +363,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<WorkspaceExport>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<WorkspaceExport>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -387,7 +387,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -449,7 +449,7 @@ public class Conversation {
         systemSettings: WorkspaceSystemSettings? = nil,
         append: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Workspace>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Workspace>?, WatsonError?) -> Void)
     {
         // construct body
         let updateWorkspaceRequest = UpdateWorkspace(
@@ -464,7 +464,7 @@ public class Conversation {
             learningOptOut: learningOptOut,
             systemSettings: systemSettings)
         guard let body = try? JSONEncoder().encodeIfPresent(updateWorkspaceRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -487,7 +487,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -518,7 +518,7 @@ public class Conversation {
     public func deleteWorkspace(
         workspaceID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -534,7 +534,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -581,7 +581,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IntentCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IntentCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -621,7 +621,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -661,12 +661,12 @@ public class Conversation {
         description: String? = nil,
         examples: [CreateExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Intent>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Intent>?, WatsonError?) -> Void)
     {
         // construct body
         let createIntentRequest = CreateIntent(intent: intent, description: description, examples: examples)
         guard let body = try? JSONEncoder().encode(createIntentRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -685,7 +685,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -726,7 +726,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IntentExport>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IntentExport>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -750,7 +750,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -792,12 +792,12 @@ public class Conversation {
         newDescription: String? = nil,
         newExamples: [CreateExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Intent>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Intent>?, WatsonError?) -> Void)
     {
         // construct body
         let updateIntentRequest = UpdateIntent(intent: newIntent, description: newDescription, examples: newExamples)
         guard let body = try? JSONEncoder().encode(updateIntentRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -816,7 +816,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -849,7 +849,7 @@ public class Conversation {
         workspaceID: String,
         intent: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -865,7 +865,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -909,7 +909,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ExampleCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ExampleCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -945,7 +945,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -984,12 +984,12 @@ public class Conversation {
         text: String,
         mentions: [Mentions]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, WatsonError?) -> Void)
     {
         // construct body
         let createExampleRequest = CreateExample(text: text, mentions: mentions)
         guard let body = try? JSONEncoder().encode(createExampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1008,7 +1008,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1046,7 +1046,7 @@ public class Conversation {
         text: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1066,7 +1066,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1107,12 +1107,12 @@ public class Conversation {
         newText: String? = nil,
         newMentions: [Mentions]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Example>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Example>?, WatsonError?) -> Void)
     {
         // construct body
         let updateExampleRequest = UpdateExample(text: newText, mentions: newMentions)
         guard let body = try? JSONEncoder().encode(updateExampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1131,7 +1131,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1166,7 +1166,7 @@ public class Conversation {
         intent: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1182,7 +1182,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1224,7 +1224,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<CounterexampleCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<CounterexampleCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1260,7 +1260,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1296,12 +1296,12 @@ public class Conversation {
         workspaceID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, WatsonError?) -> Void)
     {
         // construct body
         let createCounterexampleRequest = CreateCounterexample(text: text)
         guard let body = try? JSONEncoder().encode(createCounterexampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1320,7 +1320,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1356,7 +1356,7 @@ public class Conversation {
         text: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1376,7 +1376,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1410,12 +1410,12 @@ public class Conversation {
         text: String,
         newText: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Counterexample>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Counterexample>?, WatsonError?) -> Void)
     {
         // construct body
         let updateCounterexampleRequest = UpdateCounterexample(text: newText)
         guard let body = try? JSONEncoder().encode(updateCounterexampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1434,7 +1434,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1467,7 +1467,7 @@ public class Conversation {
         workspaceID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1483,7 +1483,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1530,7 +1530,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1570,7 +1570,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1614,12 +1614,12 @@ public class Conversation {
         values: [CreateValue]? = nil,
         fuzzyMatch: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Entity>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Entity>?, WatsonError?) -> Void)
     {
         // construct body
         let createEntityRequest = CreateEntity(entity: entity, description: description, metadata: metadata, values: values, fuzzyMatch: fuzzyMatch)
         guard let body = try? JSONEncoder().encode(createEntityRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1638,7 +1638,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1679,7 +1679,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityExport>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityExport>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1703,7 +1703,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1750,12 +1750,12 @@ public class Conversation {
         newFuzzyMatch: Bool? = nil,
         newValues: [CreateValue]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Entity>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Entity>?, WatsonError?) -> Void)
     {
         // construct body
         let updateEntityRequest = UpdateEntity(entity: newEntity, description: newDescription, metadata: newMetadata, fuzzyMatch: newFuzzyMatch, values: newValues)
         guard let body = try? JSONEncoder().encode(updateEntityRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1774,7 +1774,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1807,7 +1807,7 @@ public class Conversation {
         workspaceID: String,
         entity: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1823,7 +1823,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1863,7 +1863,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<EntityMentionCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<EntityMentionCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1887,7 +1887,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/mentions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1935,7 +1935,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ValueCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ValueCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1975,7 +1975,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2027,12 +2027,12 @@ public class Conversation {
         patterns: [String]? = nil,
         valueType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Value>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Value>?, WatsonError?) -> Void)
     {
         // construct body
         let createValueRequest = CreateValue(value: value, metadata: metadata, synonyms: synonyms, patterns: patterns, valueType: valueType)
         guard let body = try? JSONEncoder().encode(createValueRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2051,7 +2051,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2093,7 +2093,7 @@ public class Conversation {
         export: Bool? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ValueExport>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ValueExport>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2117,7 +2117,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2172,12 +2172,12 @@ public class Conversation {
         newSynonyms: [String]? = nil,
         newPatterns: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Value>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Value>?, WatsonError?) -> Void)
     {
         // construct body
         let updateValueRequest = UpdateValue(value: newValue, metadata: newMetadata, valueType: newType, synonyms: newSynonyms, patterns: newPatterns)
         guard let body = try? JSONEncoder().encode(updateValueRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2196,7 +2196,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2231,7 +2231,7 @@ public class Conversation {
         entity: String,
         value: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2247,7 +2247,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2293,7 +2293,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SynonymCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SynonymCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2329,7 +2329,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2368,12 +2368,12 @@ public class Conversation {
         value: String,
         synonym: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, WatsonError?) -> Void)
     {
         // construct body
         let createSynonymRequest = CreateSynonym(synonym: synonym)
         guard let body = try? JSONEncoder().encode(createSynonymRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2392,7 +2392,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2432,7 +2432,7 @@ public class Conversation {
         synonym: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2452,7 +2452,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2493,12 +2493,12 @@ public class Conversation {
         synonym: String,
         newSynonym: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Synonym>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Synonym>?, WatsonError?) -> Void)
     {
         // construct body
         let updateSynonymRequest = UpdateSynonym(synonym: newSynonym)
         guard let body = try? JSONEncoder().encode(updateSynonymRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2517,7 +2517,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2554,7 +2554,7 @@ public class Conversation {
         value: String,
         synonym: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2570,7 +2570,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2612,7 +2612,7 @@ public class Conversation {
         cursor: String? = nil,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNodeCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNodeCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2648,7 +2648,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2722,7 +2722,7 @@ public class Conversation {
         digressOutSlots: String? = nil,
         userLabel: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, WatsonError?) -> Void)
     {
         // construct body
         let createDialogNodeRequest = CreateDialogNode(
@@ -2745,7 +2745,7 @@ public class Conversation {
             digressOutSlots: digressOutSlots,
             userLabel: userLabel)
         guard let body = try? JSONEncoder().encode(createDialogNodeRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2764,7 +2764,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2800,7 +2800,7 @@ public class Conversation {
         dialogNode: String,
         includeAudit: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2820,7 +2820,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2897,7 +2897,7 @@ public class Conversation {
         newDigressOutSlots: String? = nil,
         newUserLabel: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DialogNode>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DialogNode>?, WatsonError?) -> Void)
     {
         // construct body
         let updateDialogNodeRequest = UpdateDialogNode(
@@ -2920,7 +2920,7 @@ public class Conversation {
             digressOutSlots: newDigressOutSlots,
             userLabel: newUserLabel)
         guard let body = try? JSONEncoder().encode(updateDialogNodeRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2939,7 +2939,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2972,7 +2972,7 @@ public class Conversation {
         workspaceID: String,
         dialogNode: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2988,7 +2988,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3030,7 +3030,7 @@ public class Conversation {
         pageLimit: Int? = nil,
         cursor: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3062,7 +3062,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/logs"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3103,7 +3103,7 @@ public class Conversation {
         pageLimit: Int? = nil,
         cursor: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogCollection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3160,7 +3160,7 @@ public class Conversation {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/ConversationV1/Conversation.swift
+++ b/Source/ConversationV1/Conversation.swift
@@ -94,15 +94,16 @@ public class Conversation {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -169,7 +170,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/message"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -386,7 +387,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -486,7 +487,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -533,7 +534,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -620,7 +621,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -684,7 +685,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -749,7 +750,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -815,7 +816,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -864,7 +865,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -944,7 +945,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1007,7 +1008,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1065,7 +1066,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1130,7 +1131,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1181,7 +1182,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/intents/\(intent)/examples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1259,7 +1260,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1319,7 +1320,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1375,7 +1376,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1433,7 +1434,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1482,7 +1483,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/counterexamples/\(text)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1569,7 +1570,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1637,7 +1638,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1702,7 +1703,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1773,7 +1774,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1822,7 +1823,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1886,7 +1887,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/mentions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1974,7 +1975,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2050,7 +2051,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2116,7 +2117,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2195,7 +2196,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2246,7 +2247,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2328,7 +2329,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2391,7 +2392,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2451,7 +2452,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2516,7 +2517,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2569,7 +2570,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/entities/\(entity)/values/\(value)/synonyms/\(synonym)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2647,7 +2648,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2763,7 +2764,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2819,7 +2820,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2938,7 +2939,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2987,7 +2988,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/dialog_nodes/\(dialogNode)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3061,7 +3062,7 @@ public class Conversation {
         // construct REST request
         let path = "/v1/workspaces/\(workspaceID)/logs"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -132,7 +132,7 @@ public class Discovery {
         description: String? = nil,
         size: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Environment>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Environment>?, RestError?) -> Void)
     {
         // construct body
         let createEnvironmentRequest = CreateEnvironmentRequest(name: name, description: description, size: size)
@@ -181,7 +181,7 @@ public class Discovery {
     public func listEnvironments(
         name: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListEnvironmentsResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListEnvironmentsResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -223,7 +223,7 @@ public class Discovery {
     public func getEnvironment(
         environmentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Environment>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Environment>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -276,7 +276,7 @@ public class Discovery {
         description: String? = nil,
         size: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Environment>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Environment>?, RestError?) -> Void)
     {
         // construct body
         let updateEnvironmentRequest = UpdateEnvironmentRequest(name: name, description: description, size: size)
@@ -328,7 +328,7 @@ public class Discovery {
     public func deleteEnvironment(
         environmentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteEnvironmentResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteEnvironmentResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -375,7 +375,7 @@ public class Discovery {
         environmentID: String,
         collectionIds: [String],
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListCollectionFieldsResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListCollectionFieldsResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -440,7 +440,7 @@ public class Discovery {
         normalizations: [NormalizationOperation]? = nil,
         source: Source? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Configuration>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Configuration>?, RestError?) -> Void)
     {
         // construct body
         let createConfigurationRequest = Configuration(name: name, description: description, conversions: conversions, enrichments: enrichments, normalizations: normalizations, source: source)
@@ -496,7 +496,7 @@ public class Discovery {
         environmentID: String,
         name: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListConfigurationsResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListConfigurationsResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -545,7 +545,7 @@ public class Discovery {
         environmentID: String,
         configurationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Configuration>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Configuration>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -611,7 +611,7 @@ public class Discovery {
         normalizations: [NormalizationOperation]? = nil,
         source: Source? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Configuration>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Configuration>?, RestError?) -> Void)
     {
         // construct body
         let updateConfigurationRequest = Configuration(name: name, description: description, conversions: conversions, enrichments: enrichments, normalizations: normalizations, source: source)
@@ -670,7 +670,7 @@ public class Discovery {
         environmentID: String,
         configurationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteConfigurationResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteConfigurationResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -741,7 +741,7 @@ public class Discovery {
         metadata: String? = nil,
         fileContentType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TestDocument>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TestDocument>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -828,7 +828,7 @@ public class Discovery {
         configurationID: String? = nil,
         language: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Collection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Collection>?, RestError?) -> Void)
     {
         // construct body
         let createCollectionRequest = CreateCollectionRequest(name: name, description: description, configurationID: configurationID, language: language)
@@ -884,7 +884,7 @@ public class Discovery {
         environmentID: String,
         name: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListCollectionsResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListCollectionsResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -933,7 +933,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Collection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Collection>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -984,7 +984,7 @@ public class Discovery {
         description: String? = nil,
         configurationID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Collection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Collection>?, RestError?) -> Void)
     {
         // construct body
         let updateCollectionRequest = UpdateCollectionRequest(name: name, description: description, configurationID: configurationID)
@@ -1038,7 +1038,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteCollectionResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteCollectionResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1085,7 +1085,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListCollectionFieldsResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListCollectionFieldsResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1133,7 +1133,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Expansions>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Expansions>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1193,7 +1193,7 @@ public class Discovery {
         collectionID: String,
         expansions: [Expansion],
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Expansions>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Expansions>?, RestError?) -> Void)
     {
         // construct body
         let createExpansionsRequest = Expansions(expansions: expansions)
@@ -1250,7 +1250,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1321,7 +1321,7 @@ public class Discovery {
         metadata: String? = nil,
         fileContentType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DocumentAccepted>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DocumentAccepted>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -1394,7 +1394,7 @@ public class Discovery {
         collectionID: String,
         documentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DocumentStatus>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DocumentStatus>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1456,7 +1456,7 @@ public class Discovery {
         metadata: String? = nil,
         fileContentType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DocumentAccepted>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DocumentAccepted>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -1528,7 +1528,7 @@ public class Discovery {
         collectionID: String,
         documentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteDocumentResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteDocumentResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1645,7 +1645,7 @@ public class Discovery {
         bias: String? = nil,
         loggingOptOut: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryResponse>?, RestError?) -> Void)
     {
         // construct body
         let returnFieldsJoined = returnFields?.joined(separator: ",")
@@ -1785,7 +1785,7 @@ public class Discovery {
         similarDocumentIds: [String]? = nil,
         similarFields: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryNoticesResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryNoticesResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1970,7 +1970,7 @@ public class Discovery {
         bias: String? = nil,
         loggingOptOut: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryResponse>?, RestError?) -> Void)
     {
         // construct body
         let returnFieldsJoined = returnFields?.joined(separator: ",")
@@ -2102,7 +2102,7 @@ public class Discovery {
         similarDocumentIds: [String]? = nil,
         similarFields: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryNoticesResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryNoticesResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2217,7 +2217,7 @@ public class Discovery {
         count: Int? = nil,
         evidenceCount: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryEntitiesResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryEntitiesResponse>?, RestError?) -> Void)
     {
         // construct body
         let queryEntitiesRequest = QueryEntities(feature: feature, entity: entity, context: context, count: count, evidenceCount: evidenceCount)
@@ -2290,7 +2290,7 @@ public class Discovery {
         count: Int? = nil,
         evidenceCount: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryRelationsResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryRelationsResponse>?, RestError?) -> Void)
     {
         // construct body
         let queryRelationsRequest = QueryRelations(entities: entities, context: context, sort: sort, filter: filter, count: count, evidenceCount: evidenceCount)
@@ -2346,7 +2346,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingDataSet>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingDataSet>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2399,7 +2399,7 @@ public class Discovery {
         filter: String? = nil,
         examples: [TrainingExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingQuery>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingQuery>?, RestError?) -> Void)
     {
         // construct body
         let addTrainingDataRequest = NewTrainingQuery(naturalLanguageQuery: naturalLanguageQuery, filter: filter, examples: examples)
@@ -2455,7 +2455,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2504,7 +2504,7 @@ public class Discovery {
         collectionID: String,
         queryID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingQuery>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingQuery>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2553,7 +2553,7 @@ public class Discovery {
         collectionID: String,
         queryID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2602,7 +2602,7 @@ public class Discovery {
         collectionID: String,
         queryID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingExampleList>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingExampleList>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2657,7 +2657,7 @@ public class Discovery {
         crossReference: String? = nil,
         relevance: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingExample>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingExample>?, RestError?) -> Void)
     {
         // construct body
         let createTrainingExampleRequest = TrainingExample(documentID: documentID, crossReference: crossReference, relevance: relevance)
@@ -2717,7 +2717,7 @@ public class Discovery {
         queryID: String,
         exampleID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2772,7 +2772,7 @@ public class Discovery {
         crossReference: String? = nil,
         relevance: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingExample>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingExample>?, RestError?) -> Void)
     {
         // construct body
         let updateTrainingExampleRequest = TrainingExamplePatch(crossReference: crossReference, relevance: relevance)
@@ -2832,7 +2832,7 @@ public class Discovery {
         queryID: String,
         exampleID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingExample>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingExample>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2881,7 +2881,7 @@ public class Discovery {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2925,7 +2925,7 @@ public class Discovery {
         type: String,
         data: EventData,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<CreateEventResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<CreateEventResponse>?, RestError?) -> Void)
     {
         // construct body
         let createEventRequest = CreateEventObject(type: type, data: data)
@@ -2989,7 +2989,7 @@ public class Discovery {
         offset: Int? = nil,
         sort: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogQueryResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogQueryResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3055,7 +3055,7 @@ public class Discovery {
         endTime: String? = nil,
         resultType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3115,7 +3115,7 @@ public class Discovery {
         endTime: String? = nil,
         resultType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3174,7 +3174,7 @@ public class Discovery {
         endTime: String? = nil,
         resultType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3234,7 +3234,7 @@ public class Discovery {
         endTime: String? = nil,
         resultType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3288,7 +3288,7 @@ public class Discovery {
     public func getMetricsQueryTokenEvent(
         count: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricTokenResponse>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricTokenResponse>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3333,7 +3333,7 @@ public class Discovery {
     public func listCredentials(
         environmentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<CredentialsList>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<CredentialsList>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3388,7 +3388,7 @@ public class Discovery {
         sourceType: String? = nil,
         credentialDetails: CredentialDetails? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Credentials>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Credentials>?, RestError?) -> Void)
     {
         // construct body
         let createCredentialsRequest = Credentials(sourceType: sourceType, credentialDetails: credentialDetails)
@@ -3446,7 +3446,7 @@ public class Discovery {
         environmentID: String,
         credentialID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Credentials>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Credentials>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3502,7 +3502,7 @@ public class Discovery {
         sourceType: String? = nil,
         credentialDetails: CredentialDetails? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Credentials>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Credentials>?, RestError?) -> Void)
     {
         // construct body
         let updateCredentialsRequest = Credentials(sourceType: sourceType, credentialDetails: credentialDetails)
@@ -3558,7 +3558,7 @@ public class Discovery {
         environmentID: String,
         credentialID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteCredentials>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteCredentials>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -85,27 +85,30 @@ public class Discovery {
     }
 
     /**
-     If the response or data represents an error returned by the Discovery service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Discovery service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["description"] {
-                userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
+                metadata["description"] = JSON.string(description)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -91,7 +91,7 @@ public class Discovery {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -106,10 +106,10 @@ public class Discovery {
             if case let .some(.string(description)) = json["description"] {
                 metadata["description"] = description
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -132,12 +132,12 @@ public class Discovery {
         description: String? = nil,
         size: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Environment>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Environment>?, WatsonError?) -> Void)
     {
         // construct body
         let createEnvironmentRequest = CreateEnvironmentRequest(name: name, description: description, size: size)
         guard let body = try? JSONEncoder().encode(createEnvironmentRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -181,7 +181,7 @@ public class Discovery {
     public func listEnvironments(
         name: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListEnvironmentsResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListEnvironmentsResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -223,7 +223,7 @@ public class Discovery {
     public func getEnvironment(
         environmentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Environment>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Environment>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -239,7 +239,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -276,12 +276,12 @@ public class Discovery {
         description: String? = nil,
         size: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Environment>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Environment>?, WatsonError?) -> Void)
     {
         // construct body
         let updateEnvironmentRequest = UpdateEnvironmentRequest(name: name, description: description, size: size)
         guard let body = try? JSONEncoder().encode(updateEnvironmentRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -300,7 +300,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -328,7 +328,7 @@ public class Discovery {
     public func deleteEnvironment(
         environmentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteEnvironmentResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteEnvironmentResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -344,7 +344,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -375,7 +375,7 @@ public class Discovery {
         environmentID: String,
         collectionIds: [String],
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListCollectionFieldsResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListCollectionFieldsResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -392,7 +392,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/fields"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -440,12 +440,12 @@ public class Discovery {
         normalizations: [NormalizationOperation]? = nil,
         source: Source? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Configuration>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Configuration>?, WatsonError?) -> Void)
     {
         // construct body
         let createConfigurationRequest = Configuration(name: name, description: description, conversions: conversions, enrichments: enrichments, normalizations: normalizations, source: source)
         guard let body = try? JSONEncoder().encode(createConfigurationRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -464,7 +464,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -496,7 +496,7 @@ public class Discovery {
         environmentID: String,
         name: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListConfigurationsResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListConfigurationsResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -516,7 +516,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -545,7 +545,7 @@ public class Discovery {
         environmentID: String,
         configurationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Configuration>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Configuration>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -561,7 +561,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations/\(configurationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -611,12 +611,12 @@ public class Discovery {
         normalizations: [NormalizationOperation]? = nil,
         source: Source? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Configuration>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Configuration>?, WatsonError?) -> Void)
     {
         // construct body
         let updateConfigurationRequest = Configuration(name: name, description: description, conversions: conversions, enrichments: enrichments, normalizations: normalizations, source: source)
         guard let body = try? JSONEncoder().encode(updateConfigurationRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -635,7 +635,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations/\(configurationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -670,7 +670,7 @@ public class Discovery {
         environmentID: String,
         configurationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteConfigurationResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteConfigurationResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -686,7 +686,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations/\(configurationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -741,7 +741,7 @@ public class Discovery {
         metadata: String? = nil,
         fileContentType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TestDocument>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TestDocument>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -754,7 +754,7 @@ public class Discovery {
             do {
                 try multipartFormData.append(file: file, withName: "file")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(file.path)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(file.path)"))
                 return
             }
         }
@@ -764,7 +764,7 @@ public class Discovery {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -791,7 +791,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/preview"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -828,12 +828,12 @@ public class Discovery {
         configurationID: String? = nil,
         language: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Collection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Collection>?, WatsonError?) -> Void)
     {
         // construct body
         let createCollectionRequest = CreateCollectionRequest(name: name, description: description, configurationID: configurationID, language: language)
         guard let body = try? JSONEncoder().encode(createCollectionRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -852,7 +852,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -884,7 +884,7 @@ public class Discovery {
         environmentID: String,
         name: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListCollectionsResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListCollectionsResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -904,7 +904,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -933,7 +933,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Collection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Collection>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -949,7 +949,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -984,12 +984,12 @@ public class Discovery {
         description: String? = nil,
         configurationID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Collection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Collection>?, WatsonError?) -> Void)
     {
         // construct body
         let updateCollectionRequest = UpdateCollectionRequest(name: name, description: description, configurationID: configurationID)
         guard let body = try? JSONEncoder().encodeIfPresent(updateCollectionRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1008,7 +1008,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1038,7 +1038,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteCollectionResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteCollectionResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1054,7 +1054,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1085,7 +1085,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListCollectionFieldsResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListCollectionFieldsResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1101,7 +1101,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/fields"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1133,7 +1133,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Expansions>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Expansions>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1149,7 +1149,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/expansions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1193,12 +1193,12 @@ public class Discovery {
         collectionID: String,
         expansions: [Expansion],
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Expansions>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Expansions>?, WatsonError?) -> Void)
     {
         // construct body
         let createExpansionsRequest = Expansions(expansions: expansions)
         guard let body = try? JSONEncoder().encode(createExpansionsRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1217,7 +1217,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/expansions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1250,7 +1250,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1266,7 +1266,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/expansions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1321,7 +1321,7 @@ public class Discovery {
         metadata: String? = nil,
         fileContentType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DocumentAccepted>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DocumentAccepted>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -1329,7 +1329,7 @@ public class Discovery {
             do {
                 try multipartFormData.append(file: file, withName: "file")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(file.path)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(file.path)"))
                 return
             }
         }
@@ -1339,7 +1339,7 @@ public class Discovery {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -1358,7 +1358,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1394,7 +1394,7 @@ public class Discovery {
         collectionID: String,
         documentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DocumentStatus>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DocumentStatus>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1410,7 +1410,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents/\(documentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1456,7 +1456,7 @@ public class Discovery {
         metadata: String? = nil,
         fileContentType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DocumentAccepted>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DocumentAccepted>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -1464,7 +1464,7 @@ public class Discovery {
             do {
                 try multipartFormData.append(file: file, withName: "file")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(file.path)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(file.path)"))
                 return
             }
         }
@@ -1474,7 +1474,7 @@ public class Discovery {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -1493,7 +1493,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents/\(documentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1528,7 +1528,7 @@ public class Discovery {
         collectionID: String,
         documentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteDocumentResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteDocumentResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1544,7 +1544,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents/\(documentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1645,7 +1645,7 @@ public class Discovery {
         bias: String? = nil,
         loggingOptOut: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryResponse>?, WatsonError?) -> Void)
     {
         // construct body
         let returnFieldsJoined = returnFields?.joined(separator: ",")
@@ -1674,7 +1674,7 @@ public class Discovery {
             similarFields: similarFieldsJoined,
             bias: bias)
         guard let body = try? JSONEncoder().encode(queryLong) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1696,7 +1696,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/query"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1785,7 +1785,7 @@ public class Discovery {
         similarDocumentIds: [String]? = nil,
         similarFields: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryNoticesResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryNoticesResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1869,7 +1869,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/notices"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1970,7 +1970,7 @@ public class Discovery {
         bias: String? = nil,
         loggingOptOut: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryResponse>?, WatsonError?) -> Void)
     {
         // construct body
         let returnFieldsJoined = returnFields?.joined(separator: ",")
@@ -2001,7 +2001,7 @@ public class Discovery {
             similarFields: similarFieldsJoined,
             bias: bias)
         guard let body = try? JSONEncoder().encode(queryLong) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2023,7 +2023,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/query"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2102,7 +2102,7 @@ public class Discovery {
         similarDocumentIds: [String]? = nil,
         similarFields: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryNoticesResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryNoticesResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2171,7 +2171,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/notices"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2217,12 +2217,12 @@ public class Discovery {
         count: Int? = nil,
         evidenceCount: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryEntitiesResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryEntitiesResponse>?, WatsonError?) -> Void)
     {
         // construct body
         let queryEntitiesRequest = QueryEntities(feature: feature, entity: entity, context: context, count: count, evidenceCount: evidenceCount)
         guard let body = try? JSONEncoder().encode(queryEntitiesRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2241,7 +2241,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/query_entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2290,12 +2290,12 @@ public class Discovery {
         count: Int? = nil,
         evidenceCount: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<QueryRelationsResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<QueryRelationsResponse>?, WatsonError?) -> Void)
     {
         // construct body
         let queryRelationsRequest = QueryRelations(entities: entities, context: context, sort: sort, filter: filter, count: count, evidenceCount: evidenceCount)
         guard let body = try? JSONEncoder().encode(queryRelationsRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2314,7 +2314,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/query_relations"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2346,7 +2346,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingDataSet>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingDataSet>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2362,7 +2362,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2399,12 +2399,12 @@ public class Discovery {
         filter: String? = nil,
         examples: [TrainingExample]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingQuery>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingQuery>?, WatsonError?) -> Void)
     {
         // construct body
         let addTrainingDataRequest = NewTrainingQuery(naturalLanguageQuery: naturalLanguageQuery, filter: filter, examples: examples)
         guard let body = try? JSONEncoder().encode(addTrainingDataRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2423,7 +2423,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2455,7 +2455,7 @@ public class Discovery {
         environmentID: String,
         collectionID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2471,7 +2471,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2504,7 +2504,7 @@ public class Discovery {
         collectionID: String,
         queryID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingQuery>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingQuery>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2520,7 +2520,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2553,7 +2553,7 @@ public class Discovery {
         collectionID: String,
         queryID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2569,7 +2569,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2602,7 +2602,7 @@ public class Discovery {
         collectionID: String,
         queryID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingExampleList>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingExampleList>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2618,7 +2618,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2657,12 +2657,12 @@ public class Discovery {
         crossReference: String? = nil,
         relevance: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingExample>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingExample>?, WatsonError?) -> Void)
     {
         // construct body
         let createTrainingExampleRequest = TrainingExample(documentID: documentID, crossReference: crossReference, relevance: relevance)
         guard let body = try? JSONEncoder().encode(createTrainingExampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2681,7 +2681,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2717,7 +2717,7 @@ public class Discovery {
         queryID: String,
         exampleID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2733,7 +2733,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples/\(exampleID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2772,12 +2772,12 @@ public class Discovery {
         crossReference: String? = nil,
         relevance: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingExample>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingExample>?, WatsonError?) -> Void)
     {
         // construct body
         let updateTrainingExampleRequest = TrainingExamplePatch(crossReference: crossReference, relevance: relevance)
         guard let body = try? JSONEncoder().encode(updateTrainingExampleRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2796,7 +2796,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples/\(exampleID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2832,7 +2832,7 @@ public class Discovery {
         queryID: String,
         exampleID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TrainingExample>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TrainingExample>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2848,7 +2848,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples/\(exampleID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2881,7 +2881,7 @@ public class Discovery {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2925,12 +2925,12 @@ public class Discovery {
         type: String,
         data: EventData,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<CreateEventResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<CreateEventResponse>?, WatsonError?) -> Void)
     {
         // construct body
         let createEventRequest = CreateEventObject(type: type, data: data)
         guard let body = try? JSONEncoder().encode(createEventRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2989,7 +2989,7 @@ public class Discovery {
         offset: Int? = nil,
         sort: [String]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LogQueryResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LogQueryResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3055,7 +3055,7 @@ public class Discovery {
         endTime: String? = nil,
         resultType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3115,7 +3115,7 @@ public class Discovery {
         endTime: String? = nil,
         resultType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3174,7 +3174,7 @@ public class Discovery {
         endTime: String? = nil,
         resultType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3234,7 +3234,7 @@ public class Discovery {
         endTime: String? = nil,
         resultType: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3288,7 +3288,7 @@ public class Discovery {
     public func getMetricsQueryTokenEvent(
         count: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<MetricTokenResponse>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<MetricTokenResponse>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3333,7 +3333,7 @@ public class Discovery {
     public func listCredentials(
         environmentID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<CredentialsList>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<CredentialsList>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3349,7 +3349,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3388,12 +3388,12 @@ public class Discovery {
         sourceType: String? = nil,
         credentialDetails: CredentialDetails? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Credentials>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Credentials>?, WatsonError?) -> Void)
     {
         // construct body
         let createCredentialsRequest = Credentials(sourceType: sourceType, credentialDetails: credentialDetails)
         guard let body = try? JSONEncoder().encode(createCredentialsRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -3412,7 +3412,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3446,7 +3446,7 @@ public class Discovery {
         environmentID: String,
         credentialID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Credentials>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Credentials>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3462,7 +3462,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials/\(credentialID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3502,12 +3502,12 @@ public class Discovery {
         sourceType: String? = nil,
         credentialDetails: CredentialDetails? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Credentials>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Credentials>?, WatsonError?) -> Void)
     {
         // construct body
         let updateCredentialsRequest = Credentials(sourceType: sourceType, credentialDetails: credentialDetails)
         guard let body = try? JSONEncoder().encode(updateCredentialsRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -3526,7 +3526,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials/\(credentialID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3558,7 +3558,7 @@ public class Discovery {
         environmentID: String,
         credentialID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteCredentials>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteCredentials>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -3574,7 +3574,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials/\(credentialID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -95,18 +95,19 @@ public class Discovery {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["description"] {
-                metadata["description"] = JSON.string(description)
+                metadata["description"] = description
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -238,7 +239,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -299,7 +300,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -343,7 +344,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -391,7 +392,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/fields"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -463,7 +464,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -515,7 +516,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -560,7 +561,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations/\(configurationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -634,7 +635,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations/\(configurationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -685,7 +686,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations/\(configurationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -790,7 +791,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/preview"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -851,7 +852,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -903,7 +904,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -948,7 +949,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1007,7 +1008,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1053,7 +1054,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1100,7 +1101,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/fields"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1148,7 +1149,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/expansions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1216,7 +1217,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/expansions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1265,7 +1266,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/expansions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1357,7 +1358,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1409,7 +1410,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents/\(documentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1492,7 +1493,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents/\(documentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1543,7 +1544,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents/\(documentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1695,7 +1696,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/query"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1868,7 +1869,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/notices"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2022,7 +2023,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/query"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2170,7 +2171,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/notices"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2240,7 +2241,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/query_entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2313,7 +2314,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/query_relations"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2361,7 +2362,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2422,7 +2423,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2470,7 +2471,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2519,7 +2520,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2568,7 +2569,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2617,7 +2618,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2680,7 +2681,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2732,7 +2733,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples/\(exampleID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2795,7 +2796,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples/\(exampleID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2847,7 +2848,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples/\(exampleID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3348,7 +3349,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3411,7 +3412,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3461,7 +3462,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials/\(credentialID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3525,7 +3526,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials/\(credentialID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3573,7 +3574,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials/\(credentialID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -136,7 +136,7 @@ public class Discovery {
         // construct body
         let createEnvironmentRequest = CreateEnvironmentRequest(name: name, description: description, size: size)
         guard let body = try? JSONEncoder().encode(createEnvironmentRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -238,7 +238,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -280,7 +280,7 @@ public class Discovery {
         // construct body
         let updateEnvironmentRequest = UpdateEnvironmentRequest(name: name, description: description, size: size)
         guard let body = try? JSONEncoder().encode(updateEnvironmentRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -299,7 +299,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -343,7 +343,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -391,7 +391,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/fields"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -444,7 +444,7 @@ public class Discovery {
         // construct body
         let createConfigurationRequest = Configuration(name: name, description: description, conversions: conversions, enrichments: enrichments, normalizations: normalizations, source: source)
         guard let body = try? JSONEncoder().encode(createConfigurationRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -463,7 +463,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -515,7 +515,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -560,7 +560,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations/\(configurationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -615,7 +615,7 @@ public class Discovery {
         // construct body
         let updateConfigurationRequest = Configuration(name: name, description: description, conversions: conversions, enrichments: enrichments, normalizations: normalizations, source: source)
         guard let body = try? JSONEncoder().encode(updateConfigurationRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -634,7 +634,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations/\(configurationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -685,7 +685,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/configurations/\(configurationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -753,7 +753,7 @@ public class Discovery {
             do {
                 try multipartFormData.append(file: file, withName: "file")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(file.path)"))
                 return
             }
         }
@@ -763,7 +763,7 @@ public class Discovery {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -790,7 +790,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/preview"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -832,7 +832,7 @@ public class Discovery {
         // construct body
         let createCollectionRequest = CreateCollectionRequest(name: name, description: description, configurationID: configurationID, language: language)
         guard let body = try? JSONEncoder().encode(createCollectionRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -851,7 +851,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -903,7 +903,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -948,7 +948,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -988,7 +988,7 @@ public class Discovery {
         // construct body
         let updateCollectionRequest = UpdateCollectionRequest(name: name, description: description, configurationID: configurationID)
         guard let body = try? JSONEncoder().encodeIfPresent(updateCollectionRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1007,7 +1007,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1053,7 +1053,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1100,7 +1100,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/fields"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1148,7 +1148,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/expansions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1197,7 +1197,7 @@ public class Discovery {
         // construct body
         let createExpansionsRequest = Expansions(expansions: expansions)
         guard let body = try? JSONEncoder().encode(createExpansionsRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1216,7 +1216,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/expansions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1265,7 +1265,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/expansions"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1328,7 +1328,7 @@ public class Discovery {
             do {
                 try multipartFormData.append(file: file, withName: "file")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(file.path)"))
                 return
             }
         }
@@ -1338,7 +1338,7 @@ public class Discovery {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -1357,7 +1357,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1409,7 +1409,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents/\(documentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1463,7 +1463,7 @@ public class Discovery {
             do {
                 try multipartFormData.append(file: file, withName: "file")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(file.path)"))
                 return
             }
         }
@@ -1473,7 +1473,7 @@ public class Discovery {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -1492,7 +1492,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents/\(documentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1543,7 +1543,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/documents/\(documentID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1673,7 +1673,7 @@ public class Discovery {
             similarFields: similarFieldsJoined,
             bias: bias)
         guard let body = try? JSONEncoder().encode(queryLong) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1695,7 +1695,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/query"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1868,7 +1868,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/notices"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2000,7 +2000,7 @@ public class Discovery {
             similarFields: similarFieldsJoined,
             bias: bias)
         guard let body = try? JSONEncoder().encode(queryLong) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2022,7 +2022,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/query"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2170,7 +2170,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/notices"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2221,7 +2221,7 @@ public class Discovery {
         // construct body
         let queryEntitiesRequest = QueryEntities(feature: feature, entity: entity, context: context, count: count, evidenceCount: evidenceCount)
         guard let body = try? JSONEncoder().encode(queryEntitiesRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2240,7 +2240,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/query_entities"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2294,7 +2294,7 @@ public class Discovery {
         // construct body
         let queryRelationsRequest = QueryRelations(entities: entities, context: context, sort: sort, filter: filter, count: count, evidenceCount: evidenceCount)
         guard let body = try? JSONEncoder().encode(queryRelationsRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2313,7 +2313,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/query_relations"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2361,7 +2361,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2403,7 +2403,7 @@ public class Discovery {
         // construct body
         let addTrainingDataRequest = NewTrainingQuery(naturalLanguageQuery: naturalLanguageQuery, filter: filter, examples: examples)
         guard let body = try? JSONEncoder().encode(addTrainingDataRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2422,7 +2422,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2470,7 +2470,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2519,7 +2519,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2568,7 +2568,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2617,7 +2617,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2661,7 +2661,7 @@ public class Discovery {
         // construct body
         let createTrainingExampleRequest = TrainingExample(documentID: documentID, crossReference: crossReference, relevance: relevance)
         guard let body = try? JSONEncoder().encode(createTrainingExampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2680,7 +2680,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2732,7 +2732,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples/\(exampleID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2776,7 +2776,7 @@ public class Discovery {
         // construct body
         let updateTrainingExampleRequest = TrainingExamplePatch(crossReference: crossReference, relevance: relevance)
         guard let body = try? JSONEncoder().encode(updateTrainingExampleRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2795,7 +2795,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples/\(exampleID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2847,7 +2847,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/collections/\(collectionID)/training_data/\(queryID)/examples/\(exampleID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2929,7 +2929,7 @@ public class Discovery {
         // construct body
         let createEventRequest = CreateEventObject(type: type, data: data)
         guard let body = try? JSONEncoder().encode(createEventRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -3348,7 +3348,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3392,7 +3392,7 @@ public class Discovery {
         // construct body
         let createCredentialsRequest = Credentials(sourceType: sourceType, credentialDetails: credentialDetails)
         guard let body = try? JSONEncoder().encode(createCredentialsRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -3411,7 +3411,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3461,7 +3461,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials/\(credentialID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3506,7 +3506,7 @@ public class Discovery {
         // construct body
         let updateCredentialsRequest = Credentials(sourceType: sourceType, credentialDetails: credentialDetails)
         guard let body = try? JSONEncoder().encode(updateCredentialsRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -3525,7 +3525,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials/\(credentialID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -3573,7 +3573,7 @@ public class Discovery {
         // construct REST request
         let path = "/v1/environments/\(environmentID)/credentials/\(credentialID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -85,24 +85,27 @@ public class LanguageTranslator {
     }
 
     /**
-     If the response or data represents an error returned by the Language Translator service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Language Translator service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -221,11 +224,9 @@ public class LanguageTranslator {
         completionHandler: @escaping (WatsonResponse<IdentifiedLanguages>?, Error?) -> Void)
     {
         // construct body
-        // convert body parameter to NSData with UTF-8 encoding
+        // convert body parameter to Data with UTF-8 encoding
         guard let body = text.data(using: .utf8) else {
-            let message = "text could not be encoded to NSData with NSUTF8StringEncoding."
-            let userInfo = [NSLocalizedDescriptionKey: message]
-            let error = NSError(domain: domain, code: 0, userInfo: userInfo)
+            let error = RestError.serialization(values: "text could not be encoded with UTF8.")
             completionHandler(nil, error)
             return
         }

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -134,7 +134,7 @@ public class LanguageTranslator {
         source: String? = nil,
         target: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TranslationResult>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TranslationResult>?, RestError?) -> Void)
     {
         // construct body
         let translateRequest = TranslateRequest(text: text, modelID: modelID, source: source, target: target)
@@ -182,7 +182,7 @@ public class LanguageTranslator {
      */
     public func listIdentifiableLanguages(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IdentifiableLanguages>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IdentifiableLanguages>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -222,7 +222,7 @@ public class LanguageTranslator {
     public func identify(
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IdentifiedLanguages>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IdentifiedLanguages>?, RestError?) -> Void)
     {
         // construct body
         // convert body parameter to Data with UTF-8 encoding
@@ -279,7 +279,7 @@ public class LanguageTranslator {
         target: String? = nil,
         defaultModels: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TranslationModels>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TranslationModels>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -354,7 +354,7 @@ public class LanguageTranslator {
         forcedGlossary: URL? = nil,
         parallelCorpus: URL? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TranslationModel>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TranslationModel>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -424,7 +424,7 @@ public class LanguageTranslator {
     public func deleteModel(
         modelID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteModelResult>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteModelResult>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -470,7 +470,7 @@ public class LanguageTranslator {
     public func getModel(
         modelID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TranslationModel>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TranslationModel>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -95,15 +95,16 @@ public class LanguageTranslator {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -439,7 +440,7 @@ public class LanguageTranslator {
         // construct REST request
         let path = "/v3/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -485,7 +486,7 @@ public class LanguageTranslator {
         // construct REST request
         let path = "/v3/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -138,7 +138,7 @@ public class LanguageTranslator {
         // construct body
         let translateRequest = TranslateRequest(text: text, modelID: modelID, source: source, target: target)
         guard let body = try? JSONEncoder().encode(translateRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -361,7 +361,7 @@ public class LanguageTranslator {
             do {
                 try multipartFormData.append(file: forcedGlossary, withName: "forced_glossary")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(forcedGlossary.path)"))
                 return
             }
         }
@@ -369,12 +369,12 @@ public class LanguageTranslator {
             do {
                 try multipartFormData.append(file: parallelCorpus, withName: "parallel_corpus")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(parallelCorpus.path)"))
                 return
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -439,7 +439,7 @@ public class LanguageTranslator {
         // construct REST request
         let path = "/v3/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -485,7 +485,7 @@ public class LanguageTranslator {
         // construct REST request
         let path = "/v3/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -91,7 +91,7 @@ public class LanguageTranslator {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -103,10 +103,10 @@ public class LanguageTranslator {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -134,12 +134,12 @@ public class LanguageTranslator {
         source: String? = nil,
         target: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TranslationResult>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TranslationResult>?, WatsonError?) -> Void)
     {
         // construct body
         let translateRequest = TranslateRequest(text: text, modelID: modelID, source: source, target: target)
         guard let body = try? JSONEncoder().encode(translateRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -182,7 +182,7 @@ public class LanguageTranslator {
      */
     public func listIdentifiableLanguages(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IdentifiableLanguages>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IdentifiableLanguages>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -222,12 +222,12 @@ public class LanguageTranslator {
     public func identify(
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<IdentifiedLanguages>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<IdentifiedLanguages>?, WatsonError?) -> Void)
     {
         // construct body
         // convert body parameter to Data with UTF-8 encoding
         guard let body = text.data(using: .utf8) else {
-            let error = RestError.serialization(values: "text could not be encoded with UTF8.")
+            let error = WatsonError.serialization(values: "text could not be encoded with UTF8.")
             completionHandler(nil, error)
             return
         }
@@ -279,7 +279,7 @@ public class LanguageTranslator {
         target: String? = nil,
         defaultModels: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TranslationModels>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TranslationModels>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -354,7 +354,7 @@ public class LanguageTranslator {
         forcedGlossary: URL? = nil,
         parallelCorpus: URL? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TranslationModel>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TranslationModel>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -362,7 +362,7 @@ public class LanguageTranslator {
             do {
                 try multipartFormData.append(file: forcedGlossary, withName: "forced_glossary")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(forcedGlossary.path)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(forcedGlossary.path)"))
                 return
             }
         }
@@ -370,12 +370,12 @@ public class LanguageTranslator {
             do {
                 try multipartFormData.append(file: parallelCorpus, withName: "parallel_corpus")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(parallelCorpus.path)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(parallelCorpus.path)"))
                 return
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -424,7 +424,7 @@ public class LanguageTranslator {
     public func deleteModel(
         modelID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteModelResult>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteModelResult>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -440,7 +440,7 @@ public class LanguageTranslator {
         // construct REST request
         let path = "/v3/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -470,7 +470,7 @@ public class LanguageTranslator {
     public func getModel(
         modelID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<TranslationModel>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<TranslationModel>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -486,7 +486,7 @@ public class LanguageTranslator {
         // construct REST request
         let path = "/v3/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -84,18 +84,19 @@ public class NaturalLanguageClassifier {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["description"] {
-                metadata["description"] = JSON.string(description)
+                metadata["description"] = description
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -136,7 +137,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)/classify"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -189,7 +190,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)/classify_collection"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -327,7 +328,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -365,7 +366,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -74,27 +74,30 @@ public class NaturalLanguageClassifier {
     }
 
     /**
-     If the response or data represents an error returned by the Natural Language Classifier service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Natural Language Classifier service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["description"] {
-                userInfo[NSLocalizedFailureReasonErrorKey] = description
+                metadata["description"] = JSON.string(description)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -80,7 +80,7 @@ public class NaturalLanguageClassifier {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -95,10 +95,10 @@ public class NaturalLanguageClassifier {
             if case let .some(.string(description)) = json["description"] {
                 metadata["description"] = description
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -117,12 +117,12 @@ public class NaturalLanguageClassifier {
         classifierID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classification>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classification>?, WatsonError?) -> Void)
     {
         // construct body
         let classifyRequest = ClassifyInput(text: text)
         guard let body = try? JSONEncoder().encode(classifyRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -137,7 +137,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)/classify"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -170,12 +170,12 @@ public class NaturalLanguageClassifier {
         classifierID: String,
         collection: [ClassifyInput],
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ClassificationCollection>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ClassificationCollection>?, WatsonError?) -> Void)
     {
         // construct body
         let classifyCollectionRequest = ClassifyCollectionInput(collection: collection)
         guard let body = try? JSONEncoder().encode(classifyCollectionRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -190,7 +190,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)/classify_collection"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -227,24 +227,24 @@ public class NaturalLanguageClassifier {
         metadata: URL,
         trainingData: URL,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
         do {
             try multipartFormData.append(file: metadata, withName: "training_metadata")
         } catch {
-            completionHandler(nil, RestError.serialization(values: "file \(metadata.path)"))
+            completionHandler(nil, WatsonError.serialization(values: "file \(metadata.path)"))
             return
         }
         do {
             try multipartFormData.append(file: trainingData, withName: "training_data")
         } catch {
-            completionHandler(nil, RestError.serialization(values: "file \(trainingData.path)"))
+            completionHandler(nil, WatsonError.serialization(values: "file \(trainingData.path)"))
             return
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -281,7 +281,7 @@ public class NaturalLanguageClassifier {
      */
     public func listClassifiers(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ClassifierList>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ClassifierList>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -316,7 +316,7 @@ public class NaturalLanguageClassifier {
     public func getClassifier(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -328,7 +328,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -354,7 +354,7 @@ public class NaturalLanguageClassifier {
     public func deleteClassifier(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -366,7 +366,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -117,7 +117,7 @@ public class NaturalLanguageClassifier {
         classifierID: String,
         text: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classification>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classification>?, RestError?) -> Void)
     {
         // construct body
         let classifyRequest = ClassifyInput(text: text)
@@ -170,7 +170,7 @@ public class NaturalLanguageClassifier {
         classifierID: String,
         collection: [ClassifyInput],
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ClassificationCollection>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ClassificationCollection>?, RestError?) -> Void)
     {
         // construct body
         let classifyCollectionRequest = ClassifyCollectionInput(collection: collection)
@@ -227,7 +227,7 @@ public class NaturalLanguageClassifier {
         metadata: URL,
         trainingData: URL,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -281,7 +281,7 @@ public class NaturalLanguageClassifier {
      */
     public func listClassifiers(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ClassifierList>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ClassifierList>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -316,7 +316,7 @@ public class NaturalLanguageClassifier {
     public func getClassifier(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -354,7 +354,7 @@ public class NaturalLanguageClassifier {
     public func deleteClassifier(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -121,7 +121,7 @@ public class NaturalLanguageClassifier {
         // construct body
         let classifyRequest = ClassifyInput(text: text)
         guard let body = try? JSONEncoder().encode(classifyRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -136,7 +136,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)/classify"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -174,7 +174,7 @@ public class NaturalLanguageClassifier {
         // construct body
         let classifyCollectionRequest = ClassifyCollectionInput(collection: collection)
         guard let body = try? JSONEncoder().encode(classifyCollectionRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -189,7 +189,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)/classify_collection"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -233,17 +233,17 @@ public class NaturalLanguageClassifier {
         do {
             try multipartFormData.append(file: metadata, withName: "training_metadata")
         } catch {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "file \(metadata.path)"))
             return
         }
         do {
             try multipartFormData.append(file: trainingData, withName: "training_data")
         } catch {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "file \(trainingData.path)"))
             return
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -327,7 +327,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -365,7 +365,7 @@ public class NaturalLanguageClassifier {
         // construct REST request
         let path = "/v1/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -98,18 +98,19 @@ public class NaturalLanguageUnderstanding {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["description"] {
-                metadata["description"] = JSON.string(description)
+                metadata["description"] = description
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -286,7 +287,7 @@ public class NaturalLanguageUnderstanding {
         // construct REST request
         let path = "/v1/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -88,27 +88,30 @@ public class NaturalLanguageUnderstanding {
     }
 
     /**
-     If the response or data represents an error returned by the Natural Language Understanding service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Natural Language Understanding service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["description"] {
-                userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
+                metadata["description"] = JSON.string(description)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -184,7 +187,7 @@ public class NaturalLanguageUnderstanding {
             language: language,
             limitTextCharacters: limitTextCharacters)
         guard let body = try? JSONEncoder().encode(analyzeRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -283,7 +286,7 @@ public class NaturalLanguageUnderstanding {
         // construct REST request
         let path = "/v1/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -173,7 +173,7 @@ public class NaturalLanguageUnderstanding {
         language: String? = nil,
         limitTextCharacters: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AnalysisResults>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AnalysisResults>?, RestError?) -> Void)
     {
         // construct body
         let analyzeRequest = Parameters(
@@ -231,7 +231,7 @@ public class NaturalLanguageUnderstanding {
      */
     public func listModels(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListModelsResults>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListModelsResults>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -271,7 +271,7 @@ public class NaturalLanguageUnderstanding {
     public func deleteModel(
         modelID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteModelResults>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteModelResults>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -94,7 +94,7 @@ public class NaturalLanguageUnderstanding {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -109,10 +109,10 @@ public class NaturalLanguageUnderstanding {
             if case let .some(.string(description)) = json["description"] {
                 metadata["description"] = description
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -173,7 +173,7 @@ public class NaturalLanguageUnderstanding {
         language: String? = nil,
         limitTextCharacters: Int? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AnalysisResults>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AnalysisResults>?, WatsonError?) -> Void)
     {
         // construct body
         let analyzeRequest = Parameters(
@@ -188,7 +188,7 @@ public class NaturalLanguageUnderstanding {
             language: language,
             limitTextCharacters: limitTextCharacters)
         guard let body = try? JSONEncoder().encode(analyzeRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -231,7 +231,7 @@ public class NaturalLanguageUnderstanding {
      */
     public func listModels(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ListModelsResults>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ListModelsResults>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -271,7 +271,7 @@ public class NaturalLanguageUnderstanding {
     public func deleteModel(
         modelID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DeleteModelResults>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DeleteModelResults>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -287,7 +287,7 @@ public class NaturalLanguageUnderstanding {
         // construct REST request
         let path = "/v1/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -104,18 +104,19 @@ public class PersonalityInsights {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(help)) = json["help"] {
-                metadata["help"] = JSON.string(help)
+                metadata["help"] = help
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -171,7 +171,7 @@ public class PersonalityInsights {
         rawScores: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Profile>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Profile>?, RestError?) -> Void)
     {
         // construct body
         guard let body = profileContent.content else {
@@ -273,7 +273,7 @@ public class PersonalityInsights {
         csvHeaders: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<String>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<String>?, RestError?) -> Void)
     {
         // construct body
         guard let body = profileContent.content else {

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -174,7 +174,7 @@ public class PersonalityInsights {
     {
         // construct body
         guard let body = profileContent.content else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -276,7 +276,7 @@ public class PersonalityInsights {
     {
         // construct body
         guard let body = profileContent.content else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -94,27 +94,30 @@ public class PersonalityInsights {
     }
 
     /**
-     If the response or data represents an error returned by the Personality Insights service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Personality Insights service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(help)) = json["help"] {
-                userInfo[NSLocalizedFailureReasonErrorKey] = help
+                metadata["help"] = JSON.string(help)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -100,7 +100,7 @@ public class PersonalityInsights {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -115,10 +115,10 @@ public class PersonalityInsights {
             if case let .some(.string(help)) = json["help"] {
                 metadata["help"] = help
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -171,11 +171,11 @@ public class PersonalityInsights {
         rawScores: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Profile>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Profile>?, WatsonError?) -> Void)
     {
         // construct body
         guard let body = profileContent.content else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -273,11 +273,11 @@ public class PersonalityInsights {
         csvHeaders: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<String>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<String>?, WatsonError?) -> Void)
     {
         // construct body
         guard let body = profileContent.content else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -59,9 +59,7 @@ extension SpeechToText {
                 completionHandler: completionHandler
             )
         } catch {
-            let failureReason = "Could not load audio data from \(audio)."
-            let userInfo = [NSLocalizedDescriptionKey: failureReason]
-            let error = NSError(domain: domain, code: 0, userInfo: userInfo)
+            let error = RestError.serialization(values: "audio data from \(audio)")
             completionHandler(nil, error)
             return
         }
@@ -183,8 +181,7 @@ extension SpeechToText {
             try audioSession.setActive(true)
         } catch {
             let failureReason = "Failed to setup the AVAudioSession sharedInstance properly."
-            let userInfo = [NSLocalizedDescriptionKey: failureReason]
-            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+            let error = RestError.other(message: failureReason)
             completionHandler(nil, error)
             return
         }
@@ -196,8 +193,7 @@ extension SpeechToText {
         // extract authMethod
         guard let basicAuth = authMethod as? BasicAuthentication else {
             let failureReason = "Invalid authenticaion method format."
-            let userInfo = [NSLocalizedDescriptionKey: failureReason]
-            let error = NSError(domain: domain, code: 0, userInfo: userInfo)
+            let error = RestError.other(message: failureReason)
             completionHandler(nil, error)
             return
         }

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -46,7 +46,7 @@ extension SpeechToText {
         model: String? = nil,
         customizationID: String? = nil,
         learningOptOut: Bool? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
     {
         do {
             let data = try Data(contentsOf: audio)
@@ -93,7 +93,7 @@ extension SpeechToText {
         acousticCustomizationID: String? = nil,
         learningOptOut: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
     {
         // create SpeechToTextSession
         let session = SpeechToTextSession(
@@ -172,7 +172,7 @@ extension SpeechToText {
         learningOptOut: Bool? = nil,
         compress: Bool = true,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
     {
         // make sure the AVAudioSession shared instance is properly configured
         do {
@@ -262,7 +262,7 @@ extension SpeechToText {
         model: String? = nil,
         customizationID: String? = nil,
         learningOptOut: Bool? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
     {
         recognizeUsingWebSocket(audio: audio, settings: settings, model: model, customizationID: customizationID,
                                 learningOptOut: learningOptOut, completionHandler: completionHandler)

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -46,7 +46,7 @@ extension SpeechToText {
         model: String? = nil,
         customizationID: String? = nil,
         learningOptOut: Bool? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
     {
         do {
             let data = try Data(contentsOf: audio)
@@ -59,7 +59,7 @@ extension SpeechToText {
                 completionHandler: completionHandler
             )
         } catch {
-            let error = RestError.serialization(values: "audio data from \(audio)")
+            let error = WatsonError.serialization(values: "audio data from \(audio)")
             completionHandler(nil, error)
             return
         }
@@ -93,7 +93,7 @@ extension SpeechToText {
         acousticCustomizationID: String? = nil,
         learningOptOut: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
     {
         // create SpeechToTextSession
         let session = SpeechToTextSession(
@@ -172,7 +172,7 @@ extension SpeechToText {
         learningOptOut: Bool? = nil,
         compress: Bool = true,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
     {
         // make sure the AVAudioSession shared instance is properly configured
         do {
@@ -181,7 +181,7 @@ extension SpeechToText {
             try audioSession.setActive(true)
         } catch {
             let failureReason = "Failed to setup the AVAudioSession sharedInstance properly."
-            let error = RestError.other(message: failureReason)
+            let error = WatsonError.other(message: failureReason)
             completionHandler(nil, error)
             return
         }
@@ -193,7 +193,7 @@ extension SpeechToText {
         // extract authMethod
         guard let basicAuth = authMethod as? BasicAuthentication else {
             let failureReason = "Invalid authenticaion method format."
-            let error = RestError.other(message: failureReason)
+            let error = WatsonError.other(message: failureReason)
             completionHandler(nil, error)
             return
         }
@@ -262,7 +262,7 @@ extension SpeechToText {
         model: String? = nil,
         customizationID: String? = nil,
         learningOptOut: Bool? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
     {
         recognizeUsingWebSocket(audio: audio, settings: settings, model: model, customizationID: customizationID,
                                 learningOptOut: learningOptOut, completionHandler: completionHandler)

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -99,18 +99,19 @@ public class SpeechToText {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["code_description"] {
-                metadata["codeDescription"] = JSON.string(description)
+                metadata["codeDescription"] = description
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -178,7 +179,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -900,7 +901,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/recognitions/\(id)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -943,7 +944,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/recognitions/\(id)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1105,7 +1106,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1150,7 +1151,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1237,7 +1238,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/train"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1284,7 +1285,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/reset"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1336,7 +1337,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/upgrade_model"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1381,7 +1382,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1488,7 +1489,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora/\(corpusName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1537,7 +1538,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora/\(corpusName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1586,7 +1587,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora/\(corpusName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1655,7 +1656,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1743,7 +1744,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1839,7 +1840,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(wordName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1888,7 +1889,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(wordName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1939,7 +1940,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(wordName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2092,7 +2093,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2137,7 +2138,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2215,7 +2216,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/train"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2262,7 +2263,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/reset"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2330,7 +2331,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/upgrade_model"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2378,7 +2379,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2516,7 +2517,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio/\(audioName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2575,7 +2576,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio/\(audioName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2624,7 +2625,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio/\(audioName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -129,7 +129,7 @@ public class SpeechToText {
      */
     public func listModels(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechModels>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechModels>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -167,7 +167,7 @@ public class SpeechToText {
     public func getModel(
         modelID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechModel>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechModel>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -335,7 +335,7 @@ public class SpeechToText {
         smartFormatting: Bool? = nil,
         speakerLabels: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
     {
         // construct body
         let body = audio
@@ -468,7 +468,7 @@ public class SpeechToText {
         callbackUrl: String,
         userSecret: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<RegisterStatus>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<RegisterStatus>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -515,7 +515,7 @@ public class SpeechToText {
     public func unregisterCallback(
         callbackUrl: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -721,7 +721,7 @@ public class SpeechToText {
         smartFormatting: Bool? = nil,
         speakerLabels: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<RecognitionJob>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<RecognitionJob>?, RestError?) -> Void)
     {
         // construct body
         let body = audio
@@ -846,7 +846,7 @@ public class SpeechToText {
      */
     public func checkJobs(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<RecognitionJobs>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<RecognitionJobs>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -889,7 +889,7 @@ public class SpeechToText {
     public func checkJob(
         id: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<RecognitionJob>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<RecognitionJob>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -932,7 +932,7 @@ public class SpeechToText {
     public func deleteJob(
         id: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -996,7 +996,7 @@ public class SpeechToText {
         dialect: String? = nil,
         description: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LanguageModel>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LanguageModel>?, RestError?) -> Void)
     {
         // construct body
         let createLanguageModelRequest = CreateLanguageModel(name: name, baseModelName: baseModelName, dialect: dialect, description: description)
@@ -1047,7 +1047,7 @@ public class SpeechToText {
     public func listLanguageModels(
         language: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LanguageModels>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LanguageModels>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1094,7 +1094,7 @@ public class SpeechToText {
     public func getLanguageModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LanguageModel>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LanguageModel>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1139,7 +1139,7 @@ public class SpeechToText {
     public func deleteLanguageModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1215,7 +1215,7 @@ public class SpeechToText {
         wordTypeToAdd: String? = nil,
         customizationWeight: Double? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1273,7 +1273,7 @@ public class SpeechToText {
     public func resetLanguageModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1325,7 +1325,7 @@ public class SpeechToText {
     public func upgradeLanguageModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1370,7 +1370,7 @@ public class SpeechToText {
     public func listCorpora(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Corpora>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Corpora>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1456,7 +1456,7 @@ public class SpeechToText {
         corpusFile: URL,
         allowOverwrite: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -1526,7 +1526,7 @@ public class SpeechToText {
         customizationID: String,
         corpusName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Corpus>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Corpus>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1575,7 +1575,7 @@ public class SpeechToText {
         customizationID: String,
         corpusName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1633,7 +1633,7 @@ public class SpeechToText {
         wordType: String? = nil,
         sort: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Words>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Words>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1724,7 +1724,7 @@ public class SpeechToText {
         customizationID: String,
         words: [CustomWord],
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct body
         let addWordsRequest = CustomWords(words: words)
@@ -1820,7 +1820,7 @@ public class SpeechToText {
         soundsLike: [String]? = nil,
         displayAs: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct body
         let addWordRequest = CustomWord(word: word, soundsLike: soundsLike, displayAs: displayAs)
@@ -1877,7 +1877,7 @@ public class SpeechToText {
         customizationID: String,
         wordName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Word>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Word>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1928,7 +1928,7 @@ public class SpeechToText {
         customizationID: String,
         wordName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1983,7 +1983,7 @@ public class SpeechToText {
         baseModelName: String,
         description: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AcousticModel>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AcousticModel>?, RestError?) -> Void)
     {
         // construct body
         let createAcousticModelRequest = CreateAcousticModel(name: name, baseModelName: baseModelName, description: description)
@@ -2034,7 +2034,7 @@ public class SpeechToText {
     public func listAcousticModels(
         language: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AcousticModels>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AcousticModels>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2081,7 +2081,7 @@ public class SpeechToText {
     public func getAcousticModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AcousticModel>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AcousticModel>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2126,7 +2126,7 @@ public class SpeechToText {
     public func deleteAcousticModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2197,7 +2197,7 @@ public class SpeechToText {
         customizationID: String,
         customLanguageModelID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2251,7 +2251,7 @@ public class SpeechToText {
     public func resetAcousticModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2312,7 +2312,7 @@ public class SpeechToText {
         customizationID: String,
         customLanguageModelID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2367,7 +2367,7 @@ public class SpeechToText {
     public func listAudio(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AudioResources>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AudioResources>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2492,7 +2492,7 @@ public class SpeechToText {
         containedContentType: String? = nil,
         allowOverwrite: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         let body = audioResource
 
@@ -2564,7 +2564,7 @@ public class SpeechToText {
         customizationID: String,
         audioName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AudioListing>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AudioListing>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2613,7 +2613,7 @@ public class SpeechToText {
         customizationID: String,
         audioName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2660,7 +2660,7 @@ public class SpeechToText {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -89,27 +89,30 @@ public class SpeechToText {
     }
 
     /**
-     If the response or data represents an error returned by the Speech to Text service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Speech to Text service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["code_description"] {
-                userInfo[NSLocalizedRecoverySuggestionErrorKey] = description
+                metadata["codeDescription"] = JSON.string(description)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -178,7 +178,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -900,7 +900,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/recognitions/\(id)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -943,7 +943,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/recognitions/\(id)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1000,7 +1000,7 @@ public class SpeechToText {
         // construct body
         let createLanguageModelRequest = CreateLanguageModel(name: name, baseModelName: baseModelName, dialect: dialect, description: description)
         guard let body = try? JSONEncoder().encode(createLanguageModelRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1105,7 +1105,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1150,7 +1150,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1237,7 +1237,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/train"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1284,7 +1284,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/reset"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1336,7 +1336,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/upgrade_model"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1381,7 +1381,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1462,11 +1462,11 @@ public class SpeechToText {
         do {
             try multipartFormData.append(file: corpusFile, withName: "corpus_file")
         } catch {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "file \(corpusFile.path)"))
             return
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -1488,7 +1488,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora/\(corpusName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1537,7 +1537,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora/\(corpusName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1586,7 +1586,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora/\(corpusName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1655,7 +1655,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1728,7 +1728,7 @@ public class SpeechToText {
         // construct body
         let addWordsRequest = CustomWords(words: words)
         guard let body = try? JSONEncoder().encode(addWordsRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1743,7 +1743,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1824,7 +1824,7 @@ public class SpeechToText {
         // construct body
         let addWordRequest = CustomWord(word: word, soundsLike: soundsLike, displayAs: displayAs)
         guard let body = try? JSONEncoder().encode(addWordRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -1839,7 +1839,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(wordName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1888,7 +1888,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(wordName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1939,7 +1939,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(wordName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1987,7 +1987,7 @@ public class SpeechToText {
         // construct body
         let createAcousticModelRequest = CreateAcousticModel(name: name, baseModelName: baseModelName, description: description)
         guard let body = try? JSONEncoder().encode(createAcousticModelRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -2092,7 +2092,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2137,7 +2137,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2215,7 +2215,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/train"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2262,7 +2262,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/reset"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2330,7 +2330,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/upgrade_model"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2378,7 +2378,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2516,7 +2516,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio/\(audioName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2575,7 +2575,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio/\(audioName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2624,7 +2624,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio/\(audioName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -95,7 +95,7 @@ public class SpeechToText {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -110,10 +110,10 @@ public class SpeechToText {
             if case let .some(.string(description)) = json["code_description"] {
                 metadata["codeDescription"] = description
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -129,7 +129,7 @@ public class SpeechToText {
      */
     public func listModels(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechModels>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechModels>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -167,7 +167,7 @@ public class SpeechToText {
     public func getModel(
         modelID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechModel>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechModel>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -179,7 +179,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/models/\(modelID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -335,7 +335,7 @@ public class SpeechToText {
         smartFormatting: Bool? = nil,
         speakerLabels: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
     {
         // construct body
         let body = audio
@@ -468,7 +468,7 @@ public class SpeechToText {
         callbackUrl: String,
         userSecret: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<RegisterStatus>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<RegisterStatus>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -515,7 +515,7 @@ public class SpeechToText {
     public func unregisterCallback(
         callbackUrl: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -721,7 +721,7 @@ public class SpeechToText {
         smartFormatting: Bool? = nil,
         speakerLabels: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<RecognitionJob>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<RecognitionJob>?, WatsonError?) -> Void)
     {
         // construct body
         let body = audio
@@ -846,7 +846,7 @@ public class SpeechToText {
      */
     public func checkJobs(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<RecognitionJobs>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<RecognitionJobs>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -889,7 +889,7 @@ public class SpeechToText {
     public func checkJob(
         id: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<RecognitionJob>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<RecognitionJob>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -901,7 +901,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/recognitions/\(id)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -932,7 +932,7 @@ public class SpeechToText {
     public func deleteJob(
         id: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -944,7 +944,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/recognitions/\(id)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -996,12 +996,12 @@ public class SpeechToText {
         dialect: String? = nil,
         description: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LanguageModel>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LanguageModel>?, WatsonError?) -> Void)
     {
         // construct body
         let createLanguageModelRequest = CreateLanguageModel(name: name, baseModelName: baseModelName, dialect: dialect, description: description)
         guard let body = try? JSONEncoder().encode(createLanguageModelRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1047,7 +1047,7 @@ public class SpeechToText {
     public func listLanguageModels(
         language: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LanguageModels>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LanguageModels>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1094,7 +1094,7 @@ public class SpeechToText {
     public func getLanguageModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<LanguageModel>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<LanguageModel>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1106,7 +1106,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1139,7 +1139,7 @@ public class SpeechToText {
     public func deleteLanguageModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1151,7 +1151,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1215,7 +1215,7 @@ public class SpeechToText {
         wordTypeToAdd: String? = nil,
         customizationWeight: Double? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1238,7 +1238,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/train"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1273,7 +1273,7 @@ public class SpeechToText {
     public func resetLanguageModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1285,7 +1285,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/reset"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1325,7 +1325,7 @@ public class SpeechToText {
     public func upgradeLanguageModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1337,7 +1337,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/upgrade_model"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1370,7 +1370,7 @@ public class SpeechToText {
     public func listCorpora(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Corpora>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Corpora>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1382,7 +1382,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1456,18 +1456,18 @@ public class SpeechToText {
         corpusFile: URL,
         allowOverwrite: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
         do {
             try multipartFormData.append(file: corpusFile, withName: "corpus_file")
         } catch {
-            completionHandler(nil, RestError.serialization(values: "file \(corpusFile.path)"))
+            completionHandler(nil, WatsonError.serialization(values: "file \(corpusFile.path)"))
             return
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -1489,7 +1489,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora/\(corpusName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1526,7 +1526,7 @@ public class SpeechToText {
         customizationID: String,
         corpusName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Corpus>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Corpus>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1538,7 +1538,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora/\(corpusName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1575,7 +1575,7 @@ public class SpeechToText {
         customizationID: String,
         corpusName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1587,7 +1587,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/corpora/\(corpusName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1633,7 +1633,7 @@ public class SpeechToText {
         wordType: String? = nil,
         sort: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Words>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Words>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1656,7 +1656,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1724,12 +1724,12 @@ public class SpeechToText {
         customizationID: String,
         words: [CustomWord],
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct body
         let addWordsRequest = CustomWords(words: words)
         guard let body = try? JSONEncoder().encode(addWordsRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1744,7 +1744,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1820,12 +1820,12 @@ public class SpeechToText {
         soundsLike: [String]? = nil,
         displayAs: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct body
         let addWordRequest = CustomWord(word: word, soundsLike: soundsLike, displayAs: displayAs)
         guard let body = try? JSONEncoder().encode(addWordRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -1840,7 +1840,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(wordName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1877,7 +1877,7 @@ public class SpeechToText {
         customizationID: String,
         wordName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Word>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Word>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1889,7 +1889,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(wordName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1928,7 +1928,7 @@ public class SpeechToText {
         customizationID: String,
         wordName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -1940,7 +1940,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(wordName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -1983,12 +1983,12 @@ public class SpeechToText {
         baseModelName: String,
         description: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AcousticModel>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AcousticModel>?, WatsonError?) -> Void)
     {
         // construct body
         let createAcousticModelRequest = CreateAcousticModel(name: name, baseModelName: baseModelName, description: description)
         guard let body = try? JSONEncoder().encode(createAcousticModelRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -2034,7 +2034,7 @@ public class SpeechToText {
     public func listAcousticModels(
         language: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AcousticModels>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AcousticModels>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2081,7 +2081,7 @@ public class SpeechToText {
     public func getAcousticModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AcousticModel>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AcousticModel>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2093,7 +2093,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2126,7 +2126,7 @@ public class SpeechToText {
     public func deleteAcousticModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2138,7 +2138,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2197,7 +2197,7 @@ public class SpeechToText {
         customizationID: String,
         customLanguageModelID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2216,7 +2216,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/train"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2251,7 +2251,7 @@ public class SpeechToText {
     public func resetAcousticModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2263,7 +2263,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/reset"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2312,7 +2312,7 @@ public class SpeechToText {
         customizationID: String,
         customLanguageModelID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2331,7 +2331,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/upgrade_model"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2367,7 +2367,7 @@ public class SpeechToText {
     public func listAudio(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AudioResources>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AudioResources>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2379,7 +2379,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2492,7 +2492,7 @@ public class SpeechToText {
         containedContentType: String? = nil,
         allowOverwrite: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         let body = audioResource
 
@@ -2517,7 +2517,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio/\(audioName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2564,7 +2564,7 @@ public class SpeechToText {
         customizationID: String,
         audioName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<AudioListing>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<AudioListing>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2576,7 +2576,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio/\(audioName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2613,7 +2613,7 @@ public class SpeechToText {
         customizationID: String,
         audioName: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -2625,7 +2625,7 @@ public class SpeechToText {
         // construct REST request
         let path = "/v1/acoustic_customizations/\(customizationID)/audio/\(audioName)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -2660,7 +2660,7 @@ public class SpeechToText {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
@@ -211,9 +211,7 @@ public class SpeechToTextSession {
             let data = try Data(contentsOf: audio)
             recognize(audio: data)
         } catch {
-            let failureReason = "Could not load audio data from \(audio)."
-            let userInfo = [NSLocalizedDescriptionKey: failureReason]
-            let error = NSError(domain: domain, code: 0, userInfo: userInfo)
+            let error = RestError.serialization(values: "audio data from \(audio)")
             onError?(error)
             return
         }
@@ -260,8 +258,7 @@ public class SpeechToTextSession {
         recorder.session.requestRecordPermission { granted in
             guard granted else {
                 let failureReason = "Permission was not granted to access the microphone."
-                let userInfo = [NSLocalizedDescriptionKey: failureReason]
-                let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                let error = RestError.other(message: failureReason)
                 self.onError?(error)
                 return
             }
@@ -298,8 +295,7 @@ public class SpeechToTextSession {
                 try self.recorder.startRecording()
             } catch {
                 let failureReason = "Failed to start recording."
-                let userInfo = [NSLocalizedDescriptionKey: failureReason]
-                let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                let error = RestError.other(message: failureReason)
                 self.onError?(error)
                 return
             }
@@ -314,8 +310,7 @@ public class SpeechToTextSession {
             try recorder.stopRecording()
         } catch {
             let failureReason = "Failed to stop recording."
-            let userInfo = [NSLocalizedDescriptionKey: failureReason]
-            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+            let error = RestError.other(message: failureReason)
             self.onError?(error)
             return
         }

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
@@ -74,7 +74,7 @@ public class SpeechToTextSession {
     }
 
     /// Invoked when an error or warning occurs.
-    public var onError: ((Error) -> Void)? {
+    public var onError: ((RestError) -> Void)? {
         get { return socket.onError }
         set { socket.onError = newValue }
     }

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
@@ -74,7 +74,7 @@ public class SpeechToTextSession {
     }
 
     /// Invoked when an error or warning occurs.
-    public var onError: ((RestError) -> Void)? {
+    public var onError: ((WatsonError) -> Void)? {
         get { return socket.onError }
         set { socket.onError = newValue }
     }
@@ -211,7 +211,7 @@ public class SpeechToTextSession {
             let data = try Data(contentsOf: audio)
             recognize(audio: data)
         } catch {
-            let error = RestError.serialization(values: "audio data from \(audio)")
+            let error = WatsonError.serialization(values: "audio data from \(audio)")
             onError?(error)
             return
         }
@@ -258,7 +258,7 @@ public class SpeechToTextSession {
         recorder.session.requestRecordPermission { granted in
             guard granted else {
                 let failureReason = "Permission was not granted to access the microphone."
-                let error = RestError.other(message: failureReason)
+                let error = WatsonError.other(message: failureReason)
                 self.onError?(error)
                 return
             }
@@ -295,7 +295,7 @@ public class SpeechToTextSession {
                 try self.recorder.startRecording()
             } catch {
                 let failureReason = "Failed to start recording."
-                let error = RestError.other(message: failureReason)
+                let error = WatsonError.other(message: failureReason)
                 self.onError?(error)
                 return
             }
@@ -310,7 +310,7 @@ public class SpeechToTextSession {
             try recorder.stopRecording()
         } catch {
             let failureReason = "Failed to stop recording."
-            let error = RestError.other(message: failureReason)
+            let error = WatsonError.other(message: failureReason)
             self.onError?(error)
             return
         }

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
@@ -26,7 +26,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
     internal var onConnect: (() -> Void)?
     internal var onListening: (() -> Void)?
     internal var onResults: ((SpeechRecognitionResults) -> Void)?
-    internal var onError: ((RestError) -> Void)?
+    internal var onError: ((WatsonError) -> Void)?
     internal var onDisconnect: (() -> Void)?
 
     private let url: URL
@@ -73,7 +73,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
         // restrict the number of retries
         guard connectAttempts <= maxConnectAttempts else {
             let failureReason = "Invalid HTTP upgrade. Check credentials."
-            let error = RestError.http(statusCode: 400, message: failureReason, metadata: ["type": "Websocket"])
+            let error = WatsonError.http(statusCode: 400, message: failureReason, metadata: ["type": "Websocket"])
             onError?(error)
             return
         }
@@ -94,7 +94,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
                 self.socket.delegate = self
                 self.socket.connect()
             } else {
-                self.onError?(error ?? RestError.http(statusCode: 400, message: "Token Manager error", metadata: nil))
+                self.onError?(error ?? WatsonError.http(statusCode: 400, message: "Token Manager error", metadata: nil))
             }
         }
     }
@@ -191,7 +191,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
     }
 
     private func onErrorMessage(error: String) {
-        let error = RestError.other(message: error)
+        let error = WatsonError.other(message: error)
         onError?(error)
     }
 
@@ -255,7 +255,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
             self.connect()
             return
         }
-        onError?(RestError.other(message: String(describing: error)))
+        onError?(WatsonError.other(message: String(describing: error)))
         onDisconnect?()
     }
 }

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
@@ -26,7 +26,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
     internal var onConnect: (() -> Void)?
     internal var onListening: (() -> Void)?
     internal var onResults: ((SpeechRecognitionResults) -> Void)?
-    internal var onError: ((Error) -> Void)?
+    internal var onError: ((RestError) -> Void)?
     internal var onDisconnect: (() -> Void)?
 
     private let url: URL
@@ -198,7 +198,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
     private func isAuthenticationFailure(error: Error) -> Bool {
         if let error = error as? WSError {
             let matchesCode = (error.code == 400)
-            let matchesType = (error.type == .upgradeError)
+            let matchesType     = (error.type == .upgradeError)
             return matchesCode && matchesType
         }
         return false
@@ -255,7 +255,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
             self.connect()
             return
         }
-        onError?(error)
+        onError?(RestError.other(message: String(describing: error)))
         onDisconnect?()
     }
 }

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
@@ -95,7 +95,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
                 self.socket.delegate = self
                 self.socket.connect()
             } else {
-                self.onError?(error ?? RestError.failure(400, "Token Manager error"))
+                self.onError?(error ?? RestError.http(statusCode: 400, message: "Token Manager error", metadata: nil))
             }
         }
     }
@@ -192,7 +192,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
     }
 
     private func onErrorMessage(error: String) {
-        let error = RestError.failure(0, error)
+        let error = RestError.http(statusCode: nil, message: error, metadata: nil)
         onError?(error)
     }
 

--- a/Source/SupportingFiles/Shared.swift
+++ b/Source/SupportingFiles/Shared.swift
@@ -17,6 +17,9 @@
 import Foundation
 import RestKit
 
+public typealias WatsonResponse = RestResponse
+public typealias WatsonError = RestError
+
 /// Contains functionality and information common to all of the services
 internal struct Shared {
 

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -287,9 +287,7 @@ public class TextToSpeech {
                 // repair the WAV header
                 var wav = data
                 guard WAVRepair.isWAVFile(data: wav) else {
-                    let failureReason = "Returned audio is in an unexpected format."
-                    let userInfo = [NSLocalizedDescriptionKey: failureReason]
-                    let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                    let error = RestError.other(message: "Expected returned audio to be in WAV format")
                     completionHandler(nil, error)
                     return
                 }
@@ -302,9 +300,7 @@ public class TextToSpeech {
                     response?.result = decodedAudio.pcmDataWithHeaders
                     completionHandler(response, nil)
                 } catch {
-                    let failureReason = "Returned audio is in an unexpected format."
-                    let userInfo = [NSLocalizedDescriptionKey: failureReason]
-                    let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                    let error = RestError.serialization(values: "returned audio")
                     completionHandler(nil, error)
                     return
                 }

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -123,7 +123,7 @@ public class TextToSpeech {
      */
     public func listVoices(
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Voices>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Voices>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -165,7 +165,7 @@ public class TextToSpeech {
         voice: String,
         customizationID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Voice>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Voice>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -234,7 +234,7 @@ public class TextToSpeech {
         voice: String? = nil,
         customizationID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Data>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Data>?, RestError?) -> Void)
     {
         // construct body
         let synthesizeRequest = Text(text: text)
@@ -277,7 +277,7 @@ public class TextToSpeech {
         )
 
         // execute REST request
-        request.response { (response: WatsonResponse<Data>?, error: Error?) in
+        request.response { (response: WatsonResponse<Data>?, error: RestError?) in
             var response = response
             guard let data = response?.result else {
                 completionHandler(response, error)
@@ -339,7 +339,7 @@ public class TextToSpeech {
         format: String? = nil,
         customizationID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Pronunciation>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Pronunciation>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -401,7 +401,7 @@ public class TextToSpeech {
         language: String? = nil,
         description: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<VoiceModel>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<VoiceModel>?, RestError?) -> Void)
     {
         // construct body
         let createVoiceModelRequest = CreateVoiceModel(name: name, language: language, description: description)
@@ -453,7 +453,7 @@ public class TextToSpeech {
     public func listVoiceModels(
         language: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<VoiceModels>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<VoiceModels>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -521,7 +521,7 @@ public class TextToSpeech {
         description: String? = nil,
         words: [Word]? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct body
         let updateVoiceModelRequest = UpdateVoiceModel(name: name, description: description, words: words)
@@ -576,7 +576,7 @@ public class TextToSpeech {
     public func getVoiceModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<VoiceModel>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<VoiceModel>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -621,7 +621,7 @@ public class TextToSpeech {
     public func deleteVoiceModel(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -683,7 +683,7 @@ public class TextToSpeech {
         customizationID: String,
         words: [Word],
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct body
         let addWordsRequest = Words(words: words)
@@ -738,7 +738,7 @@ public class TextToSpeech {
     public func listWords(
         customizationID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Words>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Words>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -807,7 +807,7 @@ public class TextToSpeech {
         translation: String,
         partOfSpeech: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct body
         let addWordRequest = Translation(translation: translation, partOfSpeech: partOfSpeech)
@@ -862,7 +862,7 @@ public class TextToSpeech {
         customizationID: String,
         word: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Translation>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Translation>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -909,7 +909,7 @@ public class TextToSpeech {
         customizationID: String,
         word: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -955,7 +955,7 @@ public class TextToSpeech {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -93,18 +93,19 @@ public class TextToSpeech {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["code_description"] {
-                metadata["codeDescription"] = JSON.string(description)
+                metadata["codeDescription"] = description
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -183,7 +184,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/voices/\(voice)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -544,7 +545,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -591,7 +592,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -635,7 +636,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -706,7 +707,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -753,7 +754,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -829,7 +830,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(word)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -877,7 +878,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(word)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -923,7 +924,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(word)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -83,27 +83,30 @@ public class TextToSpeech {
     }
 
     /**
-     If the response or data represents an error returned by the Text to Speech service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Text to Speech service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
             if case let .some(.string(description)) = json["code_description"] {
-                userInfo[NSLocalizedFailureReasonErrorKey] = description
+                metadata["codeDescription"] = JSON.string(description)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -183,7 +183,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/voices/\(voice)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -238,7 +238,7 @@ public class TextToSpeech {
         // construct body
         let synthesizeRequest = Text(text: text)
         guard let body = try? JSONEncoder().encode(synthesizeRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -409,7 +409,7 @@ public class TextToSpeech {
         // construct body
         let createVoiceModelRequest = CreateVoiceModel(name: name, language: language, description: description)
         guard let body = try? JSONEncoder().encode(createVoiceModelRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -529,7 +529,7 @@ public class TextToSpeech {
         // construct body
         let updateVoiceModelRequest = UpdateVoiceModel(name: name, description: description, words: words)
         guard let body = try? JSONEncoder().encode(updateVoiceModelRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -544,7 +544,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -591,7 +591,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -635,7 +635,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -691,7 +691,7 @@ public class TextToSpeech {
         // construct body
         let addWordsRequest = Words(words: words)
         guard let body = try? JSONEncoder().encode(addWordsRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -706,7 +706,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -753,7 +753,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -815,7 +815,7 @@ public class TextToSpeech {
         // construct body
         let addWordRequest = Translation(translation: translation, partOfSpeech: partOfSpeech)
         guard let body = try? JSONEncoder().encode(addWordRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -829,7 +829,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(word)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -877,7 +877,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(word)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -923,7 +923,7 @@ public class TextToSpeech {
         // construct REST request
         let path = "/v1/customizations/\(customizationID)/words/\(word)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -159,7 +159,7 @@ public class ToneAnalyzer {
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ToneAnalysis>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ToneAnalysis>?, RestError?) -> Void)
     {
         // construct body
         guard let body = toneContent.content else {
@@ -242,7 +242,7 @@ public class ToneAnalyzer {
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<UtteranceAnalyses>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<UtteranceAnalyses>?, RestError?) -> Void)
     {
         // construct body
         let toneChatRequest = ToneChatInput(utterances: utterances)

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -94,7 +94,7 @@ public class ToneAnalyzer {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -106,10 +106,10 @@ public class ToneAnalyzer {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -159,11 +159,11 @@ public class ToneAnalyzer {
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ToneAnalysis>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ToneAnalysis>?, WatsonError?) -> Void)
     {
         // construct body
         guard let body = toneContent.content else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 
@@ -242,12 +242,12 @@ public class ToneAnalyzer {
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<UtteranceAnalyses>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<UtteranceAnalyses>?, WatsonError?) -> Void)
     {
         // construct body
         let toneChatRequest = ToneChatInput(utterances: utterances)
         guard let body = try? JSONEncoder().encode(toneChatRequest) else {
-            completionHandler(nil, RestError.serialization(values: "request body"))
+            completionHandler(nil, WatsonError.serialization(values: "request body"))
             return
         }
 

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -162,7 +162,7 @@ public class ToneAnalyzer {
     {
         // construct body
         guard let body = toneContent.content else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 
@@ -246,7 +246,7 @@ public class ToneAnalyzer {
         // construct body
         let toneChatRequest = ToneChatInput(utterances: utterances)
         guard let body = try? JSONEncoder().encode(toneChatRequest) else {
-            completionHandler(nil, RestError.serializationError)
+            completionHandler(nil, RestError.serialization(values: "request body"))
             return
         }
 

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -88,24 +88,27 @@ public class ToneAnalyzer {
     }
 
     /**
-     If the response or data represents an error returned by the Tone Analyzer service,
-     then return NSError with information about the error that occured. Otherwise, return nil.
+     Use the HTTP response and data received by the Tone Analyzer service to extract
+     information about the error that occurred.
 
-     - parameter data: Raw data returned from the service that may represent an error.
-     - parameter response: the URL response returned from the service.
+     - parameter data: Raw data returned by the service that may represent an error.
+     - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> Error {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
 
-        let code = response.statusCode
+        let statusCode = response.statusCode
+        var errorMessage: String?
+        var metadata = [String: JSON]()
+
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
-            var userInfo: [String: Any] = [:]
             if case let .some(.string(message)) = json["error"] {
-                userInfo[NSLocalizedDescriptionKey] = message
+                errorMessage = message
+                metadata["error"] = JSON.string(message)
             }
-            return NSError(domain: domain, code: code, userInfo: userInfo)
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
         } catch {
-            return NSError(domain: domain, code: code, userInfo: nil)
+            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -98,15 +98,16 @@ public class ToneAnalyzer {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-                metadata["error"] = JSON.string(message)
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }

--- a/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
@@ -313,7 +313,7 @@ extension VisualRecognition {
         let json = """
             { "images": [{ "classifiers": [ \(classifiers.joined(separator: ",")) ] }] }
         """
-        guard let data = json.data(using: .utf8) else { throw RestError.serializationError }
+        guard let data = json.data(using: .utf8) else { throw RestError.serialization(values: "Core ML classification") }
         return try JSONDecoder().decode(ClassifiedImages.self, from: data)
     }
 

--- a/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
@@ -47,7 +47,7 @@ extension VisualRecognition {
      */
     public func updateLocalModel(
         classifierID: String,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
     {
         // setup date formatter '2017-12-04T19:44:27.419Z'
         let dateFormatter = DateFormatter()
@@ -142,7 +142,7 @@ extension VisualRecognition {
         imageData: Data,
         classifierIDs: [String] = ["default"],
         threshold: Double? = nil,
-        completionHandler: @escaping (ClassifiedImages?, Error?) -> Void)
+        completionHandler: @escaping (ClassifiedImages?, RestError?) -> Void)
     {
         // ensure a classifier id was provided
         guard !classifierIDs.isEmpty else {
@@ -313,7 +313,7 @@ extension VisualRecognition {
      */
     private func downloadClassifier(
         classifierID: String,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+CoreML.swift
@@ -146,9 +146,7 @@ extension VisualRecognition {
     {
         // ensure a classifier id was provided
         guard !classifierIDs.isEmpty else {
-            let description = "Please provide at least one classifierID."
-            let userInfo = [NSLocalizedDescriptionKey: description]
-            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+            let error = RestError.other(message: "Please provide at least one classifierID.")
             completionHandler(nil, error)
             return
         }
@@ -168,9 +166,7 @@ extension VisualRecognition {
                     model = try self.loadModelFromDisk(classifierID: classifierID)
                 } catch {
                     dispatchGroup.leave()
-                    let description = "Failed to load model for classifier \(classifierID): \(error.localizedDescription)"
-                    let userInfo = [NSLocalizedDescriptionKey: description]
-                    let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                    let error = RestError.other(message: "Failed to load model for classifier \(classifierID): \(error.localizedDescription)")
                     completionHandler(nil, error)
                     return
                 }
@@ -181,9 +177,7 @@ extension VisualRecognition {
                     classifier = try VNCoreMLModel(for: model)
                 } catch {
                     dispatchGroup.leave()
-                    let description = "Failed to convert model for classifier \(classifierID): \(error.localizedDescription)"
-                    let userInfo = [NSLocalizedDescriptionKey: description]
-                    let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                    let error = RestError.other(message: "Failed to convert model for classifier \(classifierID): \(error.localizedDescription)")
                     completionHandler(nil, error)
                     return
                 }
@@ -192,17 +186,13 @@ extension VisualRecognition {
                 let request = VNCoreMLRequest(model: classifier) { request, error in
                     if let error = error {
                         dispatchGroup.leave()
-                        let description = "Classifier \(classifierID) failed with error: \(error)"
-                        let userInfo = [NSLocalizedDescriptionKey: description]
-                        let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                        let error = RestError.other(message: "Classifier \(classifierID) failed with error: \(error)")
                         completionHandler(nil, error)
                         return
                     }
                     guard let observations = request.results as? [VNClassificationObservation] else {
                         dispatchGroup.leave()
-                        let description = "Failed to parse results for classifier \(classifierID)"
-                        let userInfo = [NSLocalizedDescriptionKey: description]
-                        let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                        let error = RestError.other(message: "Failed to parse results for classifier \(classifierID)")
                         completionHandler(nil, error)
                         return
                     }
@@ -219,9 +209,7 @@ extension VisualRecognition {
                     try requestHandler.perform([request])
                 } catch {
                     dispatchGroup.leave()
-                    let description = "Failed to process classification request: \(error.localizedDescription)"
-                    let userInfo = [NSLocalizedDescriptionKey: description]
-                    let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                    let error = RestError.other(message: "Failed to process classification request: \(error.localizedDescription)")
                     completionHandler(nil, error)
                     return
                 }
@@ -235,9 +223,7 @@ extension VisualRecognition {
             do {
                 classifiedImages = try self.convert(results: results, threshold: threshold)
             } catch {
-                let description = "Failed to represent results as JSON: \(error.localizedDescription)"
-                let userInfo = [NSLocalizedDescriptionKey: description]
-                let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                let error = RestError.other(message: "Failed to represent results as JSON: \(error.localizedDescription)")
                 completionHandler(nil, error)
                 return
             }
@@ -269,9 +255,7 @@ extension VisualRecognition {
         }
 
         // model not found -> throw an error
-        let description = "Failed to locate a Core ML model on disk for classifier \(classifierID)."
-        let userInfo = [NSLocalizedDescriptionKey: description]
-        let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+        let error = RestError.other(message: "Failed to locate a Core ML model on disk for classifier \(classifierID).")
         throw error
     }
 
@@ -361,9 +345,7 @@ extension VisualRecognition {
                 create: true
             )
         } catch {
-            let description = "Failed to create temporary downloads directory: \(error.localizedDescription)"
-            let userInfo = [NSLocalizedDescriptionKey: description]
-            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+            let error = RestError.other(message: "Failed to create temporary downloads directory: \(error.localizedDescription)")
             completionHandler(nil, error)
             return
         }
@@ -378,9 +360,7 @@ extension VisualRecognition {
                 create: true
             )
         } catch {
-            let description = "Failed to locate application support directory: \(error.localizedDescription)"
-            let userInfo = [NSLocalizedDescriptionKey: description]
-            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+            let error = RestError.other(message: "Failed to locate application support directory: \(error.localizedDescription)")
             completionHandler(nil, error)
             return
         }
@@ -399,17 +379,13 @@ extension VisualRecognition {
             }
 
             guard let statusCode = response?.statusCode else {
-                let description = "Did not receive response."
-                let userInfo = [NSLocalizedDescriptionKey: description]
-                let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                let error = RestError.noResponse
                 completionHandler(nil, error)
                 return
             }
 
             guard (200..<300).contains(statusCode) else {
-                let description = "Status code was not acceptable: \(statusCode)."
-                let userInfo = [NSLocalizedDescriptionKey: description]
-                let error = NSError(domain: self.domain, code: statusCode, userInfo: userInfo)
+                let error = RestError.http(statusCode: statusCode, message: nil, metadata: nil)
                 completionHandler(nil, error)
                 return
             }
@@ -419,9 +395,7 @@ extension VisualRecognition {
             do {
                 compiledModelTemporaryURL = try MLModel.compileModel(at: sourceModelURL)
             } catch {
-                let description = "Could not compile Core ML model from source: \(error.localizedDescription)"
-                let userInfo = [NSLocalizedDescriptionKey: description]
-                let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                let error = RestError.other(message: "Could not compile Core ML model from source: \(error.localizedDescription)")
                 completionHandler(nil, error)
                 return
             }
@@ -435,9 +409,7 @@ extension VisualRecognition {
                     try fileManager.copyItem(at: compiledModelTemporaryURL, to: compiledModelURL)
                 }
             } catch {
-                let description = "Failed to move compiled model: \(error.localizedDescription)"
-                let userInfo = [NSLocalizedDescriptionKey: description]
-                let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                let error = RestError.other(message: "Failed to move compiled model: \(error.localizedDescription)")
                 completionHandler(nil, error)
                 return
             }
@@ -448,9 +420,7 @@ extension VisualRecognition {
             do {
                 try compiledModelURL.setResourceValues(urlResourceValues)
             } catch {
-                let description = "Could not exclude compiled model from backup: \(error.localizedDescription)"
-                let userInfo = [NSLocalizedDescriptionKey: description]
-                let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+                let error = RestError.other(message: "Could not exclude compiled model from backup: \(error.localizedDescription)")
                 completionHandler(nil, error)
             }
 

--- a/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
@@ -155,9 +155,7 @@ extension VisualRecognition {
     {
         // convert UIImage to Data
         guard let imageData = UIImagePNGRepresentation(image) else {
-            let description = "Failed to convert image from UIImage to Data."
-            let userInfo = [NSLocalizedDescriptionKey: description]
-            let error = NSError(domain: self.domain, code: 0, userInfo: userInfo)
+            let error = RestError.serialization(values: "image to data")
             completionHandler(nil, error)
             return
         }

--- a/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
@@ -172,8 +172,8 @@ extension VisualRecognition {
     private func saveToDisk(image: UIImage) throws -> URL {
         let filename = UUID().uuidString + ".jpg"
         let directory = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        guard let file = directory.appendingPathComponent(filename) else { throw RestError.encodingError }
-        guard let data = UIImageJPEGRepresentation(image, 0.75) else { throw RestError.encodingError }
+        guard let file = directory.appendingPathComponent(filename) else { throw RestError.encoding(path: filename) }
+        guard let data = UIImageJPEGRepresentation(image, 0.75) else { throw RestError.serialization(values: "classify image") }
         try data.write(to: file)
         return file
     }

--- a/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
@@ -67,14 +67,14 @@ extension VisualRecognition {
         owners: [String]? = nil,
         classifierIDs: [String]? = nil,
         acceptLanguage: String? = nil,
-        completionHandler: @escaping (WatsonResponse<ClassifiedImages>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ClassifiedImages>?, WatsonError?) -> Void)
     {
         // save image to disk
         let file: URL
         do {
             file = try saveToDisk(image: image)
         } catch {
-            let error = RestError.saveData
+            let error = WatsonError.saveData
             completionHandler(nil, error)
             return
         }
@@ -82,7 +82,7 @@ extension VisualRecognition {
         // delete image after service call
         let deleteFile = { try? FileManager.default.removeItem(at: file) }
         let completion = {
-            (response: WatsonResponse<ClassifiedImages>?, error: RestError?) in
+            (response: WatsonResponse<ClassifiedImages>?, error: WatsonError?) in
             deleteFile()
             completionHandler(response, error)
         }
@@ -115,14 +115,14 @@ extension VisualRecognition {
      */
     public func detectFaces(
         image: UIImage,
-        completionHandler: @escaping (WatsonResponse<DetectedFaces>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DetectedFaces>?, WatsonError?) -> Void)
     {
         // save image to disk
         let file: URL
         do {
             file = try saveToDisk(image: image)
         } catch {
-            let error = RestError.saveData
+            let error = WatsonError.saveData
             completionHandler(nil, error)
             return
         }
@@ -130,7 +130,7 @@ extension VisualRecognition {
         // delete image after service call
         let deleteFile = { try? FileManager.default.removeItem(at: file) }
         let completion = {
-            (response: WatsonResponse<DetectedFaces>?, error: RestError?) in
+            (response: WatsonResponse<DetectedFaces>?, error: WatsonError?) in
             deleteFile()
             completionHandler(response, error)
         }
@@ -153,11 +153,11 @@ extension VisualRecognition {
         image: UIImage,
         classifierIDs: [String] = ["default"],
         threshold: Double? = nil,
-        completionHandler: @escaping (ClassifiedImages?, RestError?) -> Void)
+        completionHandler: @escaping (ClassifiedImages?, WatsonError?) -> Void)
     {
         // convert UIImage to Data
         guard let imageData = UIImagePNGRepresentation(image) else {
-            let error = RestError.serialization(values: "image to data")
+            let error = WatsonError.serialization(values: "image to data")
             completionHandler(nil, error)
             return
         }
@@ -172,8 +172,8 @@ extension VisualRecognition {
     private func saveToDisk(image: UIImage) throws -> URL {
         let filename = UUID().uuidString + ".jpg"
         let directory = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        guard let file = directory.appendingPathComponent(filename) else { throw RestError.urlEncoding(path: filename) }
-        guard let data = UIImageJPEGRepresentation(image, 0.75) else { throw RestError.serialization(values: "classify image") }
+        guard let file = directory.appendingPathComponent(filename) else { throw WatsonError.urlEncoding(path: filename) }
+        guard let data = UIImageJPEGRepresentation(image, 0.75) else { throw WatsonError.serialization(values: "classify image") }
         try data.write(to: file)
         return file
     }

--- a/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
@@ -67,13 +67,14 @@ extension VisualRecognition {
         owners: [String]? = nil,
         classifierIDs: [String]? = nil,
         acceptLanguage: String? = nil,
-        completionHandler: @escaping (WatsonResponse<ClassifiedImages>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ClassifiedImages>?, RestError?) -> Void)
     {
         // save image to disk
         let file: URL
         do {
             file = try saveToDisk(image: image)
         } catch {
+            let error = RestError.saveData
             completionHandler(nil, error)
             return
         }
@@ -81,7 +82,7 @@ extension VisualRecognition {
         // delete image after service call
         let deleteFile = { try? FileManager.default.removeItem(at: file) }
         let completion = {
-            (response: WatsonResponse<ClassifiedImages>?, error: Error?) in
+            (response: WatsonResponse<ClassifiedImages>?, error: RestError?) in
             deleteFile()
             completionHandler(response, error)
         }
@@ -114,13 +115,14 @@ extension VisualRecognition {
      */
     public func detectFaces(
         image: UIImage,
-        completionHandler: @escaping (WatsonResponse<DetectedFaces>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DetectedFaces>?, RestError?) -> Void)
     {
         // save image to disk
         let file: URL
         do {
             file = try saveToDisk(image: image)
         } catch {
+            let error = RestError.saveData
             completionHandler(nil, error)
             return
         }
@@ -128,7 +130,7 @@ extension VisualRecognition {
         // delete image after service call
         let deleteFile = { try? FileManager.default.removeItem(at: file) }
         let completion = {
-            (response: WatsonResponse<DetectedFaces>?, error: Error?) in
+            (response: WatsonResponse<DetectedFaces>?, error: RestError?) in
             deleteFile()
             completionHandler(response, error)
         }
@@ -151,7 +153,7 @@ extension VisualRecognition {
         image: UIImage,
         classifierIDs: [String] = ["default"],
         threshold: Double? = nil,
-        completionHandler: @escaping (ClassifiedImages?, Error?) -> Void)
+        completionHandler: @escaping (ClassifiedImages?, RestError?) -> Void)
     {
         // convert UIImage to Data
         guard let imageData = UIImagePNGRepresentation(image) else {

--- a/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition+UIImage.swift
@@ -172,7 +172,7 @@ extension VisualRecognition {
     private func saveToDisk(image: UIImage) throws -> URL {
         let filename = UUID().uuidString + ".jpg"
         let directory = NSURL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        guard let file = directory.appendingPathComponent(filename) else { throw RestError.encoding(path: filename) }
+        guard let file = directory.appendingPathComponent(filename) else { throw RestError.urlEncoding(path: filename) }
         guard let data = UIImageJPEGRepresentation(image, 0.75) else { throw RestError.serialization(values: "classify image") }
         try data.write(to: file)
         return file

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -95,18 +95,19 @@ public class VisualRecognition {
 
         let statusCode = response.statusCode
         var errorMessage: String?
-        var metadata = [String: JSON]()
+        var metadata = [String: Any]()
 
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
+            metadata = [:]
             switch statusCode {
             case 403:
                 // ErrorAuthentication
                 if case let .some(.string(status)) = json["status"],
                     case let .some(.string(statusInfo)) = json["statusInfo"] {
                     errorMessage = statusInfo
-                    metadata["status"] = JSON.string(status)
-                    metadata["statusInfo"] = JSON.string(statusInfo)
+                    metadata["status"] = status
+                    metadata["statusInfo"] = statusInfo
                 }
             case 404:
                 // "error": ErrorInfo
@@ -114,23 +115,22 @@ public class VisualRecognition {
                     case let .some(.string(message)) = errorObj["description"],
                     case let .some(.string(errorID)) = errorObj["error_id"] {
                     errorMessage = message
-                    metadata["description"] = JSON.string(message)
-                    metadata["errorID"] = JSON.string(errorID)
+                    metadata["description"] = message
+                    metadata["errorID"] = errorID
                 }
             case 413:
                 // ErrorHTML
                 if case let .some(.string(message)) = json["Error"] {
                     errorMessage = message
-                    metadata["error"] = JSON.string(message)
                 }
             default:
                 // ErrorResponse
                 if case let .some(.string(message)) = json["error"] {
                     errorMessage = message
-                    metadata["error"] = JSON.string(message)
                 }
             }
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: metadata)
+            // If metadata is empty, it should show up as nil in the RestError
+            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
             return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
@@ -483,7 +483,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -573,7 +573,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -617,7 +617,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -663,7 +663,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)/core_ml_model"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encoding(path: path))
+            completionHandler(nil, RestError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -187,7 +187,7 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: imagesFile, withName: "images_file")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(imagesFile.path)"))
                 return
             }
         }
@@ -212,7 +212,7 @@ public class VisualRecognition {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -285,7 +285,7 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: imagesFile, withName: "images_file")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(imagesFile.path)"))
                 return
             }
         }
@@ -295,7 +295,7 @@ public class VisualRecognition {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -365,7 +365,7 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: example.examples, withName: example.name + "_positive_examples")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(example.examples)"))
                 return
             }
         }
@@ -373,12 +373,12 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: negativeExamples, withName: "negative_examples")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(negativeExamples.path)"))
                 return
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -483,7 +483,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -540,7 +540,7 @@ public class VisualRecognition {
                 do {
                     try multipartFormData.append(file: example.examples, withName: example.name + "_positive_examples")
                 } catch {
-                    completionHandler(nil, RestError.serializationError)
+                    completionHandler(nil, RestError.serialization(values: "file \(example.examples)"))
                     return
                 }
             }
@@ -549,12 +549,12 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: negativeExamples, withName: "negative_examples")
             } catch {
-                completionHandler(nil, RestError.serializationError)
+                completionHandler(nil, RestError.serialization(values: "file \(negativeExamples.path)"))
                 return
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -573,7 +573,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -617,7 +617,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(
@@ -663,7 +663,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)/core_ml_model"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.encodingError)
+            completionHandler(nil, RestError.encoding(path: path))
             return
         }
         let request = RestRequest(

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -179,7 +179,7 @@ public class VisualRecognition {
         classifierIDs: [String]? = nil,
         acceptLanguage: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ClassifiedImages>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ClassifiedImages>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -277,7 +277,7 @@ public class VisualRecognition {
         imagesFile: URL? = nil,
         url: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DetectedFaces>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DetectedFaces>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -354,7 +354,7 @@ public class VisualRecognition {
         positiveExamples: [PositiveExample],
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -423,7 +423,7 @@ public class VisualRecognition {
         owners: [String]? = nil,
         verbose: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifiers>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifiers>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -467,7 +467,7 @@ public class VisualRecognition {
     public func getClassifier(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -531,7 +531,7 @@ public class VisualRecognition {
         positiveExamples: [PositiveExample]? = nil,
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -601,7 +601,7 @@ public class VisualRecognition {
     public func deleteClassifier(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -647,7 +647,7 @@ public class VisualRecognition {
     public func getCoreMlModel(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Data>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Data>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -696,7 +696,7 @@ public class VisualRecognition {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, Error?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -91,7 +91,7 @@ public class VisualRecognition {
      - parameter data: Raw data returned by the service that may represent an error.
      - parameter response: the URL response returned by the service.
      */
-    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> RestError {
+    func errorResponseDecoder(data: Data, response: HTTPURLResponse) -> WatsonError {
 
         let statusCode = response.statusCode
         var errorMessage: String?
@@ -129,10 +129,10 @@ public class VisualRecognition {
                     errorMessage = message
                 }
             }
-            // If metadata is empty, it should show up as nil in the RestError
-            return RestError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
+            // If metadata is empty, it should show up as nil in the WatsonError
+            return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
-            return RestError.http(statusCode: statusCode, message: nil, metadata: nil)
+            return WatsonError.http(statusCode: statusCode, message: nil, metadata: nil)
         }
     }
 
@@ -179,7 +179,7 @@ public class VisualRecognition {
         classifierIDs: [String]? = nil,
         acceptLanguage: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<ClassifiedImages>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<ClassifiedImages>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -187,7 +187,7 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: imagesFile, withName: "images_file")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(imagesFile.path)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(imagesFile.path)"))
                 return
             }
         }
@@ -212,7 +212,7 @@ public class VisualRecognition {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -277,7 +277,7 @@ public class VisualRecognition {
         imagesFile: URL? = nil,
         url: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<DetectedFaces>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<DetectedFaces>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -285,7 +285,7 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: imagesFile, withName: "images_file")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(imagesFile.path)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(imagesFile.path)"))
                 return
             }
         }
@@ -295,7 +295,7 @@ public class VisualRecognition {
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -354,7 +354,7 @@ public class VisualRecognition {
         positiveExamples: [PositiveExample],
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -365,7 +365,7 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: example.examples, withName: example.name + "_positive_examples")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(example.examples)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(example.examples)"))
                 return
             }
         }
@@ -373,12 +373,12 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: negativeExamples, withName: "negative_examples")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(negativeExamples.path)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(negativeExamples.path)"))
                 return
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -423,7 +423,7 @@ public class VisualRecognition {
         owners: [String]? = nil,
         verbose: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifiers>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifiers>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -467,7 +467,7 @@ public class VisualRecognition {
     public func getClassifier(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -483,7 +483,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -531,7 +531,7 @@ public class VisualRecognition {
         positiveExamples: [PositiveExample]? = nil,
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Classifier>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Classifier>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
@@ -540,7 +540,7 @@ public class VisualRecognition {
                 do {
                     try multipartFormData.append(file: example.examples, withName: example.name + "_positive_examples")
                 } catch {
-                    completionHandler(nil, RestError.serialization(values: "file \(example.examples)"))
+                    completionHandler(nil, WatsonError.serialization(values: "file \(example.examples)"))
                     return
                 }
             }
@@ -549,12 +549,12 @@ public class VisualRecognition {
             do {
                 try multipartFormData.append(file: negativeExamples, withName: "negative_examples")
             } catch {
-                completionHandler(nil, RestError.serialization(values: "file \(negativeExamples.path)"))
+                completionHandler(nil, WatsonError.serialization(values: "file \(negativeExamples.path)"))
                 return
             }
         }
         guard let body = try? multipartFormData.toData() else {
-            completionHandler(nil, RestError.serialization(values: "request multipart form data"))
+            completionHandler(nil, WatsonError.serialization(values: "request multipart form data"))
             return
         }
 
@@ -573,7 +573,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -601,7 +601,7 @@ public class VisualRecognition {
     public func deleteClassifier(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -617,7 +617,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -647,7 +647,7 @@ public class VisualRecognition {
     public func getCoreMlModel(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Data>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Data>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -663,7 +663,7 @@ public class VisualRecognition {
         // construct REST request
         let path = "/v3/classifiers/\(classifierID)/core_ml_model"
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            completionHandler(nil, RestError.urlEncoding(path: path))
+            completionHandler(nil, WatsonError.urlEncoding(path: path))
             return
         }
         let request = RestRequest(
@@ -696,7 +696,7 @@ public class VisualRecognition {
     public func deleteUserData(
         customerID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Void>?, RestError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Void>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders

--- a/Tests/AssistantV1Tests/AssistantTests.swift
+++ b/Tests/AssistantV1Tests/AssistantTests.swift
@@ -2401,13 +2401,13 @@ class AssistantTests: XCTestCase {
         let expectation = self.expectation(description: description)
         assistant.serviceURL = "this is broken"
         assistant.listWorkspaces { (_, error) in
-            guard let error = error as? RestError else {
+            guard let error = error as? WatsonError else {
                 XCTFail(missingErrorMessage)
                 return
             }
 
             switch error {
-            case RestError.badURL:
+            case WatsonError.badURL:
                 break
             default:
                 XCTFail("Unexpected error: \(error)")

--- a/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
+++ b/Tests/VisualRecognitionV3Tests/VisualRecognitionTests.swift
@@ -556,8 +556,17 @@ class VisualRecognitionTests: XCTestCase {
     /** Get the Core ML model for a trained classifier. */
     func testGetCoreMlModel() {
         let expectation = self.expectation(description: "Get the Core ML model for a trained classifier.")
-        visualRecognition.getCoreMlModel(classifierID: classifierID, failure: failWithError) {
-            coreMLModel in
+        visualRecognition.getCoreMlModel(classifierID: classifierID) {
+            response, error in
+            if let error = error {
+                XCTFail(unexpectedErrorMessage(error))
+                return
+            }
+            guard let coreMLModel = response?.result else {
+                XCTFail(missingResultMessage)
+                return
+            }
+
             XCTAssertNotNil(coreMLModel)
             expectation.fulfill()
         }


### PR DESCRIPTION
Resolves https://github.ibm.com/arf/planning-sdk-squad/issues/549

This takes the updates made to RestKit's `RestError` done in [this PR](https://github.com/watson-developer-cloud/restkit/pull/6), and applies them to the Swift SDK.

There are 3 main changes: 
1. The `errorResponseDecoder()` method on each service returns a `RestError.http` instead of an `NSError. The same was done in LanguageTranslator's `identify()` method.
1. Changed `RestError.encodingError` to `RestError.encoding(path: path)`, which specifies the URL path that failed to be encoded.
1. Changed `RestError.serializationError` to `RestError.serialization(values: "...")`, where `values` is some plain text that explains what values could not be serialized (usually the request body).

The corresponding generator changes are here: https://github.ibm.com/MIL/watson-swagger-codegen/pull/419

One more thing: I did not update the READMEs. I decided to have [one issue](https://github.ibm.com/arf/planning-sdk-squad/issues/732) for updating all of the code samples at once, since more needs to be updated than just the completion handler errors.