### PR TITLE
STT tokenURL and websocketURL

### DIFF
--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -37,9 +37,12 @@ public class SpeechToText {
     /// The base URL to use when contacting the service.
     public var serviceURL = "https://stream.watsonplatform.net/speech-to-text/api" {
         didSet {
+            if serviceURL.last == "/" {
+                serviceURL.removeLast()
+            }
             // websocketsURL and tokenURL are both derivative of serviceURL
             websocketsURL = serviceURL.replacingOccurrences(of: "http", with: "ws", options: .anchored, range: nil)
-            websocketsURL.last == "/" ? websocketsURL.append("v1/recognize") : websocketsURL.append("/v1/recognize")
+            websocketsURL.append("/v1/recognize")
 
             tokenURL = serviceURL.replacingOccurrences(of: "/speech-to-text/api", with: "/authorization/api/v1/token")
         }

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -35,13 +35,21 @@ import RestKit
 public class SpeechToText {
 
     /// The base URL to use when contacting the service.
-    public var serviceURL = "https://stream.watsonplatform.net/speech-to-text/api"
+    public var serviceURL = "https://stream.watsonplatform.net/speech-to-text/api" {
+        didSet {
+            // websocketsURL and tokenURL are both derivative of serviceURL
+            websocketsURL = serviceURL.replacingOccurrences(of: "http", with: "ws", options: .anchored, range: nil)
+            websocketsURL.last == "/" ? websocketsURL.append("v1/recognize") : websocketsURL.append("/v1/recognize")
 
-    /// The URL that shall be used to obtain a token.
-    public var tokenURL = "https://stream.watsonplatform.net/authorization/api/v1/token"
+            tokenURL = serviceURL.replacingOccurrences(of: "/speech-to-text/api", with: "/authorization/api/v1/token")
+        }
+    }
 
     /// The URL that shall be used to stream audio for transcription.
-    public var websocketsURL = "wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize"
+    internal var websocketsURL = "wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize"
+
+    /// The URL that shall be used to obtain a token.
+    internal var tokenURL = "https://stream.watsonplatform.net/authorization/api/v1/token"
 
     /// The default HTTP headers for all requests to the service.
     public var defaultHeaders = [String: String]()

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -21,8 +21,8 @@
 
 import XCTest
 import Foundation
-import SpeechToTextV1
 import RestKit
+@testable import SpeechToTextV1
 
 class SpeechToTextRecognizeTests: XCTestCase {
 

--- a/Tests/SpeechToTextV1Tests/SpeechToTextUnitTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextUnitTests.swift
@@ -1,0 +1,61 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+import RestKit
+@testable import SpeechToTextV1
+
+class SpeechToTextUnitTests: XCTestCase {
+
+    private var speechToText: SpeechToText!
+    private let timeout = 1.0
+
+    private let workspaceID = "test workspace"
+
+    override func setUp() {
+        speechToText = SpeechToText(accessToken: accessToken)
+    }
+
+    func testServiceURLSetsWebsocketsURL() {
+        speechToText.serviceURL = "https://stream.watsonplatform.net/speech-to-text/api"
+        XCTAssertEqual(speechToText.websocketsURL, "wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize")
+
+        // Trailing forward slash
+        speechToText.serviceURL = "https://stream.watsonplatform.net/speech-to-text/api/"
+        XCTAssertEqual(speechToText.websocketsURL, "wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize")
+
+        // http instead of https
+        speechToText.serviceURL = "http://stream.watsonplatform.net/speech-to-text/api"
+        XCTAssertEqual(speechToText.websocketsURL, "ws://stream.watsonplatform.net/speech-to-text/api/v1/recognize")
+
+        // Different base URL
+        speechToText.serviceURL = "https://example.com/speech-to-text/api"
+        XCTAssertEqual(speechToText.websocketsURL, "wss://example.com/speech-to-text/api/v1/recognize")
+    }
+
+    func testServiceURLSetsTokenURL() {
+        speechToText.serviceURL = "https://stream.watsonplatform.net/speech-to-text/api"
+        XCTAssertEqual(speechToText.tokenURL, "https://stream.watsonplatform.net/authorization/api/v1/token")
+
+        // http instead of https
+        speechToText.serviceURL = "http://stream.watsonplatform.net/speech-to-text/api"
+        XCTAssertEqual(speechToText.tokenURL, "http://stream.watsonplatform.net/authorization/api/v1/token")
+
+        // Different base URL
+        speechToText.serviceURL = "https://example.com/speech-to-text/api"
+        XCTAssertEqual(speechToText.tokenURL, "https://example.com/authorization/api/v1/token")
+    }
+}

--- a/Tests/SpeechToTextV1Tests/SpeechToTextUnitTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextUnitTests.swift
@@ -35,6 +35,7 @@ class SpeechToTextUnitTests: XCTestCase {
 
         // Trailing forward slash
         speechToText.serviceURL = "https://stream.watsonplatform.net/speech-to-text/api/"
+        XCTAssertEqual(speechToText.serviceURL, "https://stream.watsonplatform.net/speech-to-text/api")
         XCTAssertEqual(speechToText.websocketsURL, "wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize")
 
         // http instead of https

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -509,6 +509,7 @@
 		92ED234C2187C57C00C049A2 /* TokenDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92ED234A2187C57B00C049A2 /* TokenDict.swift */; };
 		92ED234D2187C57C00C049A2 /* TokenDictStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92ED234B2187C57B00C049A2 /* TokenDictStatusResponse.swift */; };
 		92ED234F218A598D00C049A2 /* TokenDictRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92ED234E218A598D00C049A2 /* TokenDictRule.swift */; };
+		92EE4EFD21A470630008CE33 /* SpeechToTextUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE4EFC21A470630008CE33 /* SpeechToTextUnitTests.swift */; };
 		CA151FA2200EE23F00DBA44F /* carz.zip in Resources */ = {isa = PBXBuildFile; fileRef = CA151FA0200EE0CF00DBA44F /* carz.zip */; };
 		CA17C8DA218F8C8A00677CA7 /* TokenDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA17C8D7218F8C8A00677CA7 /* TokenDict.swift */; };
 		CA17C8DB218F8C8A00677CA7 /* TokenDictStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA17C8D8218F8C8A00677CA7 /* TokenDictStatusResponse.swift */; };
@@ -1129,6 +1130,7 @@
 		929A23E521123E7E00E4C78A /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestUtilities.swift; path = Tests/TestUtilities.swift; sourceTree = "<group>"; };
 		92B470672194F225006C3333 /* AssistantV1UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantV1UnitTests.swift; sourceTree = "<group>"; };
 		92BF69AD213F129A00FE6325 /* Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Shared.swift; path = Source/SupportingFiles/Shared.swift; sourceTree = "<group>"; };
+		92EE4EFC21A470630008CE33 /* SpeechToTextUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechToTextUnitTests.swift; sourceTree = "<group>"; };
 		92F3F9882193AE7800211747 /* watson_tools.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = watson_tools.mlmodel; sourceTree = "<group>"; };
 		92F3F98E2194AFA300211747 /* watson_sample.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = watson_sample.mlmodel; sourceTree = "<group>"; };
 		92ED234A2187C57B00C049A2 /* TokenDict.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenDict.swift; sourceTree = "<group>"; };
@@ -1999,6 +2001,7 @@
 			children = (
 				7AAA9A211CEE3026002C9564 /* Audio Files */,
 				7AAA9A251CEE3026002C9564 /* SpeechToTextTests.swift */,
+				92EE4EFC21A470630008CE33 /* SpeechToTextUnitTests.swift */,
 				68BB78F82089A97E00173438 /* SpeechToTextRecognizeTests.swift */,
 				12D82B4F1E2D2E5300430DB3 /* healthcare-short.txt */,
 			);
@@ -3968,6 +3971,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				92B470702194F6AF006C3333 /* MockURLProtocol.swift in Sources */,
+				92EE4EFD21A470630008CE33 /* SpeechToTextUnitTests.swift in Sources */,
 				920A2447214B0E400077F10D /* Shared.swift in Sources */,
 				7A6C7B491D8C960300CD97FA /* WatsonCredentials.swift in Sources */,
 				7AF31BFB1D7A414D0040D944 /* SpeechToTextTests.swift in Sources */,


### PR DESCRIPTION
https://github.ibm.com/arf/planning-sdk-squad/issues/749

SpeechToText `tokenURL` and `websocketURL` are changed from `public` to `internal`. When the `serviceURL` gets set, the `tokenURL` and `websocketURL` are also set depending on the value of `serviceURL`.