### PR TITLE
Add missing parameters to SpeechToTextSession

### DIFF
--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -32,10 +32,19 @@ extension SpeechToText {
      - parameter settings: The configuration to use for this recognition request.
      - parameter model: The language and sample rate of the audio. For supported models, visit
        https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
-     - parameter customizationID: The GUID of a custom language model that is to be used with the
-       request. The base language model of the specified custom language model must match the
-       model specified with the `model` parameter. By default, no custom model is used.
+     - parameter baseModelVersion: The version of the specified base model that is to be used for all requests sent
+       over the connection. Multiple versions of a base model can exist when a model is updated for internal improvements.
+       The parameter is intended primarily for use with custom models that have been upgraded for a new base model.
+       The default value depends on whether the parameter is used with or without a custom model. See
+       [Base model version](https://cloud.ibm.com/docs/services/speech-to-text/input.html#version).
+     - parameter languageCustomizationID: The customization ID (GUID) of a custom language model that is to be used
+       with the recognition request. The base model of the specified custom language model must match the model
+       specified with the `model` parameter. You must make the request with service credentials created for the instance
+       of the service that owns the custom model. By default, no custom language model is used. See [Custom
+       models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
+     - parameter customerID: Associates a customer ID with all data that is passed over the connection.
+       By default, no customer ID is associated with the data.
      - parameter failure: A function executed whenever an error occurs.
      - parameter success: A function executed with all transcription results whenever
        a final or interim transcription is received.
@@ -44,8 +53,10 @@ extension SpeechToText {
         audio: URL,
         settings: RecognitionSettings,
         model: String? = nil,
-        customizationID: String? = nil,
+        baseModelVersion: String? = nil,
+        languageCustomizationID: String? = nil,
         learningOptOut: Bool? = nil,
+        customerID: String? = nil,
         completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
     {
         do {
@@ -54,8 +65,10 @@ extension SpeechToText {
                 audio: data,
                 settings: settings,
                 model: model,
-                customizationID: customizationID,
+                baseModelVersion: baseModelVersion,
+                languageCustomizationID: languageCustomizationID,
                 learningOptOut: learningOptOut,
+                customerID: customerID,
                 completionHandler: completionHandler
             )
         } catch {
@@ -72,14 +85,23 @@ extension SpeechToText {
      - parameter settings: The configuration to use for this recognition request.
      - parameter model: The language and sample rate of the audio. For supported models, visit
        https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
-     - parameter customizationID: The GUID of a custom language model that is to be used with the
-       request. The base language model of the specified custom language model must match the
-       model specified with the `model` parameter. By default, no custom model is used.
+     - parameter baseModelVersion: The version of the specified base model that is to be used for all requests sent
+       over the connection. Multiple versions of a base model can exist when a model is updated for internal improvements.
+       The parameter is intended primarily for use with custom models that have been upgraded for a new base model.
+       The default value depends on whether the parameter is used with or without a custom model. See
+       [Base model version](https://cloud.ibm.com/docs/services/speech-to-text/input.html#version).
+     - parameter languageCustomizationID: The customization ID (GUID) of a custom language model that is to be used
+       with the recognition request. The base model of the specified custom language model must match the model
+       specified with the `model` parameter. You must make the request with service credentials created for the instance
+       of the service that owns the custom model. By default, no custom language model is used. See [Custom
+       models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model
        that is to be used with the recognition request. The base model of the specified custom
        acoustic model must match the model specified with the `model` parameter. By default, no
        custom acoustic model is used.
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
+     - parameter customerID: Associates a customer ID with all data that is passed over the connection.
+       By default, no customer ID is associated with the data.
      - parameter headers: A dictionary of request headers to be sent with this request.
      - parameter failure: A function executed whenever an error occurs.
      - parameter success: A function executed with all transcription results whenever
@@ -89,9 +111,11 @@ extension SpeechToText {
         audio: Data,
         settings: RecognitionSettings,
         model: String? = nil,
-        customizationID: String? = nil,
+        baseModelVersion: String? = nil,
+        languageCustomizationID: String? = nil,
         acousticCustomizationID: String? = nil,
         learningOptOut: Bool? = nil,
+        customerID: String? = nil,
         headers: [String: String]? = nil,
         completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
     {
@@ -99,9 +123,11 @@ extension SpeechToText {
         let session = SpeechToTextSession(
             authMethod: authMethod,
             model: model,
-            customizationID: customizationID,
+            baseModelVersion: baseModelVersion,
+            languageCustomizationID: languageCustomizationID,
             acousticCustomizationID: acousticCustomizationID,
-            learningOptOut: learningOptOut
+            learningOptOut: learningOptOut,
+            customerID: customerID
         )
 
         // set urls
@@ -149,14 +175,23 @@ extension SpeechToText {
      - parameter settings: The configuration for this transcription request.
      - parameter model: The language and sample rate of the audio. For supported models, visit
        https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
-     - parameter customizationID: The GUID of a custom language model that is to be used with the
-       request. The base language model of the specified custom language model must match the
-       model specified with the `model` parameter. By default, no custom model is used.
+     - parameter baseModelVersion: The version of the specified base model that is to be used for all requests sent
+       over the connection. Multiple versions of a base model can exist when a model is updated for internal improvements.
+       The parameter is intended primarily for use with custom models that have been upgraded for a new base model.
+       The default value depends on whether the parameter is used with or without a custom model. See
+       [Base model version](https://cloud.ibm.com/docs/services/speech-to-text/input.html#version).
+     - parameter languageCustomizationID: The customization ID (GUID) of a custom language model that is to be used
+       with the recognition request. The base model of the specified custom language model must match the model
+       specified with the `model` parameter. You must make the request with service credentials created for the instance
+       of the service that owns the custom model. By default, no custom language model is used. See [Custom
+       models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model
        that is to be used with the recognition request. The base model of the specified custom
        acoustic model must match the model specified with the `model` parameter. By default, no
        custom acoustic model is used.
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
+     - parameter customerID: Associates a customer ID with all data that is passed over the connection.
+       By default, no customer ID is associated with the data.
      - parameter compress: Should microphone audio be compressed to Opus format?
        (Opus compression reduces latency and bandwidth.)
      - parameter headers: A dictionary of request headers to be sent with this request.
@@ -167,9 +202,11 @@ extension SpeechToText {
     public func recognizeMicrophone(
         settings: RecognitionSettings,
         model: String? = nil,
-        customizationID: String? = nil,
+        baseModelVersion: String? = nil,
+        languageCustomizationID: String? = nil,
         acousticCustomizationID: String? = nil,
         learningOptOut: Bool? = nil,
+        customerID: String? = nil,
         compress: Bool = true,
         headers: [String: String]? = nil,
         completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
@@ -198,9 +235,11 @@ extension SpeechToText {
         let session = SpeechToTextSession(
             authMethod: authMethod,
             model: model,
-            customizationID: customizationID,
+            baseModelVersion: baseModelVersion,
+            languageCustomizationID: languageCustomizationID,
             acousticCustomizationID: acousticCustomizationID,
-            learningOptOut: learningOptOut
+            learningOptOut: learningOptOut,
+            customerID: customerID
         )
 
         // set urls
@@ -245,22 +284,6 @@ extension SpeechToText {
         microphoneSession?.stopMicrophone()
         microphoneSession?.stopRequest()
         microphoneSession?.disconnect()
-    }
-}
-
-extension SpeechToText {
-
-    @available(*, deprecated, message: "The recognize method has been deprecated in favor of recognizeUsingWebSocket method.  This method will be removed in a future release.")
-    public func recognize(
-        audio: Data,
-        settings: RecognitionSettings,
-        model: String? = nil,
-        customizationID: String? = nil,
-        learningOptOut: Bool? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
-    {
-        recognizeUsingWebSocket(audio: audio, settings: settings, model: model, customizationID: customizationID,
-                                learningOptOut: learningOptOut, completionHandler: completionHandler)
     }
 }
 

--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -194,14 +194,6 @@ extension SpeechToText {
         var settings = settings
         settings.contentType = compress ? "audio/ogg;codecs=opus" : "audio/l16;rate=16000;channels=1"
 
-        // extract authMethod
-        guard let basicAuth = authMethod as? BasicAuthentication else {
-            let failureReason = "Invalid authenticaion method format."
-            let error = WatsonError.other(message: failureReason)
-            completionHandler(nil, error)
-            return
-        }
-
         // create SpeechToTextSession
         let session = SpeechToTextSession(
             authMethod: authMethod,

--- a/Source/SpeechToTextV1/WebSockets/RecognitionSettings.swift
+++ b/Source/SpeechToTextV1/WebSockets/RecognitionSettings.swift
@@ -29,8 +29,8 @@ public struct RecognitionSettings: Codable, Equatable {
     private let action = "start"
 
     /// The format of the audio data. Endianness is automatically detected by the Speech to Text
-    /// service. For more information aboutthe supported formats, visit:
-    /// https://console.bluemix.net/docs/services/speech-to-text/input.html#formats
+    /// service. For more information about the supported formats, visit:
+    /// https://cloud.ibm.com/docs/services/speech-to-text/audio-formats.html
     public var contentType: String?
 
     /// If you specify a customization ID when you open the connection, you can use the customization
@@ -92,7 +92,7 @@ public struct RecognitionSettings: Codable, Equatable {
      Text recognition request.
      - parameter contentType: The format of the audio data. Endianness is automatically detected
         by the Speech to Text service. For more information about the supported formats, visit:
-        https://console.bluemix.net/docs/services/speech-to-text/input.html#formats
+        https://cloud.ibm.com/docs/services/speech-to-text/audio-formats.html
      - returns: An initialized `RecognitionSettings` object with the given `contentType`.
         Configure additional parameters for the recognition request by directly modifying
         the returned object's properties.

--- a/Source/SpeechToTextV1/WebSockets/RecognitionSettings.swift
+++ b/Source/SpeechToTextV1/WebSockets/RecognitionSettings.swift
@@ -31,7 +31,7 @@ public struct RecognitionSettings: Codable, Equatable {
     /// The format of the audio data. Endianness is automatically detected by the Speech to Text
     /// service. For more information aboutthe supported formats, visit:
     /// https://console.bluemix.net/docs/services/speech-to-text/input.html#formats
-    public var contentType: String
+    public var contentType: String?
 
     /// If you specify a customization ID when you open the connection, you can use the customization
     /// weight to tell the service how much weight to give to words from the custom language model
@@ -90,16 +90,14 @@ public struct RecognitionSettings: Codable, Equatable {
     /**
      Initialize a `RecognitionSettings` object to set the parameters of a Watson Speech to
      Text recognition request.
-
      - parameter contentType: The format of the audio data. Endianness is automatically detected
         by the Speech to Text service. For more information about the supported formats, visit:
         https://console.bluemix.net/docs/services/speech-to-text/input.html#formats
-
      - returns: An initialized `RecognitionSettings` object with the given `contentType`.
         Configure additional parameters for the recognition request by directly modifying
         the returned object's properties.
      */
-    public init(contentType: String) {
+    public init(contentType: String? = nil) {
         self.contentType = contentType
     }
 

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
@@ -86,9 +86,11 @@ public class SpeechToTextSession {
         let url = SpeechToTextSocket.buildURL(
             url: websocketsURL,
             model: model,
-            customizationID: customizationID,
+            baseModelVersion: baseModelVersion,
+            languageCustomizationID: languageCustomizationID,
             acousticCustomizationID: acousticCustomizationID,
-            learningOptOut: learningOptOut
+            learningOptOut: learningOptOut,
+            customerID: customerID
         )!
         var socket = SpeechToTextSocket(
             url: url,
@@ -112,21 +114,28 @@ public class SpeechToTextSession {
 
     private let authMethod: AuthenticationMethod
     private let model: String?
-    private let customizationID: String?
+    private let baseModelVersion: String?
+    private let languageCustomizationID: String?
     private let acousticCustomizationID: String?
     private let learningOptOut: Bool?
+    private let customerID: String?
 
-    internal init(authMethod: AuthenticationMethod,
-                  model: String? = nil,
-                  customizationID: String? = nil,
-                  acousticCustomizationID: String? = nil,
-                  learningOptOut: Bool? = nil)
+    internal init(
+        authMethod: AuthenticationMethod,
+        model: String? = nil,
+        baseModelVersion: String? = nil,
+        languageCustomizationID: String? = nil,
+        acousticCustomizationID: String? = nil,
+        learningOptOut: Bool? = nil,
+        customerID: String? = nil)
     {
         self.authMethod = authMethod
         self.model = model
-        self.customizationID = customizationID
+        self.baseModelVersion = baseModelVersion
+        self.languageCustomizationID = languageCustomizationID
         self.acousticCustomizationID = acousticCustomizationID
         self.learningOptOut = learningOptOut
+        self.customerID = customerID
 
         recorder = SpeechToTextRecorder()
         // swiftlint:disable:next force_try
@@ -144,18 +153,43 @@ public class SpeechToTextSession {
      - parameter password: The password used to authenticate with the service.
      - parameter model: The language and sample rate of the audio. For supported models, visit
         https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
-     - parameter customizationID: The GUID of a custom language model that is to be used with the
-        request. The base language model of the specified custom language model must match the
-        model specified with the `model` parameter. By default, no custom model is used.
+     - parameter baseModelVersion: The version of the specified base model that is to be used for all requests sent
+       over the connection. Multiple versions of a base model can exist when a model is updated for internal improvements.
+       The parameter is intended primarily for use with custom models that have been upgraded for a new base model.
+       The default value depends on whether the parameter is used with or without a custom model. See
+       [Base model version](https://cloud.ibm.com/docs/services/speech-to-text/input.html#version).
+     - parameter languageCustomizationID: The customization ID (GUID) of a custom language model that is to be used
+       with the recognition request. The base model of the specified custom language model must match the model
+       specified with the `model` parameter. You must make the request with service credentials created for the instance
+       of the service that owns the custom model. By default, no custom language model is used. See [Custom
+       models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model
        that is to be used with the recognition request. The base model of the specified custom
        acoustic model must match the model specified with the `model` parameter. By default, no
        custom acoustic model is used.
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
+     - parameter customerID: Associates a customer ID with all data that is passed over the connection.
+       By default, no customer ID is associated with the data.
      */
-    public convenience init(username: String, password: String, model: String? = nil, customizationID: String? = nil, acousticCustomizationID: String?, learningOptOut: Bool? = nil) {
+    public convenience init(
+        username: String,
+        password: String,
+        model: String? = nil,
+        baseModelVersion: String? = nil,
+        languageCustomizationID: String? = nil,
+        acousticCustomizationID: String? = nil,
+        learningOptOut: Bool? = nil,
+        customerID: String? = nil)
+    {
         let authMethod = BasicAuthentication(username: username, password: password)
-        self.init(authMethod: authMethod, model: model, customizationID: customizationID, acousticCustomizationID: acousticCustomizationID, learningOptOut: learningOptOut)
+        self.init(
+            authMethod: authMethod,
+            model: model,
+            baseModelVersion: baseModelVersion,
+            languageCustomizationID: languageCustomizationID,
+            acousticCustomizationID: acousticCustomizationID,
+            learningOptOut: learningOptOut,
+            customerID: customerID)
     }
 
     /**
@@ -164,19 +198,45 @@ public class SpeechToTextSession {
      - parameter apiKey: An API key for IAM that can be used to obtain access tokens for the service.
      - parameter iamUrl: The URL for the IAM service.
      - parameter model: The language and sample rate of the audio. For supported models, visit
-     https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
-     - parameter customizationID: The GUID of a custom language model that is to be used with the
-     request. The base language model of the specified custom language model must match the
-     model specified with the `model` parameter. By default, no custom model is used.
+       https://console.bluemix.net/docs/services/speech-to-text/input.html#models.
+     - parameter baseModelVersion: The version of the specified base model that is to be used for all requests sent
+       over the connection. Multiple versions of a base model can exist when a model is updated for internal improvements.
+       The parameter is intended primarily for use with custom models that have been upgraded for a new base model.
+       The default value depends on whether the parameter is used with or without a custom model. See
+       [Base model version](https://cloud.ibm.com/docs/services/speech-to-text/input.html#version).
+     - parameter languageCustomizationID: The customization ID (GUID) of a custom language model that is to be used
+       with the recognition request. The base model of the specified custom language model must match the model
+       specified with the `model` parameter. You must make the request with service credentials created for the instance
+       of the service that owns the custom model. By default, no custom language model is used. See [Custom
+       models](https://console.bluemix.net/docs/services/speech-to-text/input.html#custom).
      - parameter acousticCustomizationID: The customization ID (GUID) of a custom acoustic model
        that is to be used with the recognition request. The base model of the specified custom
        acoustic model must match the model specified with the `model` parameter. By default, no
        custom acoustic model is used.
      - parameter learningOptOut: If `true`, then this request will not be logged for training.
+     - parameter customerID: Associates a customer ID with all data that is passed over the connection.
+       By default, no customer ID is associated with the data.
      */
-    public convenience init(apiKey: String, iamUrl: String? = nil, model: String? = nil, customizationID: String? = nil, acousticCustomizationID: String? = nil, learningOptOut: Bool? = nil) {
+    public convenience init(
+        apiKey: String,
+        iamUrl: String? = nil,
+        model: String? = nil,
+        baseModelVersion: String? = nil,
+        languageCustomizationID: String? = nil,
+        acousticCustomizationID: String? = nil,
+        learningOptOut: Bool? = nil,
+        customerID: String? = nil)
+    {
         let authMethod = IAMAuthentication(apiKey: apiKey, url: iamUrl)
-        self.init(authMethod: authMethod, model: model, customizationID: customizationID, acousticCustomizationID: acousticCustomizationID, learningOptOut: learningOptOut)
+        self.init(
+            authMethod: authMethod,
+            model: model,
+            baseModelVersion: baseModelVersion,
+            languageCustomizationID: languageCustomizationID,
+            acousticCustomizationID: acousticCustomizationID,
+            learningOptOut: learningOptOut,
+            customerID: customerID
+        )
     }
 
     /**

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSession.swift
@@ -82,7 +82,7 @@ public class SpeechToTextSession {
     /// Invoked when the session disconnects from the Speech to Text service.
     public var onDisconnect: (() -> Void)?
 
-    private lazy var socket: SpeechToTextSocket = {
+    internal lazy var socket: SpeechToTextSocket = {
         let url = SpeechToTextSocket.buildURL(
             url: websocketsURL,
             model: model,

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
@@ -29,7 +29,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
     internal var onError: ((WatsonError) -> Void)?
     internal var onDisconnect: (() -> Void)?
 
-    private let url: URL
+    internal let url: URL
     private let authMethod: AuthenticationMethod
     private let maxConnectAttempts: Int
     private var connectAttempts: Int
@@ -185,7 +185,7 @@ internal class SpeechToTextSocket: WebSocketDelegate {
             queryParameters.append(URLQueryItem(name: "x-watson-learning-opt-out", value: value))
         }
         if let customerID = customerID {
-            let value = "customer_id%3d\(customerID)"
+            let value = "customer_id=\(customerID)"
             queryParameters.append(URLQueryItem(name: "x-watson-metadata", value: value))
         }
         var urlComponents = URLComponents(string: url)

--- a/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
+++ b/Source/SpeechToTextV1/WebSockets/SpeechToTextSocket.swift
@@ -158,13 +158,24 @@ internal class SpeechToTextSocket: WebSocketDelegate {
         }
     }
 
-    internal static func buildURL(url: String, model: String?, customizationID: String?, acousticCustomizationID: String?, learningOptOut: Bool?) -> URL? {
+    internal static func buildURL(
+        url: String,
+        model: String?,
+        baseModelVersion: String?,
+        languageCustomizationID: String?,
+        acousticCustomizationID: String?,
+        learningOptOut: Bool?,
+        customerID: String?) -> URL?
+    {
         var queryParameters = [URLQueryItem]()
         if let model = model {
             queryParameters.append(URLQueryItem(name: "model", value: model))
         }
-        if let customizationID = customizationID {
-            queryParameters.append(URLQueryItem(name: "customization_id", value: customizationID))
+        if let baseModelVersion = baseModelVersion {
+            queryParameters.append(URLQueryItem(name: "base_model_version", value: baseModelVersion))
+        }
+        if let languageCustomizationID = languageCustomizationID {
+            queryParameters.append(URLQueryItem(name: "language_customization_id", value: languageCustomizationID))
         }
         if let acousticCustomizationID = acousticCustomizationID {
             queryParameters.append(URLQueryItem(name: "acoustic_customization_id", value: acousticCustomizationID))
@@ -172,6 +183,10 @@ internal class SpeechToTextSocket: WebSocketDelegate {
         if let learningOptOut = learningOptOut {
             let value = "\(learningOptOut)"
             queryParameters.append(URLQueryItem(name: "x-watson-learning-opt-out", value: value))
+        }
+        if let customerID = customerID {
+            let value = "customer_id%3d\(customerID)"
+            queryParameters.append(URLQueryItem(name: "x-watson-metadata", value: value))
         }
         var urlComponents = URLComponents(string: url)
         if !queryParameters.isEmpty {

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -101,7 +101,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         transcribeFileDefault(filename: "SpeechSample", withExtension: "flac", format: "audio/flac")
     }
 
-    func transcribeFileDefault(filename: String, withExtension: String, format: String) {
+    func testTranscribeFileNoFormat() {
+        transcribeFileDefault(filename: "SpeechSample", withExtension: "wav", format: nil)
+    }
+
+    func transcribeFileDefault(filename: String, withExtension: String, format: String?) {
         let description = "Transcribe an audio file."
         let expectation = self.expectation(description: description)
 
@@ -148,7 +152,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         transcribeFileCustom(filename: "SpeechSample", withExtension: "flac", format: "audio/flac")
     }
 
-    func transcribeFileCustom(filename: String, withExtension: String, format: String) {
+    func testTranscribeFileCustomNoFormat() {
+        transcribeFileCustom(filename: "SpeechSample", withExtension: "ogg", format: nil)
+    }
+
+    func transcribeFileCustom(filename: String, withExtension: String, format: String?) {
         let description = "Transcribe an audio file."
         let expectation = self.expectation(description: description)
 
@@ -206,7 +214,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         transcribeDataDefault(filename: "SpeechSample", withExtension: "flac", format: "audio/flac")
     }
 
-    func transcribeDataDefault(filename: String, withExtension: String, format: String) {
+    func testTranscribeDataDefaultNoFormat() {
+        transcribeDataDefault(filename: "SpeechSample", withExtension: "flac", format: nil)
+    }
+
+    func transcribeDataDefault(filename: String, withExtension: String, format: String?) {
         let description = "Transcribe an audio file."
         let expectation = self.expectation(description: description)
 
@@ -260,7 +272,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         transcribeDataCustom(filename: "SpeechSample", withExtension: "flac", format: "audio/flac")
     }
 
-    func transcribeDataCustom(filename: String, withExtension: String, format: String) {
+    func testTranscribeDataCustomNoFormat() {
+        transcribeDataCustom(filename: "SpeechSample", withExtension: "wav", format: nil)
+    }
+
+    func transcribeDataCustom(filename: String, withExtension: String, format: String?) {
         let description = "Transcribe an audio file."
         let expectation = self.expectation(description: description)
 
@@ -515,7 +531,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         transcribeDataWithSpeakerLabels(filename: "SpeechSample", withExtension: "flac", format: "audio/flac")
     }
 
-    func transcribeDataWithSpeakerLabels(filename: String, withExtension: String, format: String) {
+    func testTranscribeDataWithSpeakerLabelsNoFormat() {
+        transcribeDataWithSpeakerLabels(filename: "SpeechSample", withExtension: "ogg", format: nil)
+    }
+
+    func transcribeDataWithSpeakerLabels(filename: String, withExtension: String, format: String?) {
         let description = "Transcribe an audio file."
         let expectation = self.expectation(description: description)
         var expectationFulfilled = false

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -355,7 +355,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
         do {
             let audio = try Data(contentsOf: file)
             let settings = RecognitionSettings(contentType: format)
-            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: baseModelName, customizationID: customizationID) {
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: baseModelName, languageCustomizationID: customizationID) {
                 response, error in
                 if let error = error {
                     XCTFail(unexpectedErrorMessage(error))

--- a/Tests/SpeechToTextV1Tests/SpeechToTextUnitTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextUnitTests.swift
@@ -29,6 +29,8 @@ class SpeechToTextUnitTests: XCTestCase {
         speechToText = SpeechToText(accessToken: accessToken)
     }
 
+    // MARK: - URLs
+
     func testServiceURLSetsWebsocketsURL() {
         speechToText.serviceURL = "https://stream.watsonplatform.net/speech-to-text/api"
         XCTAssertEqual(speechToText.websocketsURL, "wss://stream.watsonplatform.net/speech-to-text/api/v1/recognize")
@@ -58,5 +60,49 @@ class SpeechToTextUnitTests: XCTestCase {
         // Different base URL
         speechToText.serviceURL = "https://example.com/speech-to-text/api"
         XCTAssertEqual(speechToText.tokenURL, "https://example.com/authorization/api/v1/token")
+    }
+
+    // MARK - Websockets
+
+    // Check that instantiating a SpeechToTextSession creates the correct SpeechToTextSocket
+    func testSpeechToTextSessionSocket() {
+
+        let iamUrl = "https://example.com"
+        let model = "testModel"
+        let baseModelVersion = "1.0"
+        let languageCustomizationID = "123"
+        let acousticCustomizationID = "456"
+        let learningOptOut = true
+        let customerID = "Anthony"
+
+        // API Key authentication
+        var sttSession = SpeechToTextSession(
+            apiKey: "1234",
+            iamUrl: iamUrl,
+            model: model,
+            baseModelVersion: baseModelVersion,
+            languageCustomizationID: languageCustomizationID,
+            acousticCustomizationID: acousticCustomizationID,
+            learningOptOut: learningOptOut,
+            customerID: customerID)
+
+        var socket = sttSession.socket
+        var expectedURL = "\(sttSession.websocketsURL)?model=\(model)&base_model_version=\(baseModelVersion)&language_customization_id=\(languageCustomizationID)&acoustic_customization_id=\(acousticCustomizationID)&x-watson-learning-opt-out=\(learningOptOut)&x-watson-metadata=customer_id%3D\(customerID)"
+        XCTAssertEqual(socket.url, URL(string: expectedURL))
+
+        // Same as above, but with Basic Auth instead of API Key in the initializer
+        sttSession = SpeechToTextSession(
+            username: "Anthony",
+            password: "hunter2",
+            model: model,
+            baseModelVersion: baseModelVersion,
+            languageCustomizationID: languageCustomizationID,
+            acousticCustomizationID: acousticCustomizationID,
+            learningOptOut: learningOptOut,
+            customerID: customerID)
+
+        socket = sttSession.socket
+        expectedURL = "\(sttSession.websocketsURL)?model=\(model)&base_model_version=\(baseModelVersion)&language_customization_id=\(languageCustomizationID)&acoustic_customization_id=\(acousticCustomizationID)&x-watson-learning-opt-out=\(learningOptOut)&x-watson-metadata=customer_id%3D\(customerID)"
+        XCTAssertEqual(socket.url, URL(string: expectedURL))
     }
 }


### PR DESCRIPTION
https://github.ibm.com/arf/planning-sdk-squad/issues/761

Adds parameters that the `SpeechToTextSession` class was missing. The parameters were taken from the [API docs](https://console.test.cloud.ibm.com/apidocs/speech-to-text#websocket_methods). `customizationID` was removed since it is deprecated in favor of `languageCustomizationID`.