### PR TITLE
Fix travis timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,24 @@
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      sudo: required
-    - os: osx
-      osx_image: xcode10.1
 branches:
   only:
     - master
     - develop
-env:
-  global:
-    - IOS_SDK="iphonesimulator"
-    - IOS_DESTINATION="name=iPhone XS,OS=12.0"
-before_install:
-  - sudo easy_install pip
-  - nvm install node
-  - nvm use node
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
-install:
-  - gem install cocoapods
-  - gem install jazzy
-  - sudo pip install bumpversion
-  - npm install -g semantic-release@15.9.0
-  - npm install -g @semantic-release/exec
-  - npm install -g @semantic-release/changelog
-  - npm install -g @semantic-release/git
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated swiftlint || brew upgrade swiftlint ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated carthage || brew upgrade carthage ; fi
-before_script:
-  - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Source/SupportingFiles/WatsonCredentials.swift.enc -out Source/SupportingFiles/WatsonCredentials.swift -d
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pod repo update master --silent ; fi # Gets the latest version of RestKit
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then carthage update --platform iOS ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update -y ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://swift.org/builds/swift-4.1-release/ubuntu1404/swift-4.1-RELEASE/swift-4.1-RELEASE-ubuntu14.04.tar.gz -q; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xzf swift-4.1-RELEASE-ubuntu14.04.tar.gz ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=swift-4.1-RELEASE-ubuntu14.04/usr/bin:$PATH ; fi
-script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./Scripts/run-tests.sh ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./Scripts/pod-lint.sh ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then swift build ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then swift test ; fi
+jobs:
+  include:
+    - stage: test Linux
+      script: ./Scripts/travis/test-Linux.sh
+      os: linux
+    - stage: test macOS
+      script: ./Scripts/travis/test-macOS.sh
+      os: osx
+    - stage: release new version
+      script: ./Scripts/travis/new-release.sh
+      os: osx
+      if: branch = master
+    - stage: deploy to cocoapods
+      script: ./Scripts/travis/deploy-to-cocoapods.sh
+      os: osx
+      if: branch = master
+    - stage: publish documentation
+      script: ./Scripts/travis/publish-documentation.sh
+      os: osx
+      if: branch = master

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -8,7 +8,7 @@
 ####################
 
 # the device to build for
-DESTINATION="OS=11.3,name=iPhone 7"
+DESTINATION="OS=11.4,name=iPhone X"
 
 # the schemes to build, which must be invoked from the root directory of the project
 SCHEMES=$(xcodebuild -list | awk 'schemes { if (NF>0) { print $1 } } /Schemes:$/ { schemes = 1 }')

--- a/Scripts/travis/deploy-to-cocoapods.sh
+++ b/Scripts/travis/deploy-to-cocoapods.sh
@@ -1,0 +1,23 @@
+# Publishes the latest version of all services to Cocoapods
+
+set -e
+
+declare -a allPods=(
+  "IBMWatsonAssistantV1.podspec"
+  "IBMWatsonAssistantV2.podspec"
+  "IBMWatsonDiscoveryV1.podspec"
+  "IBMWatsonLanguageTranslatorV3.podspec"
+  "IBMWatsonNaturalLanguageClassifierV1.podspec"
+  "IBMWatsonNaturalLanguageUnderstandingV1.podspec"
+  "IBMWatsonPersonalityInsightsV3.podspec"
+  "IBMWatsonSpeechToTextV1.podspec"
+  "IBMWatsonTextToSpeechV1.podspec"
+  "IBMWatsonToneAnalyzerV3.podspec"
+  "IBMWatsonVisualRecognitionV3.podspec"
+)
+
+for podspec in "${allPods[@]}"
+do
+  # This will only publish pods if their version has been updated
+  pod trunk push $podspec --allow-warnings
+done

--- a/Scripts/travis/new-release.sh
+++ b/Scripts/travis/new-release.sh
@@ -7,16 +7,16 @@
 
 set -e
 
-sudo easy_install pip
+sudo easy_install pip >/dev/null
 source ~/.nvm/nvm.sh
 nvm install 10
-sudo pip install bumpversion
-npm install -g semantic-release@15.9.0
-npm install -g @semantic-release/exec
-npm install -g @semantic-release/changelog
-npm install -g @semantic-release/git
-brew update
-brew outdated carthage || brew upgrade carthage
+sudo pip install bumpversion >/dev/null
+npm install -g semantic-release@15.9.0 --silent
+npm install -g @semantic-release/exec --silent
+npm install -g @semantic-release/changelog --silent
+npm install -g @semantic-release/git --silent
+brew update >/dev/null
+brew outdated carthage || brew upgrade carthage >/dev/null
 
 carthage update --platform iOS
 npx semantic-release

--- a/Scripts/travis/new-release.sh
+++ b/Scripts/travis/new-release.sh
@@ -1,0 +1,22 @@
+# Uses the semantic-release tool to automatically release a new version to Github
+# Includes:
+	# New git tag
+	# Github release with release notes and an attached pre-built SDK
+	# Updated CHANGELOG
+	# Updated version number in source files
+
+set -e
+
+sudo easy_install pip
+source ~/.nvm/nvm.sh
+nvm install 10
+sudo pip install bumpversion
+npm install -g semantic-release@15.9.0
+npm install -g @semantic-release/exec
+npm install -g @semantic-release/changelog
+npm install -g @semantic-release/git
+brew update
+brew outdated carthage || brew upgrade carthage
+
+carthage update --platform iOS
+npx semantic-release

--- a/Scripts/travis/publish-documentation.sh
+++ b/Scripts/travis/publish-documentation.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-gem install jazzy
+gem install jazzy --silent
 
 # Configure Travis to be able to push to the Github repo
 git config --global user.email "travis@travis-ci.org"

--- a/Scripts/travis/publish-documentation.sh
+++ b/Scripts/travis/publish-documentation.sh
@@ -1,0 +1,28 @@
+# Generate API docs and upload them to Github on the gh-pages branch
+# IMPORTANT: This is only meant to be called from Travis builds!
+
+set -e
+
+gem install jazzy
+
+# Configure Travis to be able to push to the Github repo
+git config --global user.email "travis@travis-ci.org"
+git config --global user.name "Travis CI"
+git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+git remote rm origin
+git remote add origin https://watson-developer-cloud:${GH_TOKEN}@github.com/watson-developer-cloud/swift-sdk.git
+git fetch
+git fetch --tags
+latestVersion=$(git describe --abbrev=0 --tags)
+
+# Generate the API docs
+./Scripts/generate-documentation.sh
+
+# Push newly-generated docs to the gh-pages branch
+git checkout --track origin/gh-pages
+cp -r gh-pages/* .
+rm -rf gh-pages/
+git clean -df
+git add .
+git commit -m "SDK docs for release ${latestVersion}"
+git push --set-upstream origin gh-pages

--- a/Scripts/travis/test-Linux.sh
+++ b/Scripts/travis/test-Linux.sh
@@ -1,0 +1,13 @@
+# Run integration tests on Linux
+
+set -e
+
+sudo apt-get -qq update -y
+wget https://swift.org/builds/swift-4.1-release/ubuntu1404/swift-4.1-RELEASE/swift-4.1-RELEASE-ubuntu14.04.tar.gz -q
+tar xzf swift-4.1-RELEASE-ubuntu14.04.tar.gz
+export PATH=swift-4.1-RELEASE-ubuntu14.04/usr/bin:$PATH
+
+openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Source/SupportingFiles/WatsonCredentials.swift.enc -out Source/SupportingFiles/WatsonCredentials.swift -d
+
+swift build
+# swift test

--- a/Scripts/travis/test-macOS.sh
+++ b/Scripts/travis/test-macOS.sh
@@ -1,0 +1,13 @@
+# Run pod lint and integration tests on macOS
+
+set -e
+
+brew update
+brew outdated carthage || brew upgrade carthage
+openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Source/SupportingFiles/WatsonCredentials.swift.enc -out Source/SupportingFiles/WatsonCredentials.swift -d
+
+pod repo update master --silent # Gets the latest version of RestKit
+carthage update --platform iOS
+
+./Scripts/pod-lint.sh
+# ./Scripts/run-tests.sh

--- a/Scripts/travis/test-macOS.sh
+++ b/Scripts/travis/test-macOS.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-brew update
-brew outdated carthage || brew upgrade carthage
+brew update >/dev/null
+brew outdated carthage || brew upgrade carthage >/dev/null
 openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Source/SupportingFiles/WatsonCredentials.swift.enc -out Source/SupportingFiles/WatsonCredentials.swift -d
 
 pod repo update master --silent # Gets the latest version of RestKit


### PR DESCRIPTION
https://github.ibm.com/arf/planning-sdk-squad/issues/751

Travis builds were timing out during deployment of new versions. This PR splits up the Travis build into 5 jobs. Rather than a single 50 minute timeout for all of the steps, each individual step gets its own 50 minute time allocation. The steps are as follows, and are run serially:

1. Run tests on Linux (currently commented out)
1. Run tests on macOS (currently commented out)
1. Run semantic-release
1. Deploy to Cocoapods
1. Generate and publish new API docs