### PR TITLE
Fix SpeechToText recognizeMicrophone()

### DIFF
--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -195,19 +195,9 @@ extension SpeechToText {
         var settings = settings
         settings.contentType = compress ? "audio/ogg;codecs=opus" : "audio/l16;rate=16000;channels=1"
 
-        // extract authMethod
-        guard let basicAuth = authMethod as? BasicAuthentication else {
-            let failureReason = "Invalid authenticaion method format."
-            let userInfo = [NSLocalizedDescriptionKey: failureReason]
-            let error = NSError(domain: domain, code: 0, userInfo: userInfo)
-            failure?(error)
-            return
-        }
-
-        // create session
+        // create SpeechToTextSession
         let session = SpeechToTextSession(
-            username: basicAuth.username,
-            password: basicAuth.password,
+            authMethod: authMethod,
             model: model,
             customizationID: customizationID,
             acousticCustomizationID: acousticCustomizationID,


### PR DESCRIPTION
Fixes https://github.com/watson-developer-cloud/swift-sdk/issues/916

SpeechToText `recognizeMicrophone()` was only working if the SpeechToText instance was instantiated using basic auth. This fix allows the method to work with any supported authentication method.