### PR TITLE
Support loading credentials from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,40 @@ Watson services are migrating to token-based Identity and Access Management (IAM
 ### Getting credentials
 To find out which authentication to use, view the service credentials. You find the service credentials for authentication the same way for all Watson services:
 
-1. Go to the IBM Cloud [Dashboard](https://cloud.ibm.com/dashboard/apps?category=ai) page.
-1. Either click an existing Watson service instance or click [**Create resource > AI**](https://cloud.ibm.com/catalog/?category=ai) and create a service instance.
-1. Click **Show** to view your service credentials.
-1. Copy the `url` and either `apikey` or `username` and `password`.
+1. Go to the IBM Cloud [Dashboard](https://cloud.ibm.com/) page.
+1. Either click an existing Watson service instance in your [resource list](https://cloud.ibm.com/resources) or click [**Create resource > AI**](https://cloud.ibm.com/catalog?category=ai) and create a service instance.
+1. Click on the **Manage** item in the left nav bar of your service instance.
 
-### IAM
+On this page, you will see your credentials to use in the SDK to access your service instance.
+
+### Supplying credentials
+There are two ways to supply the credentials from the steps above to the SDK: either downloading and using the credentials file, or copy-pasting the credentials into the SDK.
+
+#### Credentials File
+
+On the **Manage** tab of your service instance on IBM Cloud, there is an button to download the credentials. The file will be called `ibm-credentials.env`, but you can rename it after downloading. Add this file to a location that is accessible from your project. For iOS apps, make sure to add it to the application target.
+
+Get the `URL` for the credential file's location (you can use [Bundle](https://developer.apple.com/documentation/foundation/bundle) for iOS), and pass it to the service initializer.
+
+```swift
+let discovery = Discovery(credentialsFile: credentialsURL, version: "your-version")
+```
+
+If your project is using multiple Watson services, you can merge the contents of the `ibm-credentials.env` files into a single file. Lines in the file can be added, deleted, or reordered, but the content of each line **must not** be changed.
+
+#### Copy-Pasting Credentials
+
+Copy the credentials from IBM Cloud and store them within your project. Then pass those values to the service initializer that accepts the type of credentials you have.
+
+
+##### Username and Password
+
+```swift
+let discovery = Discovery(username: "your-username", password: "your-password", version: "your-version")
+```
+
+
+##### IAM
 
 Some services use token-based Identity and Access Management (IAM) authentication. IAM authentication uses a service API key to get an access token that is passed with the call. Access tokens are valid for approximately one hour and must be regenerated.
 
@@ -165,26 +193,20 @@ You supply either an IAM service **API key** or an **access token**:
 - Use the API key to have the SDK manage the lifecycle of the access token. The SDK requests an access token, ensures that the access token is valid, and refreshes it if necessary.
 - Use the access token if you want to manage the lifecycle yourself. For details, see [Authenticating with IAM tokens](https://cloud.ibm.com/docs/services/watson/getting-started-iam.html). If you want to switch to API key, override your stored IAM credentials with an IAM API key.
 
-#### Supplying the IAM API key
+###### Supplying the IAM API key
 ```swift
 let discovery = Discovery(version: "your-version", apiKey: "your-apikey")
 ```
 
 If you are supplying an API key for IBM Cloud Private (ICP), use basic authentication instead, with `"apikey"` for the `username` and the api key (prefixed with `icp-`) for the `password`. See the [Username and Password](#username-and-password) section.
 
-#### Supplying the accessToken
+###### Supplying the accessToken
 ```swift
 let discovery = Discovery(version: "your-version", accessToken: "your-accessToken")
 ```
-#### Updating the accessToken
+###### Updating the accessToken
 ```swift
 discovery.accessToken("new-accessToken")
-```
-
-### Username and Password
-
-```swift
-let discovery = Discovery(username: "your-username", password: "your-password", version: "your-version")
 ```
 
 

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -39,6 +39,34 @@ public class Assistant {
     /**
      Create a `Assistant` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     - parameter version: The release date of the version of the API to use. Specify the date
+       in "YYYY-MM-DD" format.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "assistant") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+        self.version = version
+    }
+
+    /**
+     Create a `Assistant` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -39,6 +39,34 @@ public class Assistant {
     /**
      Create a `Assistant` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     - parameter version: The release date of the version of the API to use. Specify the date
+       in "YYYY-MM-DD" format.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "assistant") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+        self.version = version
+    }
+
+    /**
+     Create a `Assistant` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date

--- a/Source/CompareComplyV1/CompareComply.swift
+++ b/Source/CompareComplyV1/CompareComply.swift
@@ -39,6 +39,34 @@ public class CompareComply {
     /**
      Create a `CompareComply` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     - parameter version: The release date of the version of the API to use. Specify the date
+       in "YYYY-MM-DD" format.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "compare_comply") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+        self.version = version
+    }
+
+    /**
+     Create a `CompareComply` object.
+
      - parameter version: The release date of the version of the API to use. Specify the date
        in "YYYY-MM-DD" format.
      - parameter apiKey: An API key for IAM that can be used to obtain access tokens for the service.

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -41,6 +41,34 @@ public class Discovery {
     /**
      Create a `Discovery` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     - parameter version: The release date of the version of the API to use. Specify the date
+       in "YYYY-MM-DD" format.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "discovery") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+        self.version = version
+    }
+
+    /**
+     Create a `Discovery` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -41,6 +41,34 @@ public class LanguageTranslator {
     /**
      Create a `LanguageTranslator` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     - parameter version: The release date of the version of the API to use. Specify the date
+       in "YYYY-MM-DD" format.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "language_translator") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+        self.version = version
+    }
+
+    /**
+     Create a `LanguageTranslator` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -48,7 +48,7 @@ public class NaturalLanguageClassifier {
 
      - parameter credentialsFile: The URL of the credentials file.
      */
-    public init?(credentialsFile: URL, version: String) {
+    public init?(credentialsFile: URL) {
         guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "natural_language_classifier") else {
             return nil
         }

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -39,6 +39,31 @@ public class NaturalLanguageClassifier {
     /**
      Create a `NaturalLanguageClassifier` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "natural_language_classifier") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+    }
+
+    /**
+     Create a `NaturalLanguageClassifier` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      */

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -42,6 +42,34 @@ public class NaturalLanguageUnderstanding {
     /**
      Create a `NaturalLanguageUnderstanding` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     - parameter version: The release date of the version of the API to use. Specify the date
+       in "YYYY-MM-DD" format.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "natural_language_understanding") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+        self.version = version
+    }
+
+    /**
+     Create a `NaturalLanguageUnderstanding` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -50,6 +50,34 @@ public class PersonalityInsights {
     /**
      Create a `PersonalityInsights` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     - parameter version: The release date of the version of the API to use. Specify the date
+       in "YYYY-MM-DD" format.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "personality_insights") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+        self.version = version
+    }
+
+    /**
+     Create a `PersonalityInsights` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -76,7 +76,7 @@ public class SpeechToText {
 
      - parameter credentialsFile: The URL of the credentials file.
      */
-    public init?(credentialsFile: URL, version: String) {
+    public init?(credentialsFile: URL) {
         guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "speech_to_text") else {
             return nil
         }

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -67,6 +67,31 @@ public class SpeechToText {
     /**
      Create a `SpeechToText` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "speech_to_text") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+    }
+
+    /**
+     Create a `SpeechToText` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      */

--- a/Source/SupportingFiles/Shared.swift
+++ b/Source/SupportingFiles/Shared.swift
@@ -23,14 +23,23 @@ public typealias WatsonError = RestError
 /// Contains functionality and information common to all of the services
 internal struct Shared {
 
+    struct Constant {
+        static let credentialsFileName = "ibm-credentials"
+        static let serviceURL = "url"
+        static let username = "username"
+        static let password = "password"
+        static let apiKey = "apikey"
+        static let iamURL = "iam_url"
+        static let icpPrefix = "icp-"
+    }
+
     static let sdkVersion = "1.3.1"
-    static let apiKey = "apikey"
-    static let icpPrefix = "icp-"
+
 
     /// For Basic Authentication, switch to using IAM tokens for "apikey" usernames,
     /// but only for api keys that are not for ICP (which currently does not support IAM token authentication)
     static func getAuthMethod(username: String, password: String) -> AuthenticationMethod {
-        if username == Shared.apiKey && !password.starts(with: Shared.icpPrefix) {
+        if username == Constant.apiKey && !password.starts(with: Constant.icpPrefix) {
             return IAMAuthentication(apiKey: password, url: nil)
         } else {
             return BasicAuthentication(username: username, password: password)
@@ -40,11 +49,59 @@ internal struct Shared {
     /// For IAM Authentication, switch to using Basic Authentication for ICP api keys
     /// This is a workaround that is needed until ICP (IBM Cloud Private) supports IAM tokens
     static func getAuthMethod(apiKey: String, iamURL: String?) -> AuthenticationMethod {
-        if apiKey.starts(with: Shared.icpPrefix) {
-            return BasicAuthentication(username: Shared.apiKey, password: apiKey)
+        if apiKey.starts(with: Constant.icpPrefix) {
+            return BasicAuthentication(username: Constant.apiKey, password: apiKey)
         } else {
             return IAMAuthentication(apiKey: apiKey, url: iamURL)
         }
+    }
+
+    /// Get the auth method based on the provided credentials
+    static func getAuthMethod(from credentials: [String: String]) -> AuthenticationMethod? {
+        // Get the appropriate auth method for the provided credentials
+        if let apiKey = credentials[Constant.apiKey] {
+            let iamURL = credentials[Constant.iamURL]
+            return getAuthMethod(apiKey: apiKey, iamURL: iamURL)
+        }
+        else if let username = credentials[Constant.username],
+            let password = credentials[Constant.password] {
+
+            return getAuthMethod(username: username, password: password)
+        }
+        return nil
+    }
+
+    /// Get the service's base URL if it is present in the credentials
+    static func getServiceURL(from credentials: [String: String]) -> String? {
+        return credentials[Constant.serviceURL]
+    }
+
+    /// Get all credentials for the given service from a credentials file (ibm-credentials.env)
+    /// See the discussion below for an example of what the credentials file could look like.
+    ///
+    ///     VISUAL_RECOGNITION_APIKEY=1234abcd
+    ///     VISUAL_RECOGNITION_URL=https://test.us-south.containers.mybluemix.net/visual-recognition/api
+    ///     VISUAL_RECOGNITION_IAM_URL=https://cloud.ibm.com/iam
+    ///     DISCOVERY_USERNAME=me
+    ///     DISCOVERY_PASSWORD=hunter2
+    static func extractCredentials(from credentialsFile: URL, serviceName: String) -> [String: String]? {
+        // Extract credentials from file line-by-line
+        guard let fileLines = try? String(contentsOf: credentialsFile).components(separatedBy: .newlines) else {
+            return nil
+        }
+        // Turn each credential into a key/value pair
+        let serviceCredentials = fileLines
+            .filter { $0.lowercased().starts(with: serviceName.lowercased()) }
+            .reduce([:]) { (result, credentialLine) -> [String: String] in
+                let credentials = credentialLine.split(separator: "=", maxSplits: 1)
+                let lowerCaseKey = credentials[0].lowercased()
+                let removalIndex = lowerCaseKey.index(lowerCaseKey.startIndex, offsetBy: serviceName.count + 1)
+                let key = String(lowerCaseKey[removalIndex...])
+                let value = String(credentials[1])
+
+                return result.merging([key: value]) { (_, new) in new }
+            }
+        return serviceCredentials
     }
 
     /// These headers must be sent with every request in order to collect SDK metrics

--- a/Source/SupportingFiles/ibm-credentials.env
+++ b/Source/SupportingFiles/ibm-credentials.env
@@ -1,0 +1,5 @@
+VISUAL_RECOGNITION_APIKEY=1234abcd
+VISUAL_RECOGNITION_URL=https://test.us-south.containers.mybluemix.net/visual-recognition/api
+VISUAL_RECOGNITION_IAM_URL=https://cloud.ibm.com/iam
+DISCOVERY_USERNAME=me
+DISCOVERY_PASSWORD=hunter2

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -57,7 +57,7 @@ public class TextToSpeech {
 
      - parameter credentialsFile: The URL of the credentials file.
      */
-    public init?(credentialsFile: URL, version: String) {
+    public init?(credentialsFile: URL) {
         guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "text_to_speech") else {
             return nil
         }

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -48,6 +48,31 @@ public class TextToSpeech {
     /**
      Create a `TextToSpeech` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "text_to_speech") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+    }
+
+    /**
+     Create a `TextToSpeech` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      */

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -44,6 +44,34 @@ public class ToneAnalyzer {
     /**
      Create a `ToneAnalyzer` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     - parameter version: The release date of the version of the API to use. Specify the date
+       in "YYYY-MM-DD" format.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "tone_analyzer") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+        self.version = version
+    }
+
+    /**
+     Create a `ToneAnalyzer` object.
+
      - parameter username: The username used to authenticate with the service.
      - parameter password: The password used to authenticate with the service.
      - parameter version: The release date of the version of the API to use. Specify the date

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -40,6 +40,34 @@ public class VisualRecognition {
     /**
      Create a `VisualRecognition` object.
 
+     Use this initializer to automatically pull service credentials from your credentials file.
+     This file is downloaded from your service instance on IBM Cloud as ibm-credentials.env.
+     Make sure to add the credentials file to your project so that it can be loaded at runtime.
+
+     If the credentials cannot be loaded from the file, or the file is not found, initialization will fail.
+     In that case, try another initializer that directly passes in the credentials.
+
+     - parameter credentialsFile: The URL of the credentials file.
+     - parameter version: The release date of the version of the API to use. Specify the date
+       in "YYYY-MM-DD" format.
+     */
+    public init?(credentialsFile: URL, version: String) {
+        guard let credentials = Shared.extractCredentials(from: credentialsFile, serviceName: "visual_recognition") else {
+            return nil
+        }
+        guard let authMethod = Shared.getAuthMethod(from: credentials) else {
+            return nil
+        }
+        if let serviceURL = Shared.getServiceURL(from: credentials) {
+            self.serviceURL = serviceURL
+        }
+        self.authMethod = authMethod
+        self.version = version
+    }
+
+    /**
+     Create a `VisualRecognition` object.
+
      - parameter version: The release date of the version of the API to use. Specify the date
        in "YYYY-MM-DD" format.
      - parameter apiKey: An API key for IAM that can be used to obtain access tokens for the service.
@@ -84,34 +112,8 @@ public class VisualRecognition {
         do {
             let json = try JSONDecoder().decode([String: JSON].self, from: data)
             metadata = [:]
-            switch statusCode {
-            case 403:
-                // ErrorAuthentication
-                if case let .some(.string(status)) = json["status"],
-                    case let .some(.string(statusInfo)) = json["statusInfo"] {
-                    errorMessage = statusInfo
-                    metadata["status"] = status
-                    metadata["statusInfo"] = statusInfo
-                }
-            case 404:
-                // "error": ErrorInfo
-                if case let .some(.object(errorObj)) = json["error"],
-                    case let .some(.string(message)) = errorObj["description"],
-                    case let .some(.string(errorID)) = errorObj["error_id"] {
-                    errorMessage = message
-                    metadata["description"] = message
-                    metadata["errorID"] = errorID
-                }
-            case 413:
-                // ErrorHTML
-                if case let .some(.string(message)) = json["Error"] {
-                    errorMessage = message
-                }
-            default:
-                // ErrorResponse
-                if case let .some(.string(message)) = json["error"] {
-                    errorMessage = message
-                }
+            if case let .some(.string(message)) = json["error"] {
+                errorMessage = message
             }
             // If metadata is empty, it should show up as nil in the WatsonError
             return WatsonError.http(statusCode: statusCode, message: errorMessage, metadata: !metadata.isEmpty ? metadata : nil)
@@ -125,21 +127,25 @@ public class VisualRecognition {
 
      Classify images with built-in or custom classifiers.
 
-     - parameter imagesFile: An image file (.jpg, .png) or .zip file with images. Maximum image size is 10 MB. Include
-       no more than 20 images and limit the .zip file to 100 MB. Encode the image and .zip file names in UTF-8 if they
-       contain non-ASCII characters. The service assumes UTF-8 encoding if it encounters non-ASCII characters.
+     - parameter imagesFile: An image file (.gif, .jpg, .png, .tif) or .zip file with images. Maximum image size is 10
+       MB. Include no more than 20 images and limit the .zip file to 100 MB. Encode the image and .zip file names in
+       UTF-8 if they contain non-ASCII characters. The service assumes UTF-8 encoding if it encounters non-ASCII
+       characters.
        You can also include an image with the **url** parameter.
      - parameter acceptLanguage: The desired language of parts of the response. See the response for details.
-     - parameter url: The URL of an image to analyze. Must be in .jpg, or .png format. The minimum recommended pixel
-       density is 32X32 pixels per inch, and the maximum image size is 10 MB.
+     - parameter url: The URL of an image (.gif, .jpg, .png, .tif) to analyze. The minimum recommended pixel density
+       is 32X32 pixels, but the service tends to perform better with images that are at least 224 x 224 pixels. The
+       maximum image size is 10 MB.
        You can also include images with the **images_file** parameter.
      - parameter threshold: The minimum score a class must have to be displayed in the response. Set the threshold to
-       `0.0` to ignore the classification score and return all values.
-     - parameter owners: The categories of classifiers to apply. Use `IBM` to classify against the `default` general
-       classifier, and use `me` to classify against your custom classifiers. To analyze the image against both
-       classifier categories, set the value to both `IBM` and `me`.
-       The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.
-       The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty.
+       `0.0` to return all identified classes.
+     - parameter owners: The categories of classifiers to apply. The **classifier_ids** parameter overrides
+       **owners**, so make sure that **classifier_ids** is empty.
+       - Use `IBM` to classify against the `default` general classifier. You get the same result if both
+       **classifier_ids** and **owners** parameters are empty.
+       - Use `me` to classify against all your custom classifiers. However, for better performance use
+       **classifier_ids** to specify the specific custom classifiers to apply.
+       - Use both `IBM` and `me` to analyze the image against both classifier categories.
      - parameter classifierIDs: Which classifiers to apply. Overrides the **owners** parameter. You can specify both
        custom and built-in classifier IDs. The built-in `default` classifier is used if both **classifier_ids** and
        **owners** parameters are empty.
@@ -241,7 +247,8 @@ public class VisualRecognition {
      built-in model, so no training is necessary. The Detect faces method does not support general biometric facial
      recognition.
      Supported image formats include .gif, .jpg, .png, and .tif. The maximum image size is 10 MB. The minimum
-     recommended pixel density is 32X32 pixels per inch.
+     recommended pixel density is 32X32 pixels, but the service tends to perform better with images that are at least
+     224 x 224 pixels.
 
      - parameter imagesFile: An image file (gif, .jpg, .png, .tif.) or .zip file with images. Limit the .zip file to
        100 MB. You can include a maximum of 15 images in a request.
@@ -249,8 +256,8 @@ public class VisualRecognition {
        encoding if it encounters non-ASCII characters.
        You can also include an image with the **url** parameter.
      - parameter url: The URL of an image to analyze. Must be in .gif, .jpg, .png, or .tif format. The minimum
-       recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. Redirects are followed,
-       so you can use a shortened URL.
+       recommended pixel density is 32X32 pixels, but the service tends to perform better with images that are at least
+       224 x 224 pixels. The maximum image size is 10 MB. Redirects are followed, so you can use a shortened URL.
        You can also include images with the **images_file** parameter.
      - parameter acceptLanguage: The desired language of parts of the response. See the response for details.
      - parameter imagesFileContentType: The content type of imagesFile.
@@ -501,9 +508,8 @@ public class VisualRecognition {
     /**
      Update a classifier.
 
-     Update a custom classifier by adding new positive or negative classes (examples) or by adding new images to
-     existing classes. You must supply at least one set of positive or negative examples. For details, see [Updating
-     custom
+     Update a custom classifier by adding new positive or negative classes or by adding new images to existing classes.
+     You must supply at least one set of positive or negative examples. For details, see [Updating custom
      classifiers](https://cloud.ibm.com/docs/services/visual-recognition/customizing.html#updating-custom-classifiers).
      Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image file names, and classifier and class
      names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.
@@ -684,7 +690,7 @@ public class VisualRecognition {
         )
 
         // execute REST request
-        request.response(completionHandler: completionHandler)
+        request.responseObject(completionHandler: completionHandler)
     }
 
     /**

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -525,6 +525,18 @@
 		92866206219111E30064C6FD /* WatsonCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6C7B3C1D8C960300CD97FA /* WatsonCredentials.swift */; };
 		92866260219254460064C6FD /* VisualRecognitionTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9286625F219254460064C6FD /* VisualRecognitionTestUtilities.swift */; };
 		92882AFE220CCFE6001BC702 /* AssistantV2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 924EE7D321505D7A0048C0E5 /* AssistantV2.framework */; };
+		92882B00220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B01220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B02220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B03220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B04220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B05220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B06220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B07220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B08220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B09220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B0A220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
+		92882B0B220E10B4001BC702 /* ibm-credentials.env in Resources */ = {isa = PBXBuildFile; fileRef = 92882AFF220E10B4001BC702 /* ibm-credentials.env */; };
 		929A23E621123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
 		929A23E821123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
 		929A23EA21123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
@@ -1266,6 +1278,7 @@
 		9286619D2191104C0064C6FD /* CompareComplyV1Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CompareComplyV1Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		928661A82191109C0064C6FD /* CompareComplyV1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CompareComplyV1.h; path = Source/SupportingFiles/CompareComplyV1.h; sourceTree = "<group>"; };
 		9286625F219254460064C6FD /* VisualRecognitionTestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualRecognitionTestUtilities.swift; sourceTree = "<group>"; };
+		92882AFF220E10B4001BC702 /* ibm-credentials.env */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "ibm-credentials.env"; path = "Source/SupportingFiles/ibm-credentials.env"; sourceTree = "<group>"; };
 		929A23E521123E7E00E4C78A /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestUtilities.swift; path = Tests/TestUtilities.swift; sourceTree = "<group>"; };
 		92B470672194F225006C3333 /* AssistantV1UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantV1UnitTests.swift; sourceTree = "<group>"; };
 		92BF69AD213F129A00FE6325 /* Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Shared.swift; path = Source/SupportingFiles/Shared.swift; sourceTree = "<group>"; };
@@ -2049,6 +2062,7 @@
 		7A6117231CB596E0009A4DA1 /* SupportingFiles */ = {
 			isa = PBXGroup;
 			children = (
+				92882AFF220E10B4001BC702 /* ibm-credentials.env */,
 				920645F4212E2880004ACCC9 /* Dependencies */,
 				6800FC9C2056D7340078788A /* AssistantV1.h */,
 				924EE77D21505C2C0048C0E5 /* AssistantV2.h */,
@@ -3285,6 +3299,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				12103CD71E40E89D00F9C842 /* testArticle.html in Resources */,
+				92882B06220E10B4001BC702 /* ibm-credentials.env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3299,6 +3314,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92882B09220E10B4001BC702 /* ibm-credentials.env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3315,6 +3331,7 @@
 			files = (
 				92261EAA21F11E4400A1A620 /* stopwords.txt in Resources */,
 				CE7BEE391E0A165C000367FE /* discoverySample.json in Resources */,
+				92882B03220E10B4001BC702 /* ibm-credentials.env in Resources */,
 				CE7BEE3B1E0A221B000367FE /* metadata.json in Resources */,
 				CE7BEE361E09E358000367FE /* KennedySpeech.html in Resources */,
 			);
@@ -3332,6 +3349,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92882B00220E10B4001BC702 /* ibm-credentials.env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3347,6 +3365,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7A6711A51DD0F1970070CA9D /* KennedySpeech.txt in Resources */,
+				92882B07220E10B4001BC702 /* ibm-credentials.env in Resources */,
 				7A6711A61DD0F1970070CA9D /* MobyDickIntro.txt in Resources */,
 				CE75BAA91DDE5F2F006EBB51 /* KennedySpeech.html in Resources */,
 			);
@@ -3365,6 +3384,7 @@
 			files = (
 				7AAD66541DCA5D730010481E /* car.png in Resources */,
 				7AAD66531DCA5D730010481E /* trucks.zip in Resources */,
+				92882B0B220E10B4001BC702 /* ibm-credentials.env in Resources */,
 				CE6B98D41DF09D4B004CD6B5 /* face1.jpg in Resources */,
 				7AAD66571DCA5D730010481E /* sign.jpg in Resources */,
 				CE6B98DC1DF22638004CD6B5 /* metadata.txt in Resources */,
@@ -3387,6 +3407,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92882B0A220E10B4001BC702 /* ibm-credentials.env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3407,6 +3428,7 @@
 				7AAAF4741CEE9FBA00B74848 /* SpeechSample.ogg in Resources */,
 				12D82B501E2D2E5300430DB3 /* healthcare-short.txt in Resources */,
 				7AAAF4751CEE9FBA00B74848 /* SpeechSample.wav in Resources */,
+				92882B08220E10B4001BC702 /* ibm-credentials.env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3426,6 +3448,7 @@
 				CEEFC6141E3164CD004011D5 /* training_meta.txt in Resources */,
 				7AAAF4CB1CEEA11E00B74848 /* weather_data_train.csv in Resources */,
 				7AAAF4CE1CEEA11E00B74848 /* training_meta_missing_name.txt in Resources */,
+				92882B05220E10B4001BC702 /* ibm-credentials.env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3441,6 +3464,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92882B01220E10B4001BC702 /* ibm-credentials.env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3460,6 +3484,7 @@
 				92506C0B21AE1ADA0008E88D /* cloud-object-storage-credentials-input.json in Resources */,
 				92506C0A21AE1ADA0008E88D /* cloud-object-storage-credentials-output.json in Resources */,
 				92EE4EFA219E25350008CE33 /* contract_B.pdf in Resources */,
+				92882B02220E10B4001BC702 /* ibm-credentials.env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3475,6 +3500,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA28817620CB095100FC992C /* glossary.tmx in Resources */,
+				92882B04220E10B4001BC702 /* ibm-credentials.env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -496,7 +496,6 @@
 		924EE7D921505D810048C0E5 /* SharedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920A2432214ADFB20077F10D /* SharedTests.swift */; };
 		924EE7DB21505D810048C0E5 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
 		924EE7DC21505D810048C0E5 /* WatsonCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6C7B3C1D8C960300CD97FA /* WatsonCredentials.swift */; };
-		924EE7DF21505D810048C0E5 /* AssistantV1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6877FA9A2056D4F100383B25 /* AssistantV1.framework */; };
 		924EE7E021505D810048C0E5 /* RestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92048D8F212F7C16004FD822 /* RestKit.framework */; };
 		924EE7EA21505E430048C0E5 /* AssistantV2.h in Headers */ = {isa = PBXBuildFile; fileRef = 924EE77D21505C2C0048C0E5 /* AssistantV2.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		92506C0A21AE1ADA0008E88D /* cloud-object-storage-credentials-output.json in Resources */ = {isa = PBXBuildFile; fileRef = 92506C0821AE1ADA0008E88D /* cloud-object-storage-credentials-output.json */; };
@@ -525,6 +524,7 @@
 		92866205219111E00064C6FD /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF69AD213F129A00FE6325 /* Shared.swift */; };
 		92866206219111E30064C6FD /* WatsonCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6C7B3C1D8C960300CD97FA /* WatsonCredentials.swift */; };
 		92866260219254460064C6FD /* VisualRecognitionTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9286625F219254460064C6FD /* VisualRecognitionTestUtilities.swift */; };
+		92882AFE220CCFE6001BC702 /* AssistantV2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 924EE7D321505D7A0048C0E5 /* AssistantV2.framework */; };
 		929A23E621123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
 		929A23E821123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
 		929A23EA21123E7E00E4C78A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929A23E521123E7E00E4C78A /* TestUtilities.swift */; };
@@ -1521,7 +1521,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				924EE7DF21505D810048C0E5 /* AssistantV1.framework in Frameworks */,
+				92882AFE220CCFE6001BC702 /* AssistantV2.framework in Frameworks */,
 				924EE7E021505D810048C0E5 /* RestKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
https://github.ibm.com/Watson/developer-experience/issues/5982

For Swift, I decided it makes the most sense to have one new initializer for each service that accepts a `URL` which points to the credentials file. For iOS apps, there is no reliable way to be able to find a file that exists within the app, from a separate framework (the Watson SDK).

Most of the logic is in the Shared.swift file. Please let me know if there are corner cases you think I should add to my tests.