### PR TITLE
Temporarily disable tests on Travis for master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ jobs:
     - stage: test Linux
       script: ./Scripts/travis/test-Linux.sh
       os: linux
+      if: branch = develop
     - stage: test macOS
       script: ./Scripts/travis/test-macOS.sh
       os: osx
+      if: branch = develop
     - stage: release new version
       script: ./Scripts/travis/new-release.sh
       os: osx


### PR DESCRIPTION
This is done as a very temporary measure to quickly release an emergency fix. I already verified that the test scripts succeed. I will revert this later.