### PR TITLE
Add missing fields to AssistantV1 and AssistantV2

### DIFF
--- a/Source/AssistantV1/Models/DialogNode.swift
+++ b/Source/AssistantV1/Models/DialogNode.swift
@@ -142,6 +142,11 @@ public struct DialogNode: Codable, Equatable {
     public var title: String?
 
     /**
+     For internal use only.
+     */
+    public var disabled: Bool?
+
+    /**
      How the dialog node is processed.
      */
     public var nodeType: String?
@@ -192,6 +197,7 @@ public struct DialogNode: Codable, Equatable {
         case updated = "updated"
         case actions = "actions"
         case title = "title"
+        case disabled = "disabled"
         case nodeType = "type"
         case eventName = "event_name"
         case variable = "variable"

--- a/Source/AssistantV2/Models/MessageOutput.swift
+++ b/Source/AssistantV2/Models/MessageOutput.swift
@@ -15,6 +15,7 @@
  **/
 
 import Foundation
+import RestKit
 
 /**
  Assistant output to be rendered or processed by the client.
@@ -47,6 +48,12 @@ public struct MessageOutput: Codable, Equatable {
      */
     public var debug: MessageOutputDebug?
 
+    /**
+     An object containing any custom properties included in the response. This object includes any arbitrary properties
+     defined in the dialog JSON editor as part of the dialog node output.
+     */
+    public var userDefined: [String: JSON]?
+
     // Map each property name to the key that shall be used for encoding/decoding.
     private enum CodingKeys: String, CodingKey {
         case generic = "generic"
@@ -54,6 +61,7 @@ public struct MessageOutput: Codable, Equatable {
         case entities = "entities"
         case actions = "actions"
         case debug = "debug"
+        case userDefined = "user_defined"
     }
 
 }


### PR DESCRIPTION
https://github.ibm.com/Watson/developer-experience/issues/5969
https://github.ibm.com/Watson/developer-experience/issues/5964

1. Adds the `disabled` property to the `DialogNode` type in AssistantV1. The issue above (5969) says that it should be added to the `CreateDialogNode` field, but Taj discovered that this field is actually not yet settable by the SDKs, and is only meant to be returned in a response.
1. Adds the missing `userDefined` property to `MessageOutput` in AssistantV2.