### PR TITLE
Mdk/everything codable

### DIFF
--- a/Source/AssistantV1/Models/Counterexample.swift
+++ b/Source/AssistantV1/Models/Counterexample.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Counterexample. */
-public struct Counterexample: Decodable {
+public struct Counterexample: Codable {
 
     /**
      The text of the counterexample.

--- a/Source/AssistantV1/Models/CounterexampleCollection.swift
+++ b/Source/AssistantV1/Models/CounterexampleCollection.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CounterexampleCollection. */
-public struct CounterexampleCollection: Decodable {
+public struct CounterexampleCollection: Codable {
 
     /**
      An array of objects describing the examples marked as irrelevant input.

--- a/Source/AssistantV1/Models/CreateCounterexample.swift
+++ b/Source/AssistantV1/Models/CreateCounterexample.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CreateCounterexample. */
-public struct CreateCounterexample: Encodable {
+public struct CreateCounterexample: Codable {
 
     /**
      The text of a user input marked as irrelevant input. This string must conform to the following restrictions:

--- a/Source/AssistantV1/Models/CreateDialogNode.swift
+++ b/Source/AssistantV1/Models/CreateDialogNode.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** CreateDialogNode. */
-public struct CreateDialogNode: Encodable {
+public struct CreateDialogNode: Codable {
 
     /**
      How the dialog node is processed.

--- a/Source/AssistantV1/Models/CreateEntity.swift
+++ b/Source/AssistantV1/Models/CreateEntity.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** CreateEntity. */
-public struct CreateEntity: Encodable {
+public struct CreateEntity: Codable {
 
     /**
      The name of the entity. This string must conform to the following restrictions:

--- a/Source/AssistantV1/Models/CreateExample.swift
+++ b/Source/AssistantV1/Models/CreateExample.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CreateExample. */
-public struct CreateExample: Encodable {
+public struct CreateExample: Codable {
 
     /**
      The text of a user input example. This string must conform to the following restrictions:

--- a/Source/AssistantV1/Models/CreateIntent.swift
+++ b/Source/AssistantV1/Models/CreateIntent.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CreateIntent. */
-public struct CreateIntent: Encodable {
+public struct CreateIntent: Codable {
 
     /**
      The name of the intent. This string must conform to the following restrictions:

--- a/Source/AssistantV1/Models/CreateSynonym.swift
+++ b/Source/AssistantV1/Models/CreateSynonym.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CreateSynonym. */
-internal struct CreateSynonym: Encodable {
+internal struct CreateSynonym: Codable {
 
     /**
      The text of the synonym. This string must conform to the following restrictions:

--- a/Source/AssistantV1/Models/CreateValue.swift
+++ b/Source/AssistantV1/Models/CreateValue.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** CreateValue. */
-public struct CreateValue: Encodable {
+public struct CreateValue: Codable {
 
     /**
      Specifies the type of value.

--- a/Source/AssistantV1/Models/CreateWorkspace.swift
+++ b/Source/AssistantV1/Models/CreateWorkspace.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** CreateWorkspace. */
-internal struct CreateWorkspace: Encodable {
+internal struct CreateWorkspace: Codable {
 
     /**
      The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be

--- a/Source/AssistantV1/Models/DialogNode.swift
+++ b/Source/AssistantV1/Models/DialogNode.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** DialogNode. */
-public struct DialogNode: Decodable {
+public struct DialogNode: Codable {
 
     /**
      How the dialog node is processed.

--- a/Source/AssistantV1/Models/DialogNodeCollection.swift
+++ b/Source/AssistantV1/Models/DialogNodeCollection.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An array of dialog nodes.
  */
-public struct DialogNodeCollection: Decodable {
+public struct DialogNodeCollection: Codable {
 
     /**
      An array of objects describing the dialog nodes defined for the workspace.

--- a/Source/AssistantV1/Models/Entity.swift
+++ b/Source/AssistantV1/Models/Entity.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** Entity. */
-public struct Entity: Decodable {
+public struct Entity: Codable {
 
     /**
      The name of the entity.

--- a/Source/AssistantV1/Models/EntityCollection.swift
+++ b/Source/AssistantV1/Models/EntityCollection.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An array of entities.
  */
-public struct EntityCollection: Decodable {
+public struct EntityCollection: Codable {
 
     /**
      An array of objects describing the entities defined for the workspace.

--- a/Source/AssistantV1/Models/EntityExport.swift
+++ b/Source/AssistantV1/Models/EntityExport.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** EntityExport. */
-public struct EntityExport: Decodable {
+public struct EntityExport: Codable {
 
     /**
      The name of the entity.

--- a/Source/AssistantV1/Models/EntityMention.swift
+++ b/Source/AssistantV1/Models/EntityMention.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An object describing a contextual entity mention.
  */
-public struct EntityMention: Decodable {
+public struct EntityMention: Codable {
 
     /**
      The text of the user input example.

--- a/Source/AssistantV1/Models/EntityMentionCollection.swift
+++ b/Source/AssistantV1/Models/EntityMentionCollection.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** EntityMentionCollection. */
-public struct EntityMentionCollection: Decodable {
+public struct EntityMentionCollection: Codable {
 
     /**
      An array of objects describing the entity mentions defined for an entity.

--- a/Source/AssistantV1/Models/Example.swift
+++ b/Source/AssistantV1/Models/Example.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Example. */
-public struct Example: Decodable {
+public struct Example: Codable {
 
     /**
      The text of the user input example.

--- a/Source/AssistantV1/Models/ExampleCollection.swift
+++ b/Source/AssistantV1/Models/ExampleCollection.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ExampleCollection. */
-public struct ExampleCollection: Decodable {
+public struct ExampleCollection: Codable {
 
     /**
      An array of objects describing the examples defined for the intent.

--- a/Source/AssistantV1/Models/Intent.swift
+++ b/Source/AssistantV1/Models/Intent.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Intent. */
-public struct Intent: Decodable {
+public struct Intent: Codable {
 
     /**
      The name of the intent.

--- a/Source/AssistantV1/Models/IntentCollection.swift
+++ b/Source/AssistantV1/Models/IntentCollection.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** IntentCollection. */
-public struct IntentCollection: Decodable {
+public struct IntentCollection: Codable {
 
     /**
      An array of objects describing the intents defined for the workspace.

--- a/Source/AssistantV1/Models/IntentExport.swift
+++ b/Source/AssistantV1/Models/IntentExport.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** IntentExport. */
-public struct IntentExport: Decodable {
+public struct IntentExport: Codable {
 
     /**
      The name of the intent.

--- a/Source/AssistantV1/Models/LogCollection.swift
+++ b/Source/AssistantV1/Models/LogCollection.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** LogCollection. */
-public struct LogCollection: Decodable {
+public struct LogCollection: Codable {
 
     /**
      An array of objects describing log events.

--- a/Source/AssistantV1/Models/LogExport.swift
+++ b/Source/AssistantV1/Models/LogExport.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** LogExport. */
-public struct LogExport: Decodable {
+public struct LogExport: Codable {
 
     /**
      A request received by the workspace, including the user input and context.

--- a/Source/AssistantV1/Models/LogPagination.swift
+++ b/Source/AssistantV1/Models/LogPagination.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The pagination data for the returned objects.
  */
-public struct LogPagination: Decodable {
+public struct LogPagination: Codable {
 
     /**
      The URL that will return the next page of results, if any.

--- a/Source/AssistantV1/Models/MessageInput.swift
+++ b/Source/AssistantV1/Models/MessageInput.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The text of the user input.
  */
-public struct MessageInput: Decodable {
+public struct MessageInput: Codable {
 
     /**
      The user's input.

--- a/Source/AssistantV1/Models/MessageResponse.swift
+++ b/Source/AssistantV1/Models/MessageResponse.swift
@@ -20,7 +20,7 @@ import RestKit
 /**
  A response from the Watson Assistant service.
  */
-public struct MessageResponse: Decodable {
+public struct MessageResponse: Codable {
 
     /**
      The user input from the request.
@@ -83,6 +83,19 @@ public struct MessageResponse: Decodable {
         actions = try container.decodeIfPresent([DialogNodeAction].self, forKey: .actions)
         let dynamicContainer = try decoder.container(keyedBy: DynamicKeys.self)
         additionalProperties = try dynamicContainer.decode([String: JSON].self, excluding: CodingKeys.allValues)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(input, forKey: .input)
+        try container.encode(intents, forKey: .intents)
+        try container.encode(entities, forKey: .entities)
+        try container.encodeIfPresent(alternateIntents, forKey: .alternateIntents)
+        try container.encode(context, forKey: .context)
+        try container.encode(output, forKey: .output)
+        try container.encodeIfPresent(actions, forKey: .actions)
+        var dynamicContainer = encoder.container(keyedBy: DynamicKeys.self)
+        try dynamicContainer.encodeIfPresent(additionalProperties)
     }
 
 }

--- a/Source/AssistantV1/Models/Pagination.swift
+++ b/Source/AssistantV1/Models/Pagination.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The pagination data for the returned objects.
  */
-public struct Pagination: Decodable {
+public struct Pagination: Codable {
 
     /**
      The URL that will return the same page of results.

--- a/Source/AssistantV1/Models/Synonym.swift
+++ b/Source/AssistantV1/Models/Synonym.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Synonym. */
-public struct Synonym: Decodable {
+public struct Synonym: Codable {
 
     /**
      The text of the synonym.

--- a/Source/AssistantV1/Models/SynonymCollection.swift
+++ b/Source/AssistantV1/Models/SynonymCollection.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SynonymCollection. */
-public struct SynonymCollection: Decodable {
+public struct SynonymCollection: Codable {
 
     /**
      An array of synonyms.

--- a/Source/AssistantV1/Models/UpdateCounterexample.swift
+++ b/Source/AssistantV1/Models/UpdateCounterexample.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UpdateCounterexample. */
-internal struct UpdateCounterexample: Encodable {
+internal struct UpdateCounterexample: Codable {
 
     /**
      The text of a user input counterexample.

--- a/Source/AssistantV1/Models/UpdateDialogNode.swift
+++ b/Source/AssistantV1/Models/UpdateDialogNode.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** UpdateDialogNode. */
-internal struct UpdateDialogNode: Encodable {
+internal struct UpdateDialogNode: Codable {
 
     /**
      How the dialog node is processed.

--- a/Source/AssistantV1/Models/UpdateEntity.swift
+++ b/Source/AssistantV1/Models/UpdateEntity.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** UpdateEntity. */
-internal struct UpdateEntity: Encodable {
+internal struct UpdateEntity: Codable {
 
     /**
      The name of the entity. This string must conform to the following restrictions:

--- a/Source/AssistantV1/Models/UpdateExample.swift
+++ b/Source/AssistantV1/Models/UpdateExample.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UpdateExample. */
-internal struct UpdateExample: Encodable {
+internal struct UpdateExample: Codable {
 
     /**
      The text of the user input example. This string must conform to the following restrictions:

--- a/Source/AssistantV1/Models/UpdateIntent.swift
+++ b/Source/AssistantV1/Models/UpdateIntent.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UpdateIntent. */
-internal struct UpdateIntent: Encodable {
+internal struct UpdateIntent: Codable {
 
     /**
      The name of the intent. This string must conform to the following restrictions:

--- a/Source/AssistantV1/Models/UpdateSynonym.swift
+++ b/Source/AssistantV1/Models/UpdateSynonym.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UpdateSynonym. */
-internal struct UpdateSynonym: Encodable {
+internal struct UpdateSynonym: Codable {
 
     /**
      The text of the synonym. This string must conform to the following restrictions:

--- a/Source/AssistantV1/Models/UpdateValue.swift
+++ b/Source/AssistantV1/Models/UpdateValue.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** UpdateValue. */
-internal struct UpdateValue: Encodable {
+internal struct UpdateValue: Codable {
 
     /**
      Specifies the type of value.

--- a/Source/AssistantV1/Models/UpdateWorkspace.swift
+++ b/Source/AssistantV1/Models/UpdateWorkspace.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** UpdateWorkspace. */
-internal struct UpdateWorkspace: Encodable {
+internal struct UpdateWorkspace: Codable {
 
     /**
      The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be

--- a/Source/AssistantV1/Models/Value.swift
+++ b/Source/AssistantV1/Models/Value.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** Value. */
-public struct Value: Decodable {
+public struct Value: Codable {
 
     /**
      Specifies the type of value.

--- a/Source/AssistantV1/Models/ValueCollection.swift
+++ b/Source/AssistantV1/Models/ValueCollection.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ValueCollection. */
-public struct ValueCollection: Decodable {
+public struct ValueCollection: Codable {
 
     /**
      An array of entity values.

--- a/Source/AssistantV1/Models/ValueExport.swift
+++ b/Source/AssistantV1/Models/ValueExport.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** ValueExport. */
-public struct ValueExport: Decodable {
+public struct ValueExport: Codable {
 
     /**
      Specifies the type of value.

--- a/Source/AssistantV1/Models/Workspace.swift
+++ b/Source/AssistantV1/Models/Workspace.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** Workspace. */
-public struct Workspace: Decodable {
+public struct Workspace: Codable {
 
     /**
      The name of the workspace.

--- a/Source/AssistantV1/Models/WorkspaceCollection.swift
+++ b/Source/AssistantV1/Models/WorkspaceCollection.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** WorkspaceCollection. */
-public struct WorkspaceCollection: Decodable {
+public struct WorkspaceCollection: Codable {
 
     /**
      An array of objects describing the workspaces associated with the service instance.

--- a/Source/AssistantV1/Models/WorkspaceExport.swift
+++ b/Source/AssistantV1/Models/WorkspaceExport.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** WorkspaceExport. */
-public struct WorkspaceExport: Decodable {
+public struct WorkspaceExport: Codable {
 
     /**
      The current status of the workspace.

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -131,6 +131,7 @@ public class Assistant {
             headerParameters.merge(headers) { (_, new) in new }
         }
         headerParameters["Accept"] = "application/json"
+        headerParameters["Content-Type"] = "application/json"
 
         // construct query parameters
         var queryParameters = [URLQueryItem]()

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -131,7 +131,6 @@ public class Assistant {
             headerParameters.merge(headers) { (_, new) in new }
         }
         headerParameters["Accept"] = "application/json"
-        headerParameters["Content-Type"] = "application/json"
 
         // construct query parameters
         var queryParameters = [URLQueryItem]()

--- a/Source/AssistantV2/Models/DialogLogMessage.swift
+++ b/Source/AssistantV2/Models/DialogLogMessage.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Dialog log message details.
  */
-public struct DialogLogMessage: Decodable {
+public struct DialogLogMessage: Codable {
 
     /**
      The severity of the log message.

--- a/Source/AssistantV2/Models/DialogNodeAction.swift
+++ b/Source/AssistantV2/Models/DialogNodeAction.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** DialogNodeAction. */
-public struct DialogNodeAction: Decodable {
+public struct DialogNodeAction: Codable {
 
     /**
      The type of action to invoke.

--- a/Source/AssistantV2/Models/DialogNodeOutputOptionsElement.swift
+++ b/Source/AssistantV2/Models/DialogNodeOutputOptionsElement.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DialogNodeOutputOptionsElement. */
-public struct DialogNodeOutputOptionsElement: Decodable {
+public struct DialogNodeOutputOptionsElement: Codable {
 
     /**
      The user-facing label for the option.

--- a/Source/AssistantV2/Models/DialogNodeOutputOptionsElementValue.swift
+++ b/Source/AssistantV2/Models/DialogNodeOutputOptionsElementValue.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An object defining the message input to be sent to the assistant if the user selects the corresponding option.
  */
-public struct DialogNodeOutputOptionsElementValue: Decodable {
+public struct DialogNodeOutputOptionsElementValue: Codable {
 
     /**
      The user input.

--- a/Source/AssistantV2/Models/DialogNodesVisited.swift
+++ b/Source/AssistantV2/Models/DialogNodesVisited.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DialogNodesVisited. */
-public struct DialogNodesVisited: Decodable {
+public struct DialogNodesVisited: Codable {
 
     /**
      A dialog node that was triggered during processing of the input message.

--- a/Source/AssistantV2/Models/DialogRuntimeResponseGeneric.swift
+++ b/Source/AssistantV2/Models/DialogRuntimeResponseGeneric.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DialogRuntimeResponseGeneric. */
-public struct DialogRuntimeResponseGeneric: Decodable {
+public struct DialogRuntimeResponseGeneric: Codable {
 
     /**
      The type of response returned by the dialog node. The specified response type must be supported by the client

--- a/Source/AssistantV2/Models/DialogSuggestion.swift
+++ b/Source/AssistantV2/Models/DialogSuggestion.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** DialogSuggestion. */
-public struct DialogSuggestion: Decodable {
+public struct DialogSuggestion: Codable {
 
     /**
      The user-facing label for the disambiguation option. This label is taken from the **user_label** property of the

--- a/Source/AssistantV2/Models/DialogSuggestionValue.swift
+++ b/Source/AssistantV2/Models/DialogSuggestionValue.swift
@@ -20,7 +20,7 @@ import Foundation
  An object defining the message input to be sent to the assistant if the user selects the corresponding disambiguation
  option.
  */
-public struct DialogSuggestionValue: Decodable {
+public struct DialogSuggestionValue: Codable {
 
     /**
      The user input.

--- a/Source/AssistantV2/Models/MessageOutput.swift
+++ b/Source/AssistantV2/Models/MessageOutput.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Assistant output to be rendered or processed by the client.
  */
-public struct MessageOutput: Decodable {
+public struct MessageOutput: Codable {
 
     /**
      Output intended for any channel. It is the responsibility of the client application to implement the supported

--- a/Source/AssistantV2/Models/MessageOutputDebug.swift
+++ b/Source/AssistantV2/Models/MessageOutputDebug.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Additional detailed information about a message response and how it was generated.
  */
-public struct MessageOutputDebug: Decodable {
+public struct MessageOutputDebug: Codable {
 
     /**
      When `branch_exited` is set to `true` by the Assistant, the `branch_exited_reason` specifies whether the dialog

--- a/Source/AssistantV2/Models/MessageRequest.swift
+++ b/Source/AssistantV2/Models/MessageRequest.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A request formatted for the Watson Assistant service.
  */
-internal struct MessageRequest: Encodable {
+internal struct MessageRequest: Codable {
 
     /**
      An input object that includes the input text.

--- a/Source/AssistantV2/Models/MessageResponse.swift
+++ b/Source/AssistantV2/Models/MessageResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A response from the Watson Assistant service.
  */
-public struct MessageResponse: Decodable {
+public struct MessageResponse: Codable {
 
     /**
      Assistant output to be rendered or processed by the client.

--- a/Source/AssistantV2/Models/SessionResponse.swift
+++ b/Source/AssistantV2/Models/SessionResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SessionResponse. */
-public struct SessionResponse: Decodable {
+public struct SessionResponse: Codable {
 
     /**
      The session ID.

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -102,6 +102,9 @@ public class Discovery {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
+            if case let .some(.string(description)) = json["description"] {
+                metadata["description"] = description
+            }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -102,9 +102,6 @@ public class Discovery {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            if case let .some(.string(description)) = json["description"] {
-                metadata["description"] = description
-            }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {

--- a/Source/DiscoveryV1/Models/AggregationResult.swift
+++ b/Source/DiscoveryV1/Models/AggregationResult.swift
@@ -41,4 +41,12 @@ public struct AggregationResult: Codable {
         case aggregations = "aggregations"
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let keyAsString = try? container.decode(String.self, forKey: .key) { key = keyAsString }
+        if let keyAsInt = try? container.decode(Int.self, forKey: .key) { key = "\(keyAsInt)" }
+        matchingResults = try container.decodeIfPresent(Int.self, forKey: .matchingResults)
+        aggregations = try container.decodeIfPresent([QueryAggregation].self, forKey: .aggregations)
+    }
+
 }

--- a/Source/DiscoveryV1/Models/AggregationResult.swift
+++ b/Source/DiscoveryV1/Models/AggregationResult.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** AggregationResult. */
-public struct AggregationResult: Decodable {
+public struct AggregationResult: Codable {
 
     /**
      Key that matched the aggregation type.
@@ -39,14 +39,6 @@ public struct AggregationResult: Decodable {
         case key = "key"
         case matchingResults = "matching_results"
         case aggregations = "aggregations"
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let keyAsString = try? container.decode(String.self, forKey: .key) { key = keyAsString }
-        if let keyAsInt = try? container.decode(Int.self, forKey: .key) { key = "\(keyAsInt)" }
-        matchingResults = try container.decodeIfPresent(Int.self, forKey: .matchingResults)
-        aggregations = try container.decodeIfPresent([QueryAggregation].self, forKey: .aggregations)
     }
 
 }

--- a/Source/DiscoveryV1/Models/Calculation.swift
+++ b/Source/DiscoveryV1/Models/Calculation.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Calculation. */
-public struct Calculation: Decodable {
+public struct Calculation: Codable {
 
     /**
      The type of aggregation command used. For example: term, filter, max, min, etc.

--- a/Source/DiscoveryV1/Models/Collection.swift
+++ b/Source/DiscoveryV1/Models/Collection.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A collection for storing documents.
  */
-public struct Collection: Decodable {
+public struct Collection: Codable {
 
     /**
      The status of the collection.

--- a/Source/DiscoveryV1/Models/CollectionDiskUsage.swift
+++ b/Source/DiscoveryV1/Models/CollectionDiskUsage.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Summary of the disk usage statistics for this collection.
  */
-public struct CollectionDiskUsage: Decodable {
+public struct CollectionDiskUsage: Codable {
 
     /**
      Number of bytes used by the collection.

--- a/Source/DiscoveryV1/Models/CollectionUsage.swift
+++ b/Source/DiscoveryV1/Models/CollectionUsage.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Summary of the collection usage in the environment.
  */
-public struct CollectionUsage: Decodable {
+public struct CollectionUsage: Codable {
 
     /**
      Number of active collections in the environment.

--- a/Source/DiscoveryV1/Models/CreateCollectionRequest.swift
+++ b/Source/DiscoveryV1/Models/CreateCollectionRequest.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CreateCollectionRequest. */
-internal struct CreateCollectionRequest: Encodable {
+internal struct CreateCollectionRequest: Codable {
 
     /**
      The language of the documents stored in the collection, in the form of an ISO 639-1 language code.

--- a/Source/DiscoveryV1/Models/CreateEnvironmentRequest.swift
+++ b/Source/DiscoveryV1/Models/CreateEnvironmentRequest.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CreateEnvironmentRequest. */
-internal struct CreateEnvironmentRequest: Encodable {
+internal struct CreateEnvironmentRequest: Codable {
 
     /**
      Size of the environment. In the Lite plan the default and only accepted value is `LT`, in all other plans the

--- a/Source/DiscoveryV1/Models/CreateEventObject.swift
+++ b/Source/DiscoveryV1/Models/CreateEventObject.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An object defining the event being created.
  */
-internal struct CreateEventObject: Encodable {
+internal struct CreateEventObject: Codable {
 
     /**
      The event type to be created.

--- a/Source/DiscoveryV1/Models/CreateEventResponse.swift
+++ b/Source/DiscoveryV1/Models/CreateEventResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An object defining the event being created.
  */
-public struct CreateEventResponse: Decodable {
+public struct CreateEventResponse: Codable {
 
     /**
      The event type that was created.

--- a/Source/DiscoveryV1/Models/CredentialsList.swift
+++ b/Source/DiscoveryV1/Models/CredentialsList.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CredentialsList. */
-public struct CredentialsList: Decodable {
+public struct CredentialsList: Codable {
 
     /**
      An array of credential definitions that were created for this instance.

--- a/Source/DiscoveryV1/Models/DeleteCollectionResponse.swift
+++ b/Source/DiscoveryV1/Models/DeleteCollectionResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DeleteCollectionResponse. */
-public struct DeleteCollectionResponse: Decodable {
+public struct DeleteCollectionResponse: Codable {
 
     /**
      The status of the collection. The status of a successful deletion operation is `deleted`.

--- a/Source/DiscoveryV1/Models/DeleteConfigurationResponse.swift
+++ b/Source/DiscoveryV1/Models/DeleteConfigurationResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DeleteConfigurationResponse. */
-public struct DeleteConfigurationResponse: Decodable {
+public struct DeleteConfigurationResponse: Codable {
 
     /**
      Status of the configuration. A deleted configuration has the status deleted.

--- a/Source/DiscoveryV1/Models/DeleteCredentials.swift
+++ b/Source/DiscoveryV1/Models/DeleteCredentials.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Object returned after credentials are deleted.
  */
-public struct DeleteCredentials: Decodable {
+public struct DeleteCredentials: Codable {
 
     /**
      The status of the deletion request.

--- a/Source/DiscoveryV1/Models/DeleteDocumentResponse.swift
+++ b/Source/DiscoveryV1/Models/DeleteDocumentResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DeleteDocumentResponse. */
-public struct DeleteDocumentResponse: Decodable {
+public struct DeleteDocumentResponse: Codable {
 
     /**
      Status of the document. A deleted document has the status deleted.

--- a/Source/DiscoveryV1/Models/DeleteEnvironmentResponse.swift
+++ b/Source/DiscoveryV1/Models/DeleteEnvironmentResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DeleteEnvironmentResponse. */
-public struct DeleteEnvironmentResponse: Decodable {
+public struct DeleteEnvironmentResponse: Codable {
 
     /**
      Status of the environment.

--- a/Source/DiscoveryV1/Models/DiskUsage.swift
+++ b/Source/DiscoveryV1/Models/DiskUsage.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Summary of the disk usage statistics for the environment.
  */
-public struct DiskUsage: Decodable {
+public struct DiskUsage: Codable {
 
     /**
      Number of bytes within the environment's disk capacity that are currently used to store data.

--- a/Source/DiscoveryV1/Models/DocumentAccepted.swift
+++ b/Source/DiscoveryV1/Models/DocumentAccepted.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DocumentAccepted. */
-public struct DocumentAccepted: Decodable {
+public struct DocumentAccepted: Codable {
 
     /**
      Status of the document in the ingestion process.

--- a/Source/DiscoveryV1/Models/DocumentCounts.swift
+++ b/Source/DiscoveryV1/Models/DocumentCounts.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DocumentCounts. */
-public struct DocumentCounts: Decodable {
+public struct DocumentCounts: Codable {
 
     /**
      The total number of available documents in the collection.

--- a/Source/DiscoveryV1/Models/DocumentSnapshot.swift
+++ b/Source/DiscoveryV1/Models/DocumentSnapshot.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** DocumentSnapshot. */
-public struct DocumentSnapshot: Decodable {
+public struct DocumentSnapshot: Codable {
 
     public enum Step: String {
         case htmlInput = "html_input"

--- a/Source/DiscoveryV1/Models/DocumentStatus.swift
+++ b/Source/DiscoveryV1/Models/DocumentStatus.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Status information about a submitted document.
  */
-public struct DocumentStatus: Decodable {
+public struct DocumentStatus: Codable {
 
     /**
      Status of the document in the ingestion process.

--- a/Source/DiscoveryV1/Models/Environment.swift
+++ b/Source/DiscoveryV1/Models/Environment.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Details about an environment.
  */
-public struct Environment: Decodable {
+public struct Environment: Codable {
 
     /**
      Current status of the environment. `resizing` is displayed when a request to increase the environment size has been

--- a/Source/DiscoveryV1/Models/EnvironmentDocuments.swift
+++ b/Source/DiscoveryV1/Models/EnvironmentDocuments.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Summary of the document usage statistics for the environment.
  */
-public struct EnvironmentDocuments: Decodable {
+public struct EnvironmentDocuments: Codable {
 
     /**
      Number of documents indexed for the environment.

--- a/Source/DiscoveryV1/Models/Field.swift
+++ b/Source/DiscoveryV1/Models/Field.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Field. */
-public struct Field: Decodable {
+public struct Field: Codable {
 
     /**
      The type of the field.

--- a/Source/DiscoveryV1/Models/Filter.swift
+++ b/Source/DiscoveryV1/Models/Filter.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Filter. */
-public struct Filter: Decodable {
+public struct Filter: Codable {
 
     /**
      The type of aggregation command used. For example: term, filter, max, min, etc.

--- a/Source/DiscoveryV1/Models/GenericQueryAggregation.swift
+++ b/Source/DiscoveryV1/Models/GenericQueryAggregation.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** An aggregation produced by the Discovery service to analyze the input provided. */
-public struct GenericQueryAggregation: Decodable {
+public struct GenericQueryAggregation: Codable {
 
     /// The type of aggregation command used. For example: term, filter, max, min, etc.
     public var type: String?

--- a/Source/DiscoveryV1/Models/Histogram.swift
+++ b/Source/DiscoveryV1/Models/Histogram.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Histogram. */
-public struct Histogram: Decodable {
+public struct Histogram: Codable {
 
     /**
      The type of aggregation command used. For example: term, filter, max, min, etc.

--- a/Source/DiscoveryV1/Models/IndexCapacity.swift
+++ b/Source/DiscoveryV1/Models/IndexCapacity.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Details about the resource usage and capacity of the environment.
  */
-public struct IndexCapacity: Decodable {
+public struct IndexCapacity: Codable {
 
     /**
      Summary of the document usage statistics for the environment.

--- a/Source/DiscoveryV1/Models/ListCollectionFieldsResponse.swift
+++ b/Source/DiscoveryV1/Models/ListCollectionFieldsResponse.swift
@@ -26,7 +26,7 @@ import Foundation
    * Fields returned from the News collection are prefixed with `v{N}-fullnews-t3-{YEAR}.mappings` (for example,
  `v5-fullnews-t3-2016.mappings.text.properties.author`).
  */
-public struct ListCollectionFieldsResponse: Decodable {
+public struct ListCollectionFieldsResponse: Codable {
 
     /**
      An array containing information about each field in the collections.

--- a/Source/DiscoveryV1/Models/ListCollectionsResponse.swift
+++ b/Source/DiscoveryV1/Models/ListCollectionsResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ListCollectionsResponse. */
-public struct ListCollectionsResponse: Decodable {
+public struct ListCollectionsResponse: Codable {
 
     /**
      An array containing information about each collection in the environment.

--- a/Source/DiscoveryV1/Models/ListConfigurationsResponse.swift
+++ b/Source/DiscoveryV1/Models/ListConfigurationsResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ListConfigurationsResponse. */
-public struct ListConfigurationsResponse: Decodable {
+public struct ListConfigurationsResponse: Codable {
 
     /**
      An array of Configurations that are available for the service instance.

--- a/Source/DiscoveryV1/Models/ListEnvironmentsResponse.swift
+++ b/Source/DiscoveryV1/Models/ListEnvironmentsResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ListEnvironmentsResponse. */
-public struct ListEnvironmentsResponse: Decodable {
+public struct ListEnvironmentsResponse: Codable {
 
     /**
      An array of [environments] that are available for the service instance.

--- a/Source/DiscoveryV1/Models/LogQueryResponse.swift
+++ b/Source/DiscoveryV1/Models/LogQueryResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Object containing results that match the requested **logs** query.
  */
-public struct LogQueryResponse: Decodable {
+public struct LogQueryResponse: Codable {
 
     /**
      Number of matching results.

--- a/Source/DiscoveryV1/Models/LogQueryResponseResult.swift
+++ b/Source/DiscoveryV1/Models/LogQueryResponseResult.swift
@@ -20,7 +20,7 @@ import Foundation
  Individual result object for a **logs** query. Each object represents either a query to a Discovery collection or an
  event that is associated with a query.
  */
-public struct LogQueryResponseResult: Decodable {
+public struct LogQueryResponseResult: Codable {
 
     /**
      The type of log entry returned.

--- a/Source/DiscoveryV1/Models/LogQueryResponseResultDocuments.swift
+++ b/Source/DiscoveryV1/Models/LogQueryResponseResultDocuments.swift
@@ -20,7 +20,7 @@ import Foundation
  Object containing result information that was returned by the query used to create this log entry. Only returned with
  logs of type `query`.
  */
-public struct LogQueryResponseResultDocuments: Decodable {
+public struct LogQueryResponseResultDocuments: Codable {
 
     public var results: [LogQueryResponseResultDocumentsResult]?
 

--- a/Source/DiscoveryV1/Models/LogQueryResponseResultDocumentsResult.swift
+++ b/Source/DiscoveryV1/Models/LogQueryResponseResultDocumentsResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Each object in the **results** array corresponds to an individual document returned by the original query.
  */
-public struct LogQueryResponseResultDocumentsResult: Decodable {
+public struct LogQueryResponseResultDocumentsResult: Codable {
 
     /**
      The result rank of this document. A position of `1` indicates that it was the first returned result.

--- a/Source/DiscoveryV1/Models/MemoryUsage.swift
+++ b/Source/DiscoveryV1/Models/MemoryUsage.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  **Deprecated**: Summary of the memory usage statistics for this environment.
  */
-public struct MemoryUsage: Decodable {
+public struct MemoryUsage: Codable {
 
     /**
      **Deprecated**: Number of bytes used in the environment's memory capacity.

--- a/Source/DiscoveryV1/Models/MetricAggregation.swift
+++ b/Source/DiscoveryV1/Models/MetricAggregation.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An aggregation analyzing log information for queries and events.
  */
-public struct MetricAggregation: Decodable {
+public struct MetricAggregation: Codable {
 
     /**
      The measurement interval for this metric. Metric intervals are always 1 day (`1d`).

--- a/Source/DiscoveryV1/Models/MetricAggregationResult.swift
+++ b/Source/DiscoveryV1/Models/MetricAggregationResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Aggregation result data for the requested metric.
  */
-public struct MetricAggregationResult: Decodable {
+public struct MetricAggregationResult: Codable {
 
     /**
      Date in string form representing the start of this interval.

--- a/Source/DiscoveryV1/Models/MetricResponse.swift
+++ b/Source/DiscoveryV1/Models/MetricResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The response generated from a call to a **metrics** method.
  */
-public struct MetricResponse: Decodable {
+public struct MetricResponse: Codable {
 
     public var aggregations: [MetricAggregation]?
 

--- a/Source/DiscoveryV1/Models/MetricTokenAggregation.swift
+++ b/Source/DiscoveryV1/Models/MetricTokenAggregation.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An aggregation analyzing log information for queries and events.
  */
-public struct MetricTokenAggregation: Decodable {
+public struct MetricTokenAggregation: Codable {
 
     /**
      The event type associated with this metric result. This field, when present, will always be `click`.

--- a/Source/DiscoveryV1/Models/MetricTokenAggregationResult.swift
+++ b/Source/DiscoveryV1/Models/MetricTokenAggregationResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Aggregation result data for the requested metric.
  */
-public struct MetricTokenAggregationResult: Decodable {
+public struct MetricTokenAggregationResult: Codable {
 
     /**
      The content of the **natural_language_query** parameter used in the query that this result represents.

--- a/Source/DiscoveryV1/Models/MetricTokenResponse.swift
+++ b/Source/DiscoveryV1/Models/MetricTokenResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The response generated from a call to a **metrics** method that evaluates tokens.
  */
-public struct MetricTokenResponse: Decodable {
+public struct MetricTokenResponse: Codable {
 
     public var aggregations: [MetricTokenAggregation]?
 

--- a/Source/DiscoveryV1/Models/Nested.swift
+++ b/Source/DiscoveryV1/Models/Nested.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Nested. */
-public struct Nested: Decodable {
+public struct Nested: Codable {
 
     /**
      The type of aggregation command used. For example: term, filter, max, min, etc.

--- a/Source/DiscoveryV1/Models/NewTrainingQuery.swift
+++ b/Source/DiscoveryV1/Models/NewTrainingQuery.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** NewTrainingQuery. */
-internal struct NewTrainingQuery: Encodable {
+internal struct NewTrainingQuery: Codable {
 
     public var naturalLanguageQuery: String?
 

--- a/Source/DiscoveryV1/Models/Notice.swift
+++ b/Source/DiscoveryV1/Models/Notice.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A notice produced for the collection.
  */
-public struct Notice: Decodable {
+public struct Notice: Codable {
 
     /**
      Severity level of the notice.

--- a/Source/DiscoveryV1/Models/QueryAggregation.swift
+++ b/Source/DiscoveryV1/Models/QueryAggregation.swift
@@ -16,34 +16,50 @@
 
 import Foundation
 
-/**
- An aggregation produced by the Discovery service to analyze the input provided.
- */
-public struct QueryAggregation: Codable {
+/** An aggregation produced by the Discovery service to analyze the input provided. */
+public enum QueryAggregation: Decodable {
 
-    /**
-     The type of aggregation command used. For example: term, filter, max, min, etc.
-     */
-    public var type: String?
+    // reference: https://console.bluemix.net/docs/services/discovery/query-reference.html#aggregations
 
-    public var results: [AggregationResult]?
+    case term(Term)
+    case filter(Filter)
+    case nested(Nested)
+    case histogram(Histogram)
+    case timeslice(Timeslice)
+    case topHits(TopHits)
+    case uniqueCount(Calculation)
+    case max(Calculation)
+    case min(Calculation)
+    case average(Calculation)
+    case sum(Calculation)
+    case generic(GenericQueryAggregation)
 
-    /**
-     Number of matching results.
-     */
-    public var matchingResults: Int?
-
-    /**
-     Aggregations returned by the Discovery service.
-     */
-    public var aggregations: [QueryAggregation]?
-
-    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case type = "type"
-        case results = "results"
-        case matchingResults = "matching_results"
-        case aggregations = "aggregations"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard let type = try container.decodeIfPresent(String.self, forKey: .type) else {
+            // the specification does not identify `type` as a required field,
+            // so we need a generic catch-all in case it is not present
+            self = .generic(try GenericQueryAggregation(from: decoder))
+            return
+        }
+        switch type {
+        case "term": self = .term(try Term(from: decoder))
+        case "filter": self = .filter(try Filter(from: decoder))
+        case "nested": self = .nested(try Nested(from: decoder))
+        case "histogram": self = .histogram(try Histogram(from: decoder))
+        case "timeslice": self = .timeslice(try Timeslice(from: decoder))
+        case "top_hits": self = .topHits(try TopHits(from: decoder))
+        case "unique_count": self = .uniqueCount(try Calculation(from: decoder))
+        case "max": self = .max(try Calculation(from: decoder))
+        case "min": self = .min(try Calculation(from: decoder))
+        case "average": self = .average(try Calculation(from: decoder))
+        case "sum": self = .sum(try Calculation(from: decoder))
+        default: self = .generic(try GenericQueryAggregation(from: decoder))
+        }
     }
 
 }

--- a/Source/DiscoveryV1/Models/QueryAggregation.swift
+++ b/Source/DiscoveryV1/Models/QueryAggregation.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** An aggregation produced by the Discovery service to analyze the input provided. */
-public enum QueryAggregation: Decodable {
+public enum QueryAggregation: Codable {
 
     // reference: https://console.bluemix.net/docs/services/discovery/query-reference.html#aggregations
 
@@ -59,6 +59,47 @@ public enum QueryAggregation: Decodable {
         case "average": self = .average(try Calculation(from: decoder))
         case "sum": self = .sum(try Calculation(from: decoder))
         default: self = .generic(try GenericQueryAggregation(from: decoder))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .term(let term):
+            try container.encode("term", forKey: .type)
+            try term.encode(to: encoder)
+        case .filter(let filter):
+            try container.encode("filter", forKey: .type)
+            try filter.encode(to: encoder)
+        case .nested(let nested):
+            try container.encode("nested", forKey: .type)
+            try nested.encode(to: encoder)
+        case .histogram(let histogram):
+            try container.encode("histogram", forKey: .type)
+            try histogram.encode(to: encoder)
+        case .timeslice(let timeslice):
+            try container.encode("timeslice", forKey: .type)
+            try timeslice.encode(to: encoder)
+        case .topHits(let topHits):
+            try container.encode("top_hits", forKey: .type)
+            try topHits.encode(to: encoder)
+        case .uniqueCount(let uniqueCount):
+            try container.encode("unique_count", forKey: .type)
+            try uniqueCount.encode(to: encoder)
+        case .max(let max):
+            try container.encode("max", forKey: .type)
+            try max.encode(to: encoder)
+        case .min(let min):
+            try container.encode("min", forKey: .type)
+            try min.encode(to: encoder)
+        case .average(let average):
+            try container.encode("average", forKey: .type)
+            try average.encode(to: encoder)
+        case .sum(let sum):
+            try container.encode("sum", forKey: .type)
+            try sum.encode(to: encoder)
+        case .generic(let generic):
+            try generic.encode(to: encoder)
         }
     }
 

--- a/Source/DiscoveryV1/Models/QueryAggregation.swift
+++ b/Source/DiscoveryV1/Models/QueryAggregation.swift
@@ -16,50 +16,34 @@
 
 import Foundation
 
-/** An aggregation produced by the Discovery service to analyze the input provided. */
-public enum QueryAggregation: Decodable {
+/**
+ An aggregation produced by the Discovery service to analyze the input provided.
+ */
+public struct QueryAggregation: Codable {
 
-    // reference: https://console.bluemix.net/docs/services/discovery/query-reference.html#aggregations
+    /**
+     The type of aggregation command used. For example: term, filter, max, min, etc.
+     */
+    public var type: String?
 
-    case term(Term)
-    case filter(Filter)
-    case nested(Nested)
-    case histogram(Histogram)
-    case timeslice(Timeslice)
-    case topHits(TopHits)
-    case uniqueCount(Calculation)
-    case max(Calculation)
-    case min(Calculation)
-    case average(Calculation)
-    case sum(Calculation)
-    case generic(GenericQueryAggregation)
+    public var results: [AggregationResult]?
 
+    /**
+     Number of matching results.
+     */
+    public var matchingResults: Int?
+
+    /**
+     Aggregations returned by the Discovery service.
+     */
+    public var aggregations: [QueryAggregation]?
+
+    // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case type = "type"
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        guard let type = try container.decodeIfPresent(String.self, forKey: .type) else {
-            // the specification does not identify `type` as a required field,
-            // so we need a generic catch-all in case it is not present
-            self = .generic(try GenericQueryAggregation(from: decoder))
-            return
-        }
-        switch type {
-        case "term": self = .term(try Term(from: decoder))
-        case "filter": self = .filter(try Filter(from: decoder))
-        case "nested": self = .nested(try Nested(from: decoder))
-        case "histogram": self = .histogram(try Histogram(from: decoder))
-        case "timeslice": self = .timeslice(try Timeslice(from: decoder))
-        case "top_hits": self = .topHits(try TopHits(from: decoder))
-        case "unique_count": self = .uniqueCount(try Calculation(from: decoder))
-        case "max": self = .max(try Calculation(from: decoder))
-        case "min": self = .min(try Calculation(from: decoder))
-        case "average": self = .average(try Calculation(from: decoder))
-        case "sum": self = .sum(try Calculation(from: decoder))
-        default: self = .generic(try GenericQueryAggregation(from: decoder))
-        }
+        case results = "results"
+        case matchingResults = "matching_results"
+        case aggregations = "aggregations"
     }
 
 }

--- a/Source/DiscoveryV1/Models/QueryEntities.swift
+++ b/Source/DiscoveryV1/Models/QueryEntities.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** QueryEntities. */
-internal struct QueryEntities: Encodable {
+internal struct QueryEntities: Codable {
 
     /**
      The entity query feature to perform. Supported features are `disambiguate` and `similar_entities`.

--- a/Source/DiscoveryV1/Models/QueryEntitiesContext.swift
+++ b/Source/DiscoveryV1/Models/QueryEntitiesContext.swift
@@ -20,7 +20,7 @@ import Foundation
  Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to
  query the city of London in England your query would look for `London` with the context of `England`.
  */
-public struct QueryEntitiesContext: Encodable {
+public struct QueryEntitiesContext: Codable {
 
     /**
      Entity text to provide context for the queried entity and rank based on that association. For example, if you

--- a/Source/DiscoveryV1/Models/QueryEntitiesResponse.swift
+++ b/Source/DiscoveryV1/Models/QueryEntitiesResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An array of entities resulting from the query.
  */
-public struct QueryEntitiesResponse: Decodable {
+public struct QueryEntitiesResponse: Codable {
 
     public var entities: [QueryEntitiesResponseItem]?
 

--- a/Source/DiscoveryV1/Models/QueryEntitiesResponseItem.swift
+++ b/Source/DiscoveryV1/Models/QueryEntitiesResponseItem.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Object containing Entity query response information.
  */
-public struct QueryEntitiesResponseItem: Decodable {
+public struct QueryEntitiesResponseItem: Codable {
 
     /**
      Entity text content.

--- a/Source/DiscoveryV1/Models/QueryEvidence.swift
+++ b/Source/DiscoveryV1/Models/QueryEvidence.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Description of evidence location supporting Knoweldge Graph query result.
  */
-public struct QueryEvidence: Decodable {
+public struct QueryEvidence: Codable {
 
     /**
      The docuemnt ID (as indexed in Discovery) of the evidence location.

--- a/Source/DiscoveryV1/Models/QueryEvidenceEntity.swift
+++ b/Source/DiscoveryV1/Models/QueryEvidenceEntity.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Entity description and location within evidence field.
  */
-public struct QueryEvidenceEntity: Decodable {
+public struct QueryEvidenceEntity: Codable {
 
     /**
      The entity type for this entity. Possible types vary based on model used.

--- a/Source/DiscoveryV1/Models/QueryFilterType.swift
+++ b/Source/DiscoveryV1/Models/QueryFilterType.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** QueryFilterType. */
-public struct QueryFilterType: Encodable {
+public struct QueryFilterType: Codable {
 
     /**
      A comma-separated list of types to exclude.

--- a/Source/DiscoveryV1/Models/QueryLarge.swift
+++ b/Source/DiscoveryV1/Models/QueryLarge.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Object that describes a long query.
  */
-internal struct QueryLarge: Encodable {
+internal struct QueryLarge: Codable {
 
     /**
      A cacheable query that excludes documents that don't mention the query content. Filter searches are better for

--- a/Source/DiscoveryV1/Models/QueryNoticesResponse.swift
+++ b/Source/DiscoveryV1/Models/QueryNoticesResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** QueryNoticesResponse. */
-public struct QueryNoticesResponse: Decodable {
+public struct QueryNoticesResponse: Codable {
 
     public var matchingResults: Int?
 

--- a/Source/DiscoveryV1/Models/QueryNoticesResult.swift
+++ b/Source/DiscoveryV1/Models/QueryNoticesResult.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** QueryNoticesResult. */
-public struct QueryNoticesResult: Decodable {
+public struct QueryNoticesResult: Codable {
 
     /**
      The type of the original source file.
@@ -113,6 +113,22 @@ public struct QueryNoticesResult: Decodable {
         notices = try container.decodeIfPresent([Notice].self, forKey: .notices)
         let dynamicContainer = try decoder.container(keyedBy: DynamicKeys.self)
         additionalProperties = try dynamicContainer.decode([String: JSON].self, excluding: CodingKeys.allValues)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(score, forKey: .score)
+        try container.encodeIfPresent(metadata, forKey: .metadata)
+        try container.encodeIfPresent(collectionID, forKey: .collectionID)
+        try container.encodeIfPresent(resultMetadata, forKey: .resultMetadata)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(filename, forKey: .filename)
+        try container.encodeIfPresent(fileType, forKey: .fileType)
+        try container.encodeIfPresent(sha1, forKey: .sha1)
+        try container.encodeIfPresent(notices, forKey: .notices)
+        var dynamicContainer = encoder.container(keyedBy: DynamicKeys.self)
+        try dynamicContainer.encodeIfPresent(additionalProperties)
     }
 
 }

--- a/Source/DiscoveryV1/Models/QueryPassages.swift
+++ b/Source/DiscoveryV1/Models/QueryPassages.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** QueryPassages. */
-public struct QueryPassages: Decodable {
+public struct QueryPassages: Codable {
 
     /**
      The unique identifier of the document from which the passage has been extracted.

--- a/Source/DiscoveryV1/Models/QueryRelations.swift
+++ b/Source/DiscoveryV1/Models/QueryRelations.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A respresentation of a relationship query.
  */
-internal struct QueryRelations: Encodable {
+internal struct QueryRelations: Codable {
 
     /**
      The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the number of unique times

--- a/Source/DiscoveryV1/Models/QueryRelationsArgument.swift
+++ b/Source/DiscoveryV1/Models/QueryRelationsArgument.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** QueryRelationsArgument. */
-public struct QueryRelationsArgument: Decodable {
+public struct QueryRelationsArgument: Codable {
 
     public var entities: [QueryEntitiesEntity]?
 

--- a/Source/DiscoveryV1/Models/QueryRelationsEntity.swift
+++ b/Source/DiscoveryV1/Models/QueryRelationsEntity.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** QueryRelationsEntity. */
-public struct QueryRelationsEntity: Encodable {
+public struct QueryRelationsEntity: Codable {
 
     /**
      Entity text content.

--- a/Source/DiscoveryV1/Models/QueryRelationsFilter.swift
+++ b/Source/DiscoveryV1/Models/QueryRelationsFilter.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** QueryRelationsFilter. */
-public struct QueryRelationsFilter: Encodable {
+public struct QueryRelationsFilter: Codable {
 
     /**
      A list of relation types to include or exclude from the query.

--- a/Source/DiscoveryV1/Models/QueryRelationsRelationship.swift
+++ b/Source/DiscoveryV1/Models/QueryRelationsRelationship.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** QueryRelationsRelationship. */
-public struct QueryRelationsRelationship: Decodable {
+public struct QueryRelationsRelationship: Codable {
 
     /**
      The identified relationship type.

--- a/Source/DiscoveryV1/Models/QueryRelationsResponse.swift
+++ b/Source/DiscoveryV1/Models/QueryRelationsResponse.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** QueryRelationsResponse. */
-public struct QueryRelationsResponse: Decodable {
+public struct QueryRelationsResponse: Codable {
 
     public var relations: [QueryRelationsRelationship]?
 

--- a/Source/DiscoveryV1/Models/QueryResponse.swift
+++ b/Source/DiscoveryV1/Models/QueryResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A response containing the documents and aggregations for the query.
  */
-public struct QueryResponse: Decodable {
+public struct QueryResponse: Codable {
 
     public var matchingResults: Int?
 

--- a/Source/DiscoveryV1/Models/QueryResult.swift
+++ b/Source/DiscoveryV1/Models/QueryResult.swift
@@ -18,7 +18,7 @@ import Foundation
 import RestKit
 
 /** QueryResult. */
-public struct QueryResult: Decodable {
+public struct QueryResult: Codable {
 
     /**
      The unique identifier of the document.
@@ -67,6 +67,17 @@ public struct QueryResult: Decodable {
         resultMetadata = try container.decodeIfPresent(QueryResultMetadata.self, forKey: .resultMetadata)
         let dynamicContainer = try decoder.container(keyedBy: DynamicKeys.self)
         additionalProperties = try dynamicContainer.decode([String: JSON].self, excluding: CodingKeys.allValues)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(score, forKey: .score)
+        try container.encodeIfPresent(metadata, forKey: .metadata)
+        try container.encodeIfPresent(collectionID, forKey: .collectionID)
+        try container.encodeIfPresent(resultMetadata, forKey: .resultMetadata)
+        var dynamicContainer = encoder.container(keyedBy: DynamicKeys.self)
+        try dynamicContainer.encodeIfPresent(additionalProperties)
     }
 
 }

--- a/Source/DiscoveryV1/Models/QueryResultMetadata.swift
+++ b/Source/DiscoveryV1/Models/QueryResultMetadata.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Metadata of a query result.
  */
-public struct QueryResultMetadata: Decodable {
+public struct QueryResultMetadata: Codable {
 
     /**
      An unbounded measure of the relevance of a particular result, dependent on the query and matching document. A

--- a/Source/DiscoveryV1/Models/SearchStatus.swift
+++ b/Source/DiscoveryV1/Models/SearchStatus.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Information about the Continuous Relevancy Training for this environment.
  */
-public struct SearchStatus: Decodable {
+public struct SearchStatus: Codable {
 
     /**
      The current status of Continuous Relevancy Training for this environment.

--- a/Source/DiscoveryV1/Models/SourceStatus.swift
+++ b/Source/DiscoveryV1/Models/SourceStatus.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Object containing source crawl status information.
  */
-public struct SourceStatus: Decodable {
+public struct SourceStatus: Codable {
 
     /**
      The current status of the source crawl for this collection. This field returns `not_configured` if the default

--- a/Source/DiscoveryV1/Models/Term.swift
+++ b/Source/DiscoveryV1/Models/Term.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Term. */
-public struct Term: Decodable {
+public struct Term: Codable {
 
     /**
      The type of aggregation command used. For example: term, filter, max, min, etc.

--- a/Source/DiscoveryV1/Models/TestDocument.swift
+++ b/Source/DiscoveryV1/Models/TestDocument.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TestDocument. */
-public struct TestDocument: Decodable {
+public struct TestDocument: Codable {
 
     /**
      The unique identifier for the configuration.

--- a/Source/DiscoveryV1/Models/Timeslice.swift
+++ b/Source/DiscoveryV1/Models/Timeslice.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Timeslice. */
-public struct Timeslice: Decodable {
+public struct Timeslice: Codable {
 
     /**
      The type of aggregation command used. For example: term, filter, max, min, etc.

--- a/Source/DiscoveryV1/Models/TokenDict.swift
+++ b/Source/DiscoveryV1/Models/TokenDict.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Tokenization dictionary describing how words are tokenized during ingestion and at query time.
  */
-internal struct TokenDict: Encodable {
+internal struct TokenDict: Codable {
 
     /**
      An array of tokenization rules. Each rule contains, the original `text` string, component `tokens`, any alternate

--- a/Source/DiscoveryV1/Models/TokenDictRule.swift
+++ b/Source/DiscoveryV1/Models/TokenDictRule.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An object defining a single tokenizaion rule.
  */
-public struct TokenDictRule: Encodable {
+public struct TokenDictRule: Codable {
 
     /**
      The string to tokenize.

--- a/Source/DiscoveryV1/Models/TokenDictStatusResponse.swift
+++ b/Source/DiscoveryV1/Models/TokenDictStatusResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Object describing the current status of the tokenization dictionary.
  */
-public struct TokenDictStatusResponse: Decodable {
+public struct TokenDictStatusResponse: Codable {
 
     /**
      Current tokenization dictionary status for the specified collection.

--- a/Source/DiscoveryV1/Models/TopHits.swift
+++ b/Source/DiscoveryV1/Models/TopHits.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TopHits. */
-public struct TopHits: Decodable {
+public struct TopHits: Codable {
 
     /**
      The type of aggregation command used. For example: term, filter, max, min, etc.

--- a/Source/DiscoveryV1/Models/TopHitsResults.swift
+++ b/Source/DiscoveryV1/Models/TopHitsResults.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TopHitsResults. */
-public struct TopHitsResults: Decodable {
+public struct TopHitsResults: Codable {
 
     /**
      Number of matching results.

--- a/Source/DiscoveryV1/Models/TrainingDataSet.swift
+++ b/Source/DiscoveryV1/Models/TrainingDataSet.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TrainingDataSet. */
-public struct TrainingDataSet: Decodable {
+public struct TrainingDataSet: Codable {
 
     public var environmentID: String?
 

--- a/Source/DiscoveryV1/Models/TrainingExampleList.swift
+++ b/Source/DiscoveryV1/Models/TrainingExampleList.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TrainingExampleList. */
-public struct TrainingExampleList: Decodable {
+public struct TrainingExampleList: Codable {
 
     public var examples: [TrainingExample]?
 

--- a/Source/DiscoveryV1/Models/TrainingExamplePatch.swift
+++ b/Source/DiscoveryV1/Models/TrainingExamplePatch.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TrainingExamplePatch. */
-internal struct TrainingExamplePatch: Encodable {
+internal struct TrainingExamplePatch: Codable {
 
     public var crossReference: String?
 

--- a/Source/DiscoveryV1/Models/TrainingQuery.swift
+++ b/Source/DiscoveryV1/Models/TrainingQuery.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TrainingQuery. */
-public struct TrainingQuery: Decodable {
+public struct TrainingQuery: Codable {
 
     public var queryID: String?
 

--- a/Source/DiscoveryV1/Models/TrainingStatus.swift
+++ b/Source/DiscoveryV1/Models/TrainingStatus.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TrainingStatus. */
-public struct TrainingStatus: Decodable {
+public struct TrainingStatus: Codable {
 
     public var totalExamples: Int?
 

--- a/Source/DiscoveryV1/Models/UpdateCollectionRequest.swift
+++ b/Source/DiscoveryV1/Models/UpdateCollectionRequest.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UpdateCollectionRequest. */
-internal struct UpdateCollectionRequest: Encodable {
+internal struct UpdateCollectionRequest: Codable {
 
     /**
      The name of the collection.

--- a/Source/DiscoveryV1/Models/UpdateEnvironmentRequest.swift
+++ b/Source/DiscoveryV1/Models/UpdateEnvironmentRequest.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UpdateEnvironmentRequest. */
-internal struct UpdateEnvironmentRequest: Encodable {
+internal struct UpdateEnvironmentRequest: Codable {
 
     /**
      Size that the environment should be increased to. Environment size cannot be modified when using a Lite plan.

--- a/Source/LanguageTranslatorV3/Models/DeleteModelResult.swift
+++ b/Source/LanguageTranslatorV3/Models/DeleteModelResult.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DeleteModelResult. */
-public struct DeleteModelResult: Decodable {
+public struct DeleteModelResult: Codable {
 
     /**
      "OK" indicates that the model was successfully deleted.

--- a/Source/LanguageTranslatorV3/Models/IdentifiableLanguage.swift
+++ b/Source/LanguageTranslatorV3/Models/IdentifiableLanguage.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** IdentifiableLanguage. */
-public struct IdentifiableLanguage: Decodable {
+public struct IdentifiableLanguage: Codable {
 
     /**
      The language code for an identifiable language.

--- a/Source/LanguageTranslatorV3/Models/IdentifiableLanguages.swift
+++ b/Source/LanguageTranslatorV3/Models/IdentifiableLanguages.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** IdentifiableLanguages. */
-public struct IdentifiableLanguages: Decodable {
+public struct IdentifiableLanguages: Codable {
 
     /**
      A list of all languages that the service can identify.

--- a/Source/LanguageTranslatorV3/Models/IdentifiedLanguage.swift
+++ b/Source/LanguageTranslatorV3/Models/IdentifiedLanguage.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** IdentifiedLanguage. */
-public struct IdentifiedLanguage: Decodable {
+public struct IdentifiedLanguage: Codable {
 
     /**
      The language code for an identified language.

--- a/Source/LanguageTranslatorV3/Models/IdentifiedLanguages.swift
+++ b/Source/LanguageTranslatorV3/Models/IdentifiedLanguages.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** IdentifiedLanguages. */
-public struct IdentifiedLanguages: Decodable {
+public struct IdentifiedLanguages: Codable {
 
     /**
      A ranking of identified languages with confidence scores.

--- a/Source/LanguageTranslatorV3/Models/TranslateRequest.swift
+++ b/Source/LanguageTranslatorV3/Models/TranslateRequest.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TranslateRequest. */
-internal struct TranslateRequest: Encodable {
+internal struct TranslateRequest: Codable {
 
     /**
      Input text in UTF-8 encoding. Multiple entries will result in multiple translations in the response.

--- a/Source/LanguageTranslatorV3/Models/Translation.swift
+++ b/Source/LanguageTranslatorV3/Models/Translation.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Translation. */
-public struct Translation: Decodable {
+public struct Translation: Codable {
 
     /**
      Translation output in UTF-8.

--- a/Source/LanguageTranslatorV3/Models/TranslationModel.swift
+++ b/Source/LanguageTranslatorV3/Models/TranslationModel.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Response payload for models.
  */
-public struct TranslationModel: Decodable {
+public struct TranslationModel: Codable {
 
     /**
      Availability of a model.

--- a/Source/LanguageTranslatorV3/Models/TranslationModels.swift
+++ b/Source/LanguageTranslatorV3/Models/TranslationModels.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The response type for listing existing translation models.
  */
-public struct TranslationModels: Decodable {
+public struct TranslationModels: Codable {
 
     /**
      An array of available models.

--- a/Source/LanguageTranslatorV3/Models/TranslationResult.swift
+++ b/Source/LanguageTranslatorV3/Models/TranslationResult.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TranslationResult. */
-public struct TranslationResult: Decodable {
+public struct TranslationResult: Codable {
 
     /**
      Number of words in the input text.

--- a/Source/NaturalLanguageClassifierV1/Models/Classification.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/Classification.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Response from the classifier for a phrase.
  */
-public struct Classification: Decodable {
+public struct Classification: Codable {
 
     /**
      Unique identifier for this classifier.

--- a/Source/NaturalLanguageClassifierV1/Models/ClassificationCollection.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassificationCollection.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Response from the classifier for multiple phrases.
  */
-public struct ClassificationCollection: Decodable {
+public struct ClassificationCollection: Codable {
 
     /**
      Unique identifier for this classifier.

--- a/Source/NaturalLanguageClassifierV1/Models/ClassifiedClass.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassifiedClass.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Class and confidence.
  */
-public struct ClassifiedClass: Decodable {
+public struct ClassifiedClass: Codable {
 
     /**
      A decimal percentage that represents the confidence that Watson has in this class. Higher values represent higher

--- a/Source/NaturalLanguageClassifierV1/Models/Classifier.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/Classifier.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A classifier for natural language phrases.
  */
-public struct Classifier: Decodable {
+public struct Classifier: Codable {
 
     /**
      The state of the classifier.

--- a/Source/NaturalLanguageClassifierV1/Models/ClassifierList.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassifierList.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  List of available classifiers.
  */
-public struct ClassifierList: Decodable {
+public struct ClassifierList: Codable {
 
     /**
      The classifiers available to the user. Returns an empty array if no classifiers are available.

--- a/Source/NaturalLanguageClassifierV1/Models/ClassifyCollectionInput.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassifyCollectionInput.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Request payload to classify.
  */
-internal struct ClassifyCollectionInput: Encodable {
+internal struct ClassifyCollectionInput: Codable {
 
     /**
      The submitted phrases.

--- a/Source/NaturalLanguageClassifierV1/Models/ClassifyInput.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/ClassifyInput.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Request payload to classify.
  */
-public struct ClassifyInput: Encodable {
+public struct ClassifyInput: Codable {
 
     /**
      The submitted phrase. The maximum length is 2048 characters.

--- a/Source/NaturalLanguageClassifierV1/Models/CollectionItem.swift
+++ b/Source/NaturalLanguageClassifierV1/Models/CollectionItem.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Response from the classifier for a phrase in a collection.
  */
-public struct CollectionItem: Decodable {
+public struct CollectionItem: Codable {
 
     /**
      The submitted phrase. The maximum length is 2048 characters.

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -91,9 +91,6 @@ public class NaturalLanguageClassifier {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            if case let .some(.string(description)) = json["description"] {
-                metadata["description"] = description
-            }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -91,6 +91,9 @@ public class NaturalLanguageClassifier {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
+            if case let .some(.string(description)) = json["description"] {
+                metadata["description"] = description
+            }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {

--- a/Source/NaturalLanguageUnderstandingV1/Models/AnalysisResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/AnalysisResults.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Results of the analysis, organized by feature.
  */
-public struct AnalysisResults: Decodable {
+public struct AnalysisResults: Codable {
 
     /**
      Language used to analyze the text.

--- a/Source/NaturalLanguageUnderstandingV1/Models/Author.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Author.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The author of the analyzed content.
  */
-public struct Author: Decodable {
+public struct Author: Codable {
 
     /**
      Name of the author.

--- a/Source/NaturalLanguageUnderstandingV1/Models/CategoriesOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/CategoriesOptions.swift
@@ -21,7 +21,7 @@ import RestKit
  Returns a five-level taxonomy of the content. The top three categories are returned.
  Supported languages: Arabic, English, French, German, Italian, Japanese, Korean, Portuguese, Spanish.
  */
-public struct CategoriesOptions: Encodable {
+public struct CategoriesOptions: Codable {
 
     /// Additional properties associated with this model.
     public var additionalProperties: [String: JSON]
@@ -36,6 +36,11 @@ public struct CategoriesOptions: Encodable {
     )
     {
         self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let dynamicContainer = try decoder.container(keyedBy: DynamicKeys.self)
+        additionalProperties = try dynamicContainer.decode([String: JSON].self, excluding: [CodingKey]())
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Source/NaturalLanguageUnderstandingV1/Models/CategoriesResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/CategoriesResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A categorization of the analyzed text.
  */
-public struct CategoriesResult: Decodable {
+public struct CategoriesResult: Codable {
 
     /**
      The path to the category through the 5-level taxonomy hierarchy. For the complete list of categories, see the

--- a/Source/NaturalLanguageUnderstandingV1/Models/ConceptsOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/ConceptsOptions.swift
@@ -21,7 +21,7 @@ import Foundation
  "Artificial Intelligence" although the term is not mentioned.
  Supported languages: English, French, German, Japanese, Korean, Portuguese, Spanish.
  */
-public struct ConceptsOptions: Encodable {
+public struct ConceptsOptions: Codable {
 
     /**
      Maximum number of concepts to return.

--- a/Source/NaturalLanguageUnderstandingV1/Models/ConceptsResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/ConceptsResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The general concepts referenced or alluded to in the analyzed text.
  */
-public struct ConceptsResult: Decodable {
+public struct ConceptsResult: Codable {
 
     /**
      Name of the concept.

--- a/Source/NaturalLanguageUnderstandingV1/Models/DeleteModelResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/DeleteModelResults.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Delete model results.
  */
-public struct DeleteModelResults: Decodable {
+public struct DeleteModelResults: Codable {
 
     /**
      model_id of the deleted model.

--- a/Source/NaturalLanguageUnderstandingV1/Models/DisambiguationResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/DisambiguationResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Disambiguation information for the entity.
  */
-public struct DisambiguationResult: Decodable {
+public struct DisambiguationResult: Codable {
 
     /**
      Common entity name.

--- a/Source/NaturalLanguageUnderstandingV1/Models/DocumentEmotionResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/DocumentEmotionResults.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Emotion results for the document as a whole.
  */
-public struct DocumentEmotionResults: Decodable {
+public struct DocumentEmotionResults: Codable {
 
     /**
      Emotion results for the document as a whole.

--- a/Source/NaturalLanguageUnderstandingV1/Models/DocumentSentimentResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/DocumentSentimentResults.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** DocumentSentimentResults. */
-public struct DocumentSentimentResults: Decodable {
+public struct DocumentSentimentResults: Codable {
 
     /**
      Indicates whether the sentiment is positive, neutral, or negative.

--- a/Source/NaturalLanguageUnderstandingV1/Models/EmotionOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EmotionOptions.swift
@@ -22,7 +22,7 @@ import Foundation
  keywords with `keywords.emotion`.
  Supported languages: English.
  */
-public struct EmotionOptions: Encodable {
+public struct EmotionOptions: Codable {
 
     /**
      Set this to `false` to hide document-level emotion results.

--- a/Source/NaturalLanguageUnderstandingV1/Models/EmotionResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EmotionResult.swift
@@ -20,7 +20,7 @@ import Foundation
  The detected anger, disgust, fear, joy, or sadness that is conveyed by the content. Emotion information can be returned
  for detected entities, keywords, or user-specified target phrases found in the text.
  */
-public struct EmotionResult: Decodable {
+public struct EmotionResult: Codable {
 
     /**
      Emotion results for the document as a whole.

--- a/Source/NaturalLanguageUnderstandingV1/Models/EmotionScores.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EmotionScores.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** EmotionScores. */
-public struct EmotionScores: Decodable {
+public struct EmotionScores: Codable {
 
     /**
      Anger score from 0 to 1. A higher score means that the text is more likely to convey anger.

--- a/Source/NaturalLanguageUnderstandingV1/Models/EntitiesOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EntitiesOptions.swift
@@ -22,7 +22,7 @@ import Foundation
  Supported languages: English, French, German, Italian, Japanese, Korean, Portuguese, Russian, Spanish, Swedish. Arabic,
  Chinese, and Dutch custom models are also supported.
  */
-public struct EntitiesOptions: Encodable {
+public struct EntitiesOptions: Codable {
 
     /**
      Maximum number of entities to return.

--- a/Source/NaturalLanguageUnderstandingV1/Models/EntitiesResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EntitiesResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The important people, places, geopolitical entities and other types of entities in your content.
  */
-public struct EntitiesResult: Decodable {
+public struct EntitiesResult: Codable {
 
     /**
      Entity type.

--- a/Source/NaturalLanguageUnderstandingV1/Models/EntityMention.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/EntityMention.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** EntityMention. */
-public struct EntityMention: Decodable {
+public struct EntityMention: Codable {
 
     /**
      Entity mention text.

--- a/Source/NaturalLanguageUnderstandingV1/Models/FeatureSentimentResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/FeatureSentimentResults.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** FeatureSentimentResults. */
-public struct FeatureSentimentResults: Decodable {
+public struct FeatureSentimentResults: Codable {
 
     /**
      Sentiment score from -1 (negative) to 1 (positive).

--- a/Source/NaturalLanguageUnderstandingV1/Models/Features.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Features.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Analysis features and options.
  */
-public struct Features: Encodable {
+public struct Features: Codable {
 
     /**
      Returns high-level concepts in the content. For example, a research paper about deep learning might return the

--- a/Source/NaturalLanguageUnderstandingV1/Models/Feed.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Feed.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  RSS or ATOM feed found on the webpage.
  */
-public struct Feed: Decodable {
+public struct Feed: Codable {
 
     /**
      URL of the RSS or ATOM feed.

--- a/Source/NaturalLanguageUnderstandingV1/Models/KeywordsOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/KeywordsOptions.swift
@@ -20,7 +20,7 @@ import Foundation
  Returns important keywords in the content.
  Supported languages: English, French, German, Italian, Japanese, Korean, Portuguese, Russian, Spanish, Swedish.
  */
-public struct KeywordsOptions: Encodable {
+public struct KeywordsOptions: Codable {
 
     /**
      Maximum number of keywords to return.

--- a/Source/NaturalLanguageUnderstandingV1/Models/KeywordsResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/KeywordsResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The important keywords in the content, organized by relevance.
  */
-public struct KeywordsResult: Decodable {
+public struct KeywordsResult: Codable {
 
     /**
      Relevance score from 0 to 1. Higher values indicate greater relevance.

--- a/Source/NaturalLanguageUnderstandingV1/Models/ListModelsResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/ListModelsResults.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Models available for Relations and Entities features.
  */
-public struct ListModelsResults: Decodable {
+public struct ListModelsResults: Codable {
 
     /**
      An array of available models.

--- a/Source/NaturalLanguageUnderstandingV1/Models/MetadataOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/MetadataOptions.swift
@@ -21,7 +21,7 @@ import RestKit
  Returns information from the document, including author name, title, RSS/ATOM feeds, prominent page image, and
  publication date. Supports URL and HTML input types only.
  */
-public struct MetadataOptions: Encodable {
+public struct MetadataOptions: Codable {
 
     /// Additional properties associated with this model.
     public var additionalProperties: [String: JSON]
@@ -36,6 +36,11 @@ public struct MetadataOptions: Encodable {
     )
     {
         self.additionalProperties = additionalProperties
+    }
+
+    public init(from decoder: Decoder) throws {
+        let dynamicContainer = try decoder.container(keyedBy: DynamicKeys.self)
+        additionalProperties = try dynamicContainer.decode([String: JSON].self, excluding: [CodingKey]())
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Source/NaturalLanguageUnderstandingV1/Models/MetadataResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/MetadataResult.swift
@@ -20,7 +20,7 @@ import Foundation
  The authors, publication date, title, prominent page image, and RSS/ATOM feeds of the webpage. Supports URL and HTML
  input types.
  */
-public struct MetadataResult: Decodable {
+public struct MetadataResult: Codable {
 
     /**
      The authors of the document.

--- a/Source/NaturalLanguageUnderstandingV1/Models/Model.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Model.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Model. */
-public struct Model: Decodable {
+public struct Model: Codable {
 
     /**
      When the status is `available`, the model is ready to use.

--- a/Source/NaturalLanguageUnderstandingV1/Models/Parameters.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Parameters.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An object containing request parameters.
  */
-internal struct Parameters: Encodable {
+internal struct Parameters: Codable {
 
     /**
      The plain text to analyze. One of the `text`, `html`, or `url` parameters is required.

--- a/Source/NaturalLanguageUnderstandingV1/Models/RelationArgument.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/RelationArgument.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** RelationArgument. */
-public struct RelationArgument: Decodable {
+public struct RelationArgument: Codable {
 
     /**
      An array of extracted entities.

--- a/Source/NaturalLanguageUnderstandingV1/Models/RelationEntity.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/RelationEntity.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An entity that corresponds with an argument in a relation.
  */
-public struct RelationEntity: Decodable {
+public struct RelationEntity: Codable {
 
     /**
      Text that corresponds to the entity.

--- a/Source/NaturalLanguageUnderstandingV1/Models/RelationsOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/RelationsOptions.swift
@@ -23,7 +23,7 @@ import Foundation
  Supported languages: Arabic, English, German, Japanese, Korean, Spanish. Chinese, Dutch, French, Italian, and
  Portuguese custom models are also supported.
  */
-public struct RelationsOptions: Encodable {
+public struct RelationsOptions: Codable {
 
     /**
      Enter a [custom model](/docs/services/natural-language-understanding/customizing.html) ID to override the default

--- a/Source/NaturalLanguageUnderstandingV1/Models/RelationsResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/RelationsResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The relations between entities found in the content.
  */
-public struct RelationsResult: Decodable {
+public struct RelationsResult: Codable {
 
     /**
      Confidence score for the relation. Higher values indicate greater confidence.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesAction.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesAction.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SemanticRolesAction. */
-public struct SemanticRolesAction: Decodable {
+public struct SemanticRolesAction: Codable {
 
     /**
      Analyzed text that corresponds to the action.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesEntity.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesEntity.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SemanticRolesEntity. */
-public struct SemanticRolesEntity: Decodable {
+public struct SemanticRolesEntity: Codable {
 
     /**
      Entity type.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesKeyword.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesKeyword.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SemanticRolesKeyword. */
-public struct SemanticRolesKeyword: Decodable {
+public struct SemanticRolesKeyword: Codable {
 
     /**
      The keyword text.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesObject.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesObject.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SemanticRolesObject. */
-public struct SemanticRolesObject: Decodable {
+public struct SemanticRolesObject: Codable {
 
     /**
      Object text.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesOptions.swift
@@ -20,7 +20,7 @@ import Foundation
  Parses sentences into subject, action, and object form.
  Supported languages: English, German, Japanese, Korean, Spanish.
  */
-public struct SemanticRolesOptions: Encodable {
+public struct SemanticRolesOptions: Codable {
 
     /**
      Maximum number of semantic_roles results to return.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The object containing the actions and the objects the actions act upon.
  */
-public struct SemanticRolesResult: Decodable {
+public struct SemanticRolesResult: Codable {
 
     /**
      Sentence from the source that contains the subject, action, and object.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesSubject.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesSubject.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SemanticRolesSubject. */
-public struct SemanticRolesSubject: Decodable {
+public struct SemanticRolesSubject: Codable {
 
     /**
      Text that corresponds to the subject role.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesVerb.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SemanticRolesVerb.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SemanticRolesVerb. */
-public struct SemanticRolesVerb: Decodable {
+public struct SemanticRolesVerb: Codable {
 
     /**
      The keyword text.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SentimentOptions.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SentimentOptions.swift
@@ -21,7 +21,7 @@ import Foundation
  sentiment for detected entities with `entities.sentiment` and for keywords with `keywords.sentiment`.
   Supported languages: Arabic, English, French, German, Italian, Japanese, Korean, Portuguese, Russian, Spanish.
  */
-public struct SentimentOptions: Encodable {
+public struct SentimentOptions: Codable {
 
     /**
      Set this to `false` to hide document-level sentiment results.

--- a/Source/NaturalLanguageUnderstandingV1/Models/SentimentResult.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/SentimentResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The sentiment of the content.
  */
-public struct SentimentResult: Decodable {
+public struct SentimentResult: Codable {
 
     /**
      The document level sentiment.

--- a/Source/NaturalLanguageUnderstandingV1/Models/TargetedEmotionResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/TargetedEmotionResults.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Emotion results for a specified target.
  */
-public struct TargetedEmotionResults: Decodable {
+public struct TargetedEmotionResults: Codable {
 
     /**
      Targeted text.

--- a/Source/NaturalLanguageUnderstandingV1/Models/TargetedSentimentResults.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/TargetedSentimentResults.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** TargetedSentimentResults. */
-public struct TargetedSentimentResults: Decodable {
+public struct TargetedSentimentResults: Codable {
 
     /**
      Targeted text.

--- a/Source/NaturalLanguageUnderstandingV1/Models/Usage.swift
+++ b/Source/NaturalLanguageUnderstandingV1/Models/Usage.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Usage information.
  */
-public struct Usage: Decodable {
+public struct Usage: Codable {
 
     /**
      Number of features used in the API call.

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -103,9 +103,6 @@ public class NaturalLanguageUnderstanding {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            if case let .some(.string(description)) = json["description"] {
-                metadata["description"] = description
-            }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -103,6 +103,9 @@ public class NaturalLanguageUnderstanding {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
+            if case let .some(.string(description)) = json["description"] {
+                metadata["description"] = description
+            }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {

--- a/Source/PersonalityInsightsV3/Models/Behavior.swift
+++ b/Source/PersonalityInsightsV3/Models/Behavior.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Behavior. */
-public struct Behavior: Decodable {
+public struct Behavior: Codable {
 
     /**
      The unique, non-localized identifier of the characteristic to which the results pertain. IDs have the form

--- a/Source/PersonalityInsightsV3/Models/ConsumptionPreferences.swift
+++ b/Source/PersonalityInsightsV3/Models/ConsumptionPreferences.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ConsumptionPreferences. */
-public struct ConsumptionPreferences: Decodable {
+public struct ConsumptionPreferences: Codable {
 
     /**
      The unique, non-localized identifier of the consumption preference to which the results pertain. IDs have the form

--- a/Source/PersonalityInsightsV3/Models/ConsumptionPreferencesCategory.swift
+++ b/Source/PersonalityInsightsV3/Models/ConsumptionPreferencesCategory.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ConsumptionPreferencesCategory. */
-public struct ConsumptionPreferencesCategory: Decodable {
+public struct ConsumptionPreferencesCategory: Codable {
 
     /**
      The unique, non-localized identifier of the consumption preferences category to which the results pertain. IDs have

--- a/Source/PersonalityInsightsV3/Models/Content.swift
+++ b/Source/PersonalityInsightsV3/Models/Content.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Content. */
-public struct Content: Encodable {
+public struct Content: Codable {
 
     /**
      An array of `ContentItem` objects that provides the text that is to be analyzed.

--- a/Source/PersonalityInsightsV3/Models/ContentItem.swift
+++ b/Source/PersonalityInsightsV3/Models/ContentItem.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ContentItem. */
-public struct ContentItem: Encodable {
+public struct ContentItem: Codable {
 
     /**
      The MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is

--- a/Source/PersonalityInsightsV3/Models/Profile.swift
+++ b/Source/PersonalityInsightsV3/Models/Profile.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Profile. */
-public struct Profile: Decodable {
+public struct Profile: Codable {
 
     /**
      The language model that was used to process the input.

--- a/Source/PersonalityInsightsV3/Models/Trait.swift
+++ b/Source/PersonalityInsightsV3/Models/Trait.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Trait. */
-public struct Trait: Decodable {
+public struct Trait: Codable {
 
     /**
      The category of the characteristic: `personality` for Big Five personality characteristics, `needs` for Needs, and

--- a/Source/PersonalityInsightsV3/Models/Warning.swift
+++ b/Source/PersonalityInsightsV3/Models/Warning.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Warning. */
-public struct Warning: Decodable {
+public struct Warning: Codable {
 
     /**
      The identifier of the warning message.

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -111,6 +111,9 @@ public class PersonalityInsights {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
+            if case let .some(.string(help)) = json["help"] {
+                metadata["help"] = help
+            }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
@@ -155,8 +158,6 @@ public class PersonalityInsights {
      - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each
        characteristic; raw scores are not compared with a sample population. By default, only normalized percentiles are
        returned.
-     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column
-       labels are returned. Applies only when the **Accept** parameter is set to `text/csv`.
      - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By
        default, no consumption preferences are returned.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -167,7 +168,6 @@ public class PersonalityInsights {
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         rawScores: Bool? = nil,
-        csvHeaders: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
         completionHandler: @escaping (WatsonResponse<Profile>?, WatsonError?) -> Void)
@@ -197,10 +197,6 @@ public class PersonalityInsights {
         queryParameters.append(URLQueryItem(name: "version", value: version))
         if let rawScores = rawScores {
             let queryParameter = URLQueryItem(name: "raw_scores", value: "\(rawScores)")
-            queryParameters.append(queryParameter)
-        }
-        if let csvHeaders = csvHeaders {
-            let queryParameter = URLQueryItem(name: "csv_headers", value: "\(csvHeaders)")
             queryParameters.append(queryParameter)
         }
         if let consumptionPreferences = consumptionPreferences {
@@ -276,7 +272,7 @@ public class PersonalityInsights {
         csvHeaders: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<URL>?, WatsonError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<String>?, WatsonError?) -> Void)
     {
         // construct body
         guard let body = profileContent.content else {
@@ -327,7 +323,7 @@ public class PersonalityInsights {
         )
 
         // execute REST request
-        request.responseObject(completionHandler: completionHandler)
+        request.response(completionHandler: completionHandler)
     }
 
 }

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -111,9 +111,6 @@ public class PersonalityInsights {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            if case let .some(.string(help)) = json["help"] {
-                metadata["help"] = help
-            }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
@@ -158,6 +155,8 @@ public class PersonalityInsights {
      - parameter rawScores: Indicates whether a raw score in addition to a normalized percentile is returned for each
        characteristic; raw scores are not compared with a sample population. By default, only normalized percentiles are
        returned.
+     - parameter csvHeaders: Indicates whether column labels are returned with a CSV response. By default, no column
+       labels are returned. Applies only when the **Accept** parameter is set to `text/csv`.
      - parameter consumptionPreferences: Indicates whether consumption preferences are returned with the results. By
        default, no consumption preferences are returned.
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -168,6 +167,7 @@ public class PersonalityInsights {
         contentLanguage: String? = nil,
         acceptLanguage: String? = nil,
         rawScores: Bool? = nil,
+        csvHeaders: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
         completionHandler: @escaping (WatsonResponse<Profile>?, WatsonError?) -> Void)
@@ -197,6 +197,10 @@ public class PersonalityInsights {
         queryParameters.append(URLQueryItem(name: "version", value: version))
         if let rawScores = rawScores {
             let queryParameter = URLQueryItem(name: "raw_scores", value: "\(rawScores)")
+            queryParameters.append(queryParameter)
+        }
+        if let csvHeaders = csvHeaders {
+            let queryParameter = URLQueryItem(name: "csv_headers", value: "\(csvHeaders)")
             queryParameters.append(queryParameter)
         }
         if let consumptionPreferences = consumptionPreferences {
@@ -272,7 +276,7 @@ public class PersonalityInsights {
         csvHeaders: Bool? = nil,
         consumptionPreferences: Bool? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<String>?, WatsonError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<URL>?, WatsonError?) -> Void)
     {
         // construct body
         guard let body = profileContent.content else {
@@ -323,7 +327,7 @@ public class PersonalityInsights {
         )
 
         // execute REST request
-        request.response(completionHandler: completionHandler)
+        request.responseObject(completionHandler: completionHandler)
     }
 
 }

--- a/Source/SpeechToTextV1/Models/AcousticModel.swift
+++ b/Source/SpeechToTextV1/Models/AcousticModel.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** AcousticModel. */
-public struct AcousticModel: Decodable {
+public struct AcousticModel: Codable {
 
     /**
      The current status of the custom acoustic model:

--- a/Source/SpeechToTextV1/Models/AcousticModels.swift
+++ b/Source/SpeechToTextV1/Models/AcousticModels.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** AcousticModels. */
-public struct AcousticModels: Decodable {
+public struct AcousticModels: Codable {
 
     /**
      An array of objects that provides information about each available custom acoustic model. The array is empty if the

--- a/Source/SpeechToTextV1/Models/AudioDetails.swift
+++ b/Source/SpeechToTextV1/Models/AudioDetails.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** AudioDetails. */
-public struct AudioDetails: Decodable {
+public struct AudioDetails: Codable {
 
     /**
      The type of the audio resource:

--- a/Source/SpeechToTextV1/Models/AudioListing.swift
+++ b/Source/SpeechToTextV1/Models/AudioListing.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** AudioListing. */
-public struct AudioListing: Decodable {
+public struct AudioListing: Codable {
 
     /**
      **For an audio-type resource,** the status of the resource:

--- a/Source/SpeechToTextV1/Models/AudioResource.swift
+++ b/Source/SpeechToTextV1/Models/AudioResource.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** AudioResource. */
-public struct AudioResource: Decodable {
+public struct AudioResource: Codable {
 
     /**
      The status of the audio resource:

--- a/Source/SpeechToTextV1/Models/AudioResources.swift
+++ b/Source/SpeechToTextV1/Models/AudioResources.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** AudioResources. */
-public struct AudioResources: Decodable {
+public struct AudioResources: Codable {
 
     /**
      The total minutes of accumulated audio summed over all of the valid audio resources for the custom acoustic model.

--- a/Source/SpeechToTextV1/Models/Corpora.swift
+++ b/Source/SpeechToTextV1/Models/Corpora.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Corpora. */
-public struct Corpora: Decodable {
+public struct Corpora: Codable {
 
     /**
      An array of objects that provides information about the corpora for the custom model. The array is empty if the

--- a/Source/SpeechToTextV1/Models/Corpus.swift
+++ b/Source/SpeechToTextV1/Models/Corpus.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Corpus. */
-public struct Corpus: Decodable {
+public struct Corpus: Codable {
 
     /**
      The status of the corpus:

--- a/Source/SpeechToTextV1/Models/CreateAcousticModel.swift
+++ b/Source/SpeechToTextV1/Models/CreateAcousticModel.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CreateAcousticModel. */
-internal struct CreateAcousticModel: Encodable {
+internal struct CreateAcousticModel: Codable {
 
     /**
      The name of the base language model that is to be customized by the new custom acoustic model. The new custom model

--- a/Source/SpeechToTextV1/Models/CreateLanguageModel.swift
+++ b/Source/SpeechToTextV1/Models/CreateLanguageModel.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CreateLanguageModel. */
-internal struct CreateLanguageModel: Encodable {
+internal struct CreateLanguageModel: Codable {
 
     /**
      The name of the base language model that is to be customized by the new custom language model. The new custom model

--- a/Source/SpeechToTextV1/Models/CustomWord.swift
+++ b/Source/SpeechToTextV1/Models/CustomWord.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CustomWord. */
-public struct CustomWord: Encodable {
+public struct CustomWord: Codable {
 
     /**
      For the **Add custom words** method, you must specify the custom word that is to be added to or updated in the

--- a/Source/SpeechToTextV1/Models/CustomWords.swift
+++ b/Source/SpeechToTextV1/Models/CustomWords.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CustomWords. */
-internal struct CustomWords: Encodable {
+internal struct CustomWords: Codable {
 
     /**
      An array of objects that provides information about each custom word that is to be added to or updated in the

--- a/Source/SpeechToTextV1/Models/KeywordResult.swift
+++ b/Source/SpeechToTextV1/Models/KeywordResult.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** KeywordResult. */
-public struct KeywordResult: Decodable {
+public struct KeywordResult: Codable {
 
     /**
      A specified keyword normalized to the spoken phrase that matched in the audio input.

--- a/Source/SpeechToTextV1/Models/LanguageModel.swift
+++ b/Source/SpeechToTextV1/Models/LanguageModel.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** LanguageModel. */
-public struct LanguageModel: Decodable {
+public struct LanguageModel: Codable {
 
     /**
      The current status of the custom language model:

--- a/Source/SpeechToTextV1/Models/LanguageModels.swift
+++ b/Source/SpeechToTextV1/Models/LanguageModels.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** LanguageModels. */
-public struct LanguageModels: Decodable {
+public struct LanguageModels: Codable {
 
     /**
      An array of objects that provides information about each available custom language model. The array is empty if the

--- a/Source/SpeechToTextV1/Models/RecognitionJob.swift
+++ b/Source/SpeechToTextV1/Models/RecognitionJob.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** RecognitionJob. */
-public struct RecognitionJob: Decodable {
+public struct RecognitionJob: Codable {
 
     /**
      The current status of the job:

--- a/Source/SpeechToTextV1/Models/RecognitionJobs.swift
+++ b/Source/SpeechToTextV1/Models/RecognitionJobs.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** RecognitionJobs. */
-public struct RecognitionJobs: Decodable {
+public struct RecognitionJobs: Codable {
 
     /**
      An array of objects that provides the status for each of the user's current jobs. The array is empty if the user

--- a/Source/SpeechToTextV1/Models/RegisterStatus.swift
+++ b/Source/SpeechToTextV1/Models/RegisterStatus.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** RegisterStatus. */
-public struct RegisterStatus: Decodable {
+public struct RegisterStatus: Codable {
 
     /**
      The current status of the job:

--- a/Source/SpeechToTextV1/Models/SpeakerLabelsResult.swift
+++ b/Source/SpeechToTextV1/Models/SpeakerLabelsResult.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SpeakerLabelsResult. */
-public struct SpeakerLabelsResult: Decodable {
+public struct SpeakerLabelsResult: Codable {
 
     /**
      The start time of a word from the transcript. The value matches the start time of a word from the `timestamps`

--- a/Source/SpeechToTextV1/Models/SpeechModel.swift
+++ b/Source/SpeechToTextV1/Models/SpeechModel.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SpeechModel. */
-public struct SpeechModel: Decodable {
+public struct SpeechModel: Codable {
 
     /**
      The name of the model for use as an identifier in calls to the service (for example, `en-US_BroadbandModel`).

--- a/Source/SpeechToTextV1/Models/SpeechModels.swift
+++ b/Source/SpeechToTextV1/Models/SpeechModels.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SpeechModels. */
-public struct SpeechModels: Decodable {
+public struct SpeechModels: Codable {
 
     /**
      An array of objects that provides information about each available model.

--- a/Source/SpeechToTextV1/Models/SpeechRecognitionAlternative.swift
+++ b/Source/SpeechToTextV1/Models/SpeechRecognitionAlternative.swift
@@ -35,14 +35,14 @@ public struct SpeechRecognitionAlternative: Codable {
      the word followed by its start and end time in seconds, for example: `[["hello",0.0,1.2],["world",1.2,2.5]]`.
      Timestamps are returned only for the best alternative.
      */
-    public var timestamps: [String]?
+    public var timestamps: [WordTimestamp]?
 
     /**
      A confidence score for each word of the transcript as a list of lists. Each inner list consists of two elements:
      the word and its confidence score in the range of 0.0 to 1.0, for example: `[["hello",0.95],["world",0.866]]`.
      Confidence scores are returned only for the best alternative and only with results marked as final.
      */
-    public var wordConfidence: [String]?
+    public var wordConfidence: [WordConfidence]?
 
     // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {

--- a/Source/SpeechToTextV1/Models/SpeechRecognitionAlternative.swift
+++ b/Source/SpeechToTextV1/Models/SpeechRecognitionAlternative.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SpeechRecognitionAlternative. */
-public struct SpeechRecognitionAlternative: Decodable {
+public struct SpeechRecognitionAlternative: Codable {
 
     /**
      A transcription of the audio.
@@ -35,14 +35,14 @@ public struct SpeechRecognitionAlternative: Decodable {
      the word followed by its start and end time in seconds, for example: `[["hello",0.0,1.2],["world",1.2,2.5]]`.
      Timestamps are returned only for the best alternative.
      */
-    public var timestamps: [WordTimestamp]?
+    public var timestamps: [String]?
 
     /**
      A confidence score for each word of the transcript as a list of lists. Each inner list consists of two elements:
      the word and its confidence score in the range of 0.0 to 1.0, for example: `[["hello",0.95],["world",0.866]]`.
      Confidence scores are returned only for the best alternative and only with results marked as final.
      */
-    public var wordConfidence: [WordConfidence]?
+    public var wordConfidence: [String]?
 
     // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {

--- a/Source/SpeechToTextV1/Models/SpeechRecognitionResult.swift
+++ b/Source/SpeechToTextV1/Models/SpeechRecognitionResult.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SpeechRecognitionResult. */
-public struct SpeechRecognitionResult: Decodable {
+public struct SpeechRecognitionResult: Codable {
 
     /**
      An indication of whether the transcription results are final. If `true`, the results for this utterance are not

--- a/Source/SpeechToTextV1/Models/SpeechRecognitionResults.swift
+++ b/Source/SpeechToTextV1/Models/SpeechRecognitionResults.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SpeechRecognitionResults. */
-public struct SpeechRecognitionResults: Decodable {
+public struct SpeechRecognitionResults: Codable {
 
     /**
      An array of `SpeechRecognitionResult` objects that can include interim and final results (interim results are

--- a/Source/SpeechToTextV1/Models/SupportedFeatures.swift
+++ b/Source/SpeechToTextV1/Models/SupportedFeatures.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Describes the additional service features that are supported with the model.
  */
-public struct SupportedFeatures: Decodable {
+public struct SupportedFeatures: Codable {
 
     /**
      Indicates whether the customization interface can be used to create a custom language model based on the language

--- a/Source/SpeechToTextV1/Models/Word.swift
+++ b/Source/SpeechToTextV1/Models/Word.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Word. */
-public struct Word: Decodable {
+public struct Word: Codable {
 
     /**
      A word from the custom model's words resource. The spelling of the word is used to train the model.

--- a/Source/SpeechToTextV1/Models/WordAlternativeResult.swift
+++ b/Source/SpeechToTextV1/Models/WordAlternativeResult.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** WordAlternativeResult. */
-public struct WordAlternativeResult: Decodable {
+public struct WordAlternativeResult: Codable {
 
     /**
      A confidence score for the word alternative hypothesis in the range of 0.0 to 1.0.

--- a/Source/SpeechToTextV1/Models/WordAlternativeResults.swift
+++ b/Source/SpeechToTextV1/Models/WordAlternativeResults.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** WordAlternativeResults. */
-public struct WordAlternativeResults: Decodable {
+public struct WordAlternativeResults: Codable {
 
     /**
      The start time in seconds of the word from the input audio that corresponds to the word alternatives.

--- a/Source/SpeechToTextV1/Models/WordConfidence.swift
+++ b/Source/SpeechToTextV1/Models/WordConfidence.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** The confidence of a word in a Speech to Text transcription. */
-public struct WordConfidence: Decodable {
+public struct WordConfidence: Codable {
 
     /// A particular word from the transcription.
     public let word: String

--- a/Source/SpeechToTextV1/Models/WordError.swift
+++ b/Source/SpeechToTextV1/Models/WordError.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** WordError. */
-public struct WordError: Decodable {
+public struct WordError: Codable {
 
     /**
      A key-value pair that describes an error associated with the definition of a word in the words resource. Each pair

--- a/Source/SpeechToTextV1/Models/WordTimestamp.swift
+++ b/Source/SpeechToTextV1/Models/WordTimestamp.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** The timestamp of a word in a Speech to Text transcription. */
-public struct WordTimestamp: Decodable {
+public struct WordTimestamp: Codable {
 
     /// A particular word from the transcription.
     public let word: String

--- a/Source/SpeechToTextV1/Models/Words.swift
+++ b/Source/SpeechToTextV1/Models/Words.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Words. */
-public struct Words: Decodable {
+public struct Words: Codable {
 
     /**
      An array of objects that provides information about each word in the custom model's words resource. The array is

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -37,6 +37,12 @@ public class SpeechToText {
     /// The base URL to use when contacting the service.
     public var serviceURL = "https://stream.watsonplatform.net/speech-to-text/api"
 
+    /// The URL that shall be used to obtain a token.
+    public var tokenURL = "https://stream.watsonplatform.net/authorization/api/v1/token"
+
+    /// The URL that shall be used to stream audio for transcription.
+    public var websocketsURL = "wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize"
+
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
@@ -99,6 +105,9 @@ public class SpeechToText {
             metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
+            }
+            if case let .some(.string(description)) = json["code_description"] {
+                metadata["codeDescription"] = description
             }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -37,12 +37,6 @@ public class SpeechToText {
     /// The base URL to use when contacting the service.
     public var serviceURL = "https://stream.watsonplatform.net/speech-to-text/api"
 
-    /// The URL that shall be used to obtain a token.
-    public var tokenURL = "https://stream.watsonplatform.net/authorization/api/v1/token"
-
-    /// The URL that shall be used to stream audio for transcription.
-    public var websocketsURL = "wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize"
-
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()
 
@@ -105,9 +99,6 @@ public class SpeechToText {
             metadata = [:]
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
-            }
-            if case let .some(.string(description)) = json["code_description"] {
-                metadata["codeDescription"] = description
             }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)

--- a/Source/SpeechToTextV1/WebSockets/RecognitionSettings.swift
+++ b/Source/SpeechToTextV1/WebSockets/RecognitionSettings.swift
@@ -23,7 +23,7 @@ import Foundation
  For more information about the Speech to Text service parameters, visit:
  https://console.bluemix.net/docs/services/speech-to-text/input.html
  */
-public struct RecognitionSettings: Encodable {
+public struct RecognitionSettings: Codable {
 
     /// The action to perform. Must be `start` to begin the request.
     private let action = "start"

--- a/Source/TextToSpeechV1/Models/CreateVoiceModel.swift
+++ b/Source/TextToSpeechV1/Models/CreateVoiceModel.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** CreateVoiceModel. */
-internal struct CreateVoiceModel: Encodable {
+internal struct CreateVoiceModel: Codable {
 
     /**
      The language of the new custom voice model. Omit the parameter to use the the default language, `en-US`.

--- a/Source/TextToSpeechV1/Models/Pronunciation.swift
+++ b/Source/TextToSpeechV1/Models/Pronunciation.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Pronunciation. */
-public struct Pronunciation: Decodable {
+public struct Pronunciation: Codable {
 
     /**
      The pronunciation of the specified text in the requested voice and format. If a custom voice model is specified,

--- a/Source/TextToSpeechV1/Models/SupportedFeatures.swift
+++ b/Source/TextToSpeechV1/Models/SupportedFeatures.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Describes the additional service features that are supported with the voice.
  */
-public struct SupportedFeatures: Decodable {
+public struct SupportedFeatures: Codable {
 
     /**
      If `true`, the voice can be customized; if `false`, the voice cannot be customized. (Same as `customizable`.).

--- a/Source/TextToSpeechV1/Models/Text.swift
+++ b/Source/TextToSpeechV1/Models/Text.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Text. */
-internal struct Text: Encodable {
+internal struct Text: Codable {
 
     /**
      The text to synthesize.

--- a/Source/TextToSpeechV1/Models/UpdateVoiceModel.swift
+++ b/Source/TextToSpeechV1/Models/UpdateVoiceModel.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UpdateVoiceModel. */
-internal struct UpdateVoiceModel: Encodable {
+internal struct UpdateVoiceModel: Codable {
 
     /**
      A new name for the custom voice model.

--- a/Source/TextToSpeechV1/Models/Voice.swift
+++ b/Source/TextToSpeechV1/Models/Voice.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Voice. */
-public struct Voice: Decodable {
+public struct Voice: Codable {
 
     /**
      The URI of the voice.

--- a/Source/TextToSpeechV1/Models/VoiceModel.swift
+++ b/Source/TextToSpeechV1/Models/VoiceModel.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** VoiceModel. */
-public struct VoiceModel: Decodable {
+public struct VoiceModel: Codable {
 
     /**
      The customization ID (GUID) of the custom voice model. The **Create a custom model** method returns only this

--- a/Source/TextToSpeechV1/Models/VoiceModels.swift
+++ b/Source/TextToSpeechV1/Models/VoiceModels.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** VoiceModels. */
-public struct VoiceModels: Decodable {
+public struct VoiceModels: Codable {
 
     /**
      An array of `VoiceModel` objects that provides information about each available custom voice model. The array is

--- a/Source/TextToSpeechV1/Models/Voices.swift
+++ b/Source/TextToSpeechV1/Models/Voices.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Voices. */
-public struct Voices: Decodable {
+public struct Voices: Codable {
 
     /**
      A list of available voices.

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -100,9 +100,6 @@ public class TextToSpeech {
             if case let .some(.string(message)) = json["error"] {
                 errorMessage = message
             }
-            if case let .some(.string(description)) = json["code_description"] {
-                metadata["codeDescription"] = description
-            }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
         } catch {
@@ -233,7 +230,7 @@ public class TextToSpeech {
         voice: String? = nil,
         customizationID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<Data>?, WatsonError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<URL>?, WatsonError?) -> Void)
     {
         // construct body
         let synthesizeRequest = Text(
@@ -277,37 +274,7 @@ public class TextToSpeech {
         )
 
         // execute REST request
-        request.response { (response: WatsonResponse<Data>?, error: WatsonError?) in
-            var response = response
-            guard let data = response?.result else {
-                completionHandler(response, error)
-                return
-            }
-            if accept?.lowercased().contains("audio/wav") == true {
-                // repair the WAV header
-                var wav = data
-                guard WAVRepair.isWAVFile(data: wav) else {
-                    let error = WatsonError.other(message: "Expected returned audio to be in WAV format")
-                    completionHandler(nil, error)
-                    return
-                }
-                WAVRepair.repairWAVHeader(data: &wav)
-                response?.result = wav
-                completionHandler(response, nil)
-            } else if accept?.lowercased().contains("ogg") == true && accept?.lowercased().contains("opus") == true {
-                do {
-                    let decodedAudio = try TextToSpeechDecoder(audioData: data)
-                    response?.result = decodedAudio.pcmDataWithHeaders
-                    completionHandler(response, nil)
-                } catch {
-                    let error = WatsonError.serialization(values: "returned audio")
-                    completionHandler(nil, error)
-                    return
-                }
-            } else {
-                completionHandler(response, nil)
-            }
-        }
+        request.responseObject(completionHandler: completionHandler)
     }
 
     /**

--- a/Source/ToneAnalyzerV3/Models/DocumentAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/DocumentAnalysis.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  An object of type `DocumentAnalysis` that provides the results of the analysis for the full input document.
  */
-public struct DocumentAnalysis: Decodable {
+public struct DocumentAnalysis: Codable {
 
     /**
      **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying

--- a/Source/ToneAnalyzerV3/Models/SentenceAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/SentenceAnalysis.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** SentenceAnalysis. */
-public struct SentenceAnalysis: Decodable {
+public struct SentenceAnalysis: Codable {
 
     /**
      The unique identifier of a sentence of the input content. The first sentence has ID 0, and the ID of each

--- a/Source/ToneAnalyzerV3/Models/ToneAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneAnalysis.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneAnalysis. */
-public struct ToneAnalysis: Decodable {
+public struct ToneAnalysis: Codable {
 
     /**
      An object of type `DocumentAnalysis` that provides the results of the analysis for the full input document.

--- a/Source/ToneAnalyzerV3/Models/ToneCategory.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneCategory.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneCategory. */
-public struct ToneCategory: Decodable {
+public struct ToneCategory: Codable {
 
     /**
      An array of `ToneScore` objects that provides the results for the tones of the category.

--- a/Source/ToneAnalyzerV3/Models/ToneChatInput.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneChatInput.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneChatInput. */
-internal struct ToneChatInput: Encodable {
+internal struct ToneChatInput: Codable {
 
     /**
      An array of `Utterance` objects that provides the input content that the service is to analyze.

--- a/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneChatScore.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneChatScore. */
-public struct ToneChatScore: Decodable {
+public struct ToneChatScore: Codable {
 
     /**
      The unique, non-localized identifier of the tone for the results. The service returns results only for tones whose

--- a/Source/ToneAnalyzerV3/Models/ToneInput.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneInput.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneInput. */
-public struct ToneInput: Encodable {
+public struct ToneInput: Codable {
 
     /**
      The input content that the service is to analyze.

--- a/Source/ToneAnalyzerV3/Models/ToneScore.swift
+++ b/Source/ToneAnalyzerV3/Models/ToneScore.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** ToneScore. */
-public struct ToneScore: Decodable {
+public struct ToneScore: Codable {
 
     /**
      The score for the tone.

--- a/Source/ToneAnalyzerV3/Models/Utterance.swift
+++ b/Source/ToneAnalyzerV3/Models/Utterance.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** Utterance. */
-public struct Utterance: Encodable {
+public struct Utterance: Codable {
 
     /**
      An utterance contributed by a user in the conversation that is to be analyzed. The utterance can contain multiple

--- a/Source/ToneAnalyzerV3/Models/UtteranceAnalyses.swift
+++ b/Source/ToneAnalyzerV3/Models/UtteranceAnalyses.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UtteranceAnalyses. */
-public struct UtteranceAnalyses: Decodable {
+public struct UtteranceAnalyses: Codable {
 
     /**
      An array of `UtteranceAnalysis` objects that provides the results for each utterance of the input.

--- a/Source/ToneAnalyzerV3/Models/UtteranceAnalysis.swift
+++ b/Source/ToneAnalyzerV3/Models/UtteranceAnalysis.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /** UtteranceAnalysis. */
-public struct UtteranceAnalysis: Decodable {
+public struct UtteranceAnalysis: Codable {
 
     /**
      The unique identifier of the utterance. The first utterance has ID 0, and the ID of each subsequent utterance is

--- a/Source/VisualRecognitionV3/Models/Class.swift
+++ b/Source/VisualRecognitionV3/Models/Class.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A category within a classifier.
  */
-public struct Class: Decodable {
+public struct Class: Codable {
 
     /**
      The name of the class.

--- a/Source/VisualRecognitionV3/Models/ClassResult.swift
+++ b/Source/VisualRecognitionV3/Models/ClassResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Result of a class within a classifier.
  */
-public struct ClassResult: Decodable {
+public struct ClassResult: Codable {
 
     /**
      Name of the class.

--- a/Source/VisualRecognitionV3/Models/ClassifiedImage.swift
+++ b/Source/VisualRecognitionV3/Models/ClassifiedImage.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Results for one image.
  */
-public struct ClassifiedImage: Decodable {
+public struct ClassifiedImage: Codable {
 
     /**
      Source of the image before any redirects. Not returned when the image is uploaded.

--- a/Source/VisualRecognitionV3/Models/ClassifiedImages.swift
+++ b/Source/VisualRecognitionV3/Models/ClassifiedImages.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Results for all images.
  */
-public struct ClassifiedImages: Decodable {
+public struct ClassifiedImages: Codable {
 
     /**
      Number of custom classes identified in the images.

--- a/Source/VisualRecognitionV3/Models/Classifier.swift
+++ b/Source/VisualRecognitionV3/Models/Classifier.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Information about a classifier.
  */
-public struct Classifier: Decodable {
+public struct Classifier: Codable {
 
     /**
      Training status of classifier.

--- a/Source/VisualRecognitionV3/Models/ClassifierResult.swift
+++ b/Source/VisualRecognitionV3/Models/ClassifierResult.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Classifier and score combination.
  */
-public struct ClassifierResult: Decodable {
+public struct ClassifierResult: Codable {
 
     /**
      Name of the classifier.

--- a/Source/VisualRecognitionV3/Models/Classifiers.swift
+++ b/Source/VisualRecognitionV3/Models/Classifiers.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  A container for the list of classifiers.
  */
-public struct Classifiers: Decodable {
+public struct Classifiers: Codable {
 
     /**
      List of classifiers.

--- a/Source/VisualRecognitionV3/Models/DetectedFaces.swift
+++ b/Source/VisualRecognitionV3/Models/DetectedFaces.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Results for all faces.
  */
-public struct DetectedFaces: Decodable {
+public struct DetectedFaces: Codable {
 
     /**
      Number of images processed for the API call.

--- a/Source/VisualRecognitionV3/Models/ErrorInfo.swift
+++ b/Source/VisualRecognitionV3/Models/ErrorInfo.swift
@@ -20,7 +20,7 @@ import Foundation
  Information about what might have caused a failure, such as an image that is too large. Not returned when there is no
  error.
  */
-public struct ErrorInfo: Decodable {
+public struct ErrorInfo: Codable {
 
     /**
      HTTP status code.

--- a/Source/VisualRecognitionV3/Models/Face.swift
+++ b/Source/VisualRecognitionV3/Models/Face.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Information about the face.
  */
-public struct Face: Decodable {
+public struct Face: Codable {
 
     /**
      Age information about a face.

--- a/Source/VisualRecognitionV3/Models/FaceAge.swift
+++ b/Source/VisualRecognitionV3/Models/FaceAge.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Age information about a face.
  */
-public struct FaceAge: Decodable {
+public struct FaceAge: Codable {
 
     /**
      Estimated minimum age.

--- a/Source/VisualRecognitionV3/Models/FaceGender.swift
+++ b/Source/VisualRecognitionV3/Models/FaceGender.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Information about the gender of the face.
  */
-public struct FaceGender: Decodable {
+public struct FaceGender: Codable {
 
     /**
      Gender identified by the face. For example, `MALE` or `FEMALE`.

--- a/Source/VisualRecognitionV3/Models/FaceLocation.swift
+++ b/Source/VisualRecognitionV3/Models/FaceLocation.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  The location of the bounding box around the face.
  */
-public struct FaceLocation: Decodable {
+public struct FaceLocation: Codable {
 
     /**
      Width in pixels of face region.

--- a/Source/VisualRecognitionV3/Models/ImageWithFaces.swift
+++ b/Source/VisualRecognitionV3/Models/ImageWithFaces.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Information about faces in the image.
  */
-public struct ImageWithFaces: Decodable {
+public struct ImageWithFaces: Codable {
 
     /**
      Faces detected in the images.

--- a/Source/VisualRecognitionV3/Models/WarningInfo.swift
+++ b/Source/VisualRecognitionV3/Models/WarningInfo.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Information about something that went wrong.
  */
-public struct WarningInfo: Decodable {
+public struct WarningInfo: Codable {
 
     /**
      Codified warning string, such as `limit_reached`.

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -84,8 +84,34 @@ public class VisualRecognition {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             metadata = [:]
-            if case let .some(.string(message)) = json["error"] {
-                errorMessage = message
+            switch statusCode {
+            case 403:
+                // ErrorAuthentication
+                if case let .some(.string(status)) = json["status"],
+                    case let .some(.string(statusInfo)) = json["statusInfo"] {
+                    errorMessage = statusInfo
+                    metadata["status"] = status
+                    metadata["statusInfo"] = statusInfo
+                }
+            case 404:
+                // "error": ErrorInfo
+                if case let .some(.object(errorObj)) = json["error"],
+                    case let .some(.string(message)) = errorObj["description"],
+                    case let .some(.string(errorID)) = errorObj["error_id"] {
+                    errorMessage = message
+                    metadata["description"] = message
+                    metadata["errorID"] = errorID
+                }
+            case 413:
+                // ErrorHTML
+                if case let .some(.string(message)) = json["Error"] {
+                    errorMessage = message
+                }
+            default:
+                // ErrorResponse
+                if case let .some(.string(message)) = json["error"] {
+                    errorMessage = message
+                }
             }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
@@ -297,12 +323,11 @@ public class VisualRecognition {
      names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.
 
      - parameter name: The name of the new classifier. Encode special characters in UTF-8.
-     - parameter classnamePositiveExamples: A .zip file of images that depict the visual subject of a class in the new
-       classifier. You can include more than one positive example file in a call.
-       Specify the parameter name by appending `_positive_examples` to the class name. For example,
-       `goldenretriever_positive_examples` creates the class **goldenretriever**.
-       Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels. The
-       maximum number of images is 10,000 images or 100 MB per .zip file.
+     - parameter positiveExamples: An array of of positive examples, each with a name and a compressed (.zip) file
+       of images that depict the visual subject of a class in the new classifier. You can include more than one
+       positive example file in a call.
+       Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels.
+       The maximum number of images is 10,000 images or 100 MB per .zip file.
        Encode special characters in the file name in UTF-8.
      - parameter negativeExamples: A .zip file of images that do not depict the visual subject of any of the classes
        of the new classifier. Must contain a minimum of 10 images.
@@ -312,7 +337,7 @@ public class VisualRecognition {
      */
     public func createClassifier(
         name: String,
-        classnamePositiveExamples: URL,
+        positiveExamples: [PositiveExample],
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
         completionHandler: @escaping (WatsonResponse<Classifier>?, WatsonError?) -> Void)
@@ -322,11 +347,13 @@ public class VisualRecognition {
         if let nameData = name.data(using: .utf8) {
             multipartFormData.append(nameData, withName: "name")
         }
-        do {
-            try multipartFormData.append(file: classnamePositiveExamples, withName: "classname_positive_examples")
-        } catch {
-            completionHandler(nil, WatsonError.serialization(values: "file \(classnamePositiveExamples.path)"))
-            return
+        positiveExamples.forEach { example in
+            do {
+                try multipartFormData.append(file: example.examples, withName: example.name + "_positive_examples")
+            } catch {
+                completionHandler(nil, WatsonError.serialization(values: "file \(example.examples)"))
+                return
+            }
         }
         if let negativeExamples = negativeExamples {
             do {
@@ -471,13 +498,11 @@ public class VisualRecognition {
      classifier retraining finished.
 
      - parameter classifierID: The ID of the classifier.
-     - parameter classnamePositiveExamples: A .zip file of images that depict the visual subject of a class in the
-       classifier. The positive examples create or update classes in the classifier. You can include more than one
-       positive example file in a call.
-       Specify the parameter name by appending `_positive_examples` to the class name. For example,
-       `goldenretriever_positive_examples` creates the class `goldenretriever`.
-       Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels. The
-       maximum number of images is 10,000 images or 100 MB per .zip file.
+     - parameter positiveExamples: An array of positive examples, each with a name and a compressed (.zip) file
+       of images that depict the visual subject of a class in the classifier. The positive examples create
+       or update classes in the classifier. You can include more than one positive example file in a call.
+       Include at least 10 images in .jpg or .png format. The minimum recommended image resolution is 32X32 pixels.
+       The maximum number of images is 10,000 images or 100 MB per .zip file.
        Encode special characters in the file name in UTF-8.
      - parameter negativeExamples: A .zip file of images that do not depict the visual subject of any of the classes
        of the new classifier. Must contain a minimum of 10 images.
@@ -487,19 +512,21 @@ public class VisualRecognition {
      */
     public func updateClassifier(
         classifierID: String,
-        classnamePositiveExamples: URL? = nil,
+        positiveExamples: [PositiveExample]? = nil,
         negativeExamples: URL? = nil,
         headers: [String: String]? = nil,
         completionHandler: @escaping (WatsonResponse<Classifier>?, WatsonError?) -> Void)
     {
         // construct body
         let multipartFormData = MultipartFormData()
-        if let classnamePositiveExamples = classnamePositiveExamples {
-            do {
-                try multipartFormData.append(file: classnamePositiveExamples, withName: "classname_positive_examples")
-            } catch {
-                completionHandler(nil, WatsonError.serialization(values: "file \(classnamePositiveExamples.path)"))
-                return
+        if let positiveExamples = positiveExamples {
+            positiveExamples.forEach { example in
+                do {
+                    try multipartFormData.append(file: example.examples, withName: example.name + "_positive_examples")
+                } catch {
+                    completionHandler(nil, WatsonError.serialization(values: "file \(example.examples)"))
+                    return
+                }
             }
         }
         if let negativeExamples = negativeExamples {
@@ -604,7 +631,7 @@ public class VisualRecognition {
     public func getCoreMLModel(
         classifierID: String,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<URL>?, WatsonError?) -> Void)
+        completionHandler: @escaping (WatsonResponse<Data>?, WatsonError?) -> Void)
     {
         // construct header parameters
         var headerParameters = defaultHeaders
@@ -634,7 +661,7 @@ public class VisualRecognition {
         )
 
         // execute REST request
-        request.responseObject(completionHandler: completionHandler)
+        request.response(completionHandler: completionHandler)
     }
 
     /**


### PR DESCRIPTION
This PR changes all model definitions to be `Codable`, replacing the previous scheme that used `Encodable` for models only used in requests and `Decodable` for models only expected to be returned in responses.

The original rationale for using either `Encodable` or `Decodable` was to avoid generating the encode or decode methods when they were not needed by the SDK. But we now rely on Swift to synthesize the encoding/decoding logic in most cases -- "additionalProperties" is an exception, but only affects a few classes.

Making all the models "Codable" makes them more flexible and will allow features like pretty-printing (which needs the class to be "Encodable") to be implemented easily.