### PR TITLE
Rework STT websockets methods

### DIFF
--- a/Source/SpeechToTextV1/SpeechToText+Recognize.swift
+++ b/Source/SpeechToTextV1/SpeechToText+Recognize.swift
@@ -33,57 +33,6 @@ extension SpeechToText {
     }
 
     /**
-     Perform speech recognition for an audio file.
-
-     - parameter audio: The audio file to transcribe.
-     - parameter settings: The configuration to use for this recognition request.
-     - parameter model: The language and sample rate of the audio. For supported models, visit
-       https://cloud.ibm.com/docs/services/speech-to-text/input.html#models.
-     - parameter baseModelVersion: The version of the specified base model that is to be used for all requests sent
-       over the connection. Multiple versions of a base model can exist when a model is updated for internal improvements.
-       The parameter is intended primarily for use with custom models that have been upgraded for a new base model.
-       The default value depends on whether the parameter is used with or without a custom model. See
-       [Base model version](https://cloud.ibm.com/docs/services/speech-to-text/input.html#version).
-     - parameter languageCustomizationID: The customization ID (GUID) of a custom language model that is to be used
-       with the recognition request. The base model of the specified custom language model must match the model
-       specified with the `model` parameter. You must make the request with service credentials created for the instance
-       of the service that owns the custom model. By default, no custom language model is used. See [Custom
-       models](https://cloud.ibm.com/docs/services/speech-to-text/input.html#custom).
-     - parameter learningOptOut: If `true`, then this request will not be logged for training.
-     - parameter customerID: Associates a customer ID with all data that is passed over the connection.
-       By default, no customer ID is associated with the data.
-     - parameter completionHandler: A function executed when the request completes with a successful result or error
-     */
-    public func recognize(
-        audio: URL,
-        settings: RecognitionSettings,
-        model: String? = nil,
-        baseModelVersion: String? = nil,
-        languageCustomizationID: String? = nil,
-        learningOptOut: Bool? = nil,
-        customerID: String? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
-    {
-        do {
-            let data = try Data(contentsOf: audio)
-            recognizeUsingWebSocket(
-                audio: data,
-                settings: settings,
-                model: model,
-                baseModelVersion: baseModelVersion,
-                languageCustomizationID: languageCustomizationID,
-                learningOptOut: learningOptOut,
-                customerID: customerID,
-                completionHandler: completionHandler
-            )
-        } catch {
-            let error = WatsonError.serialization(values: "audio data from \(audio)")
-            completionHandler(nil, error)
-            return
-        }
-    }
-
-    /**
      Perform speech recognition for audio data using WebSockets.
 
      - parameter audio: The audio data to transcribe.
@@ -120,7 +69,7 @@ extension SpeechToText {
         learningOptOut: Bool? = nil,
         customerID: String? = nil,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
+        callback: RecognizeCallback)
     {
         // create SpeechToTextSession
         let session = SpeechToTextSession(
@@ -145,14 +94,8 @@ extension SpeechToText {
         session.defaultHeaders.merge(sdkHeaders) { (_, new) in new }
 
         // set callbacks
-        session.onResults = { result in
-            var response = WatsonResponse<SpeechRecognitionResults>(statusCode: 0)
-            response.result = result
-            completionHandler(response, nil)
-        }
-        session.onError = { error in
-            completionHandler(nil, error)
-        }
+        session.onResults = callback.onResults
+        session.onError = callback.onError
 
         // execute recognition request
         session.connect()
@@ -210,7 +153,7 @@ extension SpeechToText {
         customerID: String? = nil,
         compress: Bool = true,
         headers: [String: String]? = nil,
-        completionHandler: @escaping (WatsonResponse<SpeechRecognitionResults>?, WatsonError?) -> Void)
+        callback: RecognizeCallback)
     {
         // make sure the AVAudioSession shared instance is properly configured
         do {
@@ -219,8 +162,7 @@ extension SpeechToText {
             try audioSession.setActive(true)
         } catch {
             let failureReason = "Failed to setup the AVAudioSession sharedInstance properly."
-            let error = WatsonError.other(message: failureReason)
-            completionHandler(nil, error)
+            callback.onError?(WatsonError.other(message: failureReason))
             return
         }
 
@@ -251,14 +193,8 @@ extension SpeechToText {
         session.defaultHeaders.merge(sdkHeaders) { (_, new) in new }
 
         // set callbacks
-        session.onResults = { result in
-            var response = WatsonResponse<SpeechRecognitionResults>(statusCode: 200)
-            response.result = result
-            completionHandler(response, nil)
-        }
-        session.onError = { error in
-            completionHandler(nil, error)
-        }
+        session.onResults = callback.onResults
+        session.onError = callback.onError
 
         // start recognition request
         session.connect()

--- a/Source/SpeechToTextV1/WebSockets/RecognizeCallback.swift
+++ b/Source/SpeechToTextV1/WebSockets/RecognizeCallback.swift
@@ -1,0 +1,27 @@
+/**
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+public struct RecognizeCallback {
+
+    /// Invoked when transcription results are received for a recognition request.
+    public var onResults: ((SpeechRecognitionResults) -> Void)?
+
+    /// Invoked when an error or warning occurs.
+    public var onError: ((WatsonError) -> Void)?
+
+}

--- a/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
+++ b/Tests/SpeechToTextV1Tests/SpeechToTextRecognizeTests.swift
@@ -112,18 +112,15 @@ class SpeechToTextRecognizeTests: XCTestCase {
             XCTFail(cannotLocateFileMessage(filename, withExtension))
             return
         }
+        let fileData = try! Data(contentsOf: file)
 
         let settings = RecognitionSettings(contentType: format)
-        speechToText.recognize(audio: file, settings: settings) {
-            response, error in
-            if let error = error {
-                XCTFail(unexpectedErrorMessage(error))
-                return
-            }
-            guard let results = response?.result else {
-                XCTFail(missingResultMessage)
-                return
-            }
+
+        var callback = RecognizeCallback()
+        callback.onError = { error in
+            XCTFail(unexpectedErrorMessage(error))
+        }
+        callback.onResults = { results in
             self.validateSTTResults(results: results, settings: settings)
             XCTAssertNotNil(results.results)
             XCTAssertEqual(results.results!.count, 1)
@@ -133,6 +130,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
             XCTAssertGreaterThan(transcript!.count, 0)
             expectation.fulfill()
         }
+        speechToText.recognizeUsingWebSocket(audio: fileData, settings: settings, callback: callback)
         wait(for: [expectation], timeout: timeout)
     }
 
@@ -163,6 +161,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
             XCTFail(cannotLocateFileMessage(filename, withExtension))
             return
         }
+        let fileData = try! Data(contentsOf: file)
 
         var settings = RecognitionSettings(contentType: format)
         settings.inactivityTimeout = -1
@@ -176,16 +175,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         settings.filterProfanity = false
         settings.smartFormatting = true
 
-        speechToText.recognize(audio: file, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
-            response, error in
-            if let error = error {
-                XCTFail(unexpectedErrorMessage(error))
-                return
-            }
-            guard let results = response?.result else {
-                XCTFail(missingResultMessage)
-                return
-            }
+        var callback = RecognizeCallback()
+        callback.onError = { error in
+            XCTFail(unexpectedErrorMessage(error))
+        }
+        callback.onResults = { results in
             self.validateSTTResults(results: results, settings: settings)
             XCTAssertNotNil(results.results)
             if results.results!.last?.finalResults == true {
@@ -195,6 +189,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
                 expectation.fulfill()
             }
         }
+        speechToText.recognizeUsingWebSocket(audio: fileData, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true, callback: callback)
         wait(for: [expectation], timeout: timeout)
     }
 
@@ -230,16 +225,12 @@ class SpeechToTextRecognizeTests: XCTestCase {
             let audio = try Data(contentsOf: file)
 
             let settings = RecognitionSettings(contentType: format)
-            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings) {
-                response, error in
-                if let error = error {
-                    XCTFail(unexpectedErrorMessage(error))
-                    return
-                }
-                guard let results = response?.result else {
-                    XCTFail(missingResultMessage)
-                    return
-                }
+
+            var callback = RecognizeCallback()
+            callback.onError = { error in
+                XCTFail(unexpectedErrorMessage(error))
+            }
+            callback.onResults = { results in
                 self.validateSTTResults(results: results, settings: settings)
                 XCTAssertNotNil(results.results)
                 XCTAssertEqual(results.results!.count, 1)
@@ -249,6 +240,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
                 XCTAssertGreaterThan(transcript!.count, 0)
                 expectation.fulfill()
             }
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, callback: callback)
             wait(for: [expectation], timeout: timeout)
         } catch {
             XCTFail(cannotReadFileMessage(filename, withExtension))
@@ -299,16 +291,12 @@ class SpeechToTextRecognizeTests: XCTestCase {
             settings.filterProfanity = false
             settings.smartFormatting = true
 
-            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
-                response, error in
-                if let error = error {
-                    XCTFail(unexpectedErrorMessage(error))
-                    return
-                }
-                guard let results = response?.result else {
-                    XCTFail(missingResultMessage)
-                    return
-                }
+            var callback = RecognizeCallback()
+            callback.onError = { error in
+                XCTFail(unexpectedErrorMessage(error))
+                return
+            }
+            callback.onResults = { results in
                 self.validateSTTResults(results: results, settings: settings)
                 if results.results?.last?.finalResults == true {
                     let transcript = results.results!.last?.alternatives.last?.transcript
@@ -317,6 +305,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
                     expectation.fulfill()
                 }
             }
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true, callback: callback)
             wait(for: [expectation], timeout: timeout)
         } catch {
             XCTFail(cannotReadFileMessage(filename, withExtension))
@@ -369,16 +358,12 @@ class SpeechToTextRecognizeTests: XCTestCase {
         do {
             let audio = try Data(contentsOf: file)
             let settings = RecognitionSettings(contentType: format)
-            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: baseModelName, languageCustomizationID: customizationID) {
-                response, error in
-                if let error = error {
-                    XCTFail(unexpectedErrorMessage(error))
-                    return
-                }
-                guard let results = response?.result else {
-                    XCTFail(missingResultMessage)
-                    return
-                }
+
+            var callback = RecognizeCallback()
+            callback.onError = { error in
+                XCTFail(unexpectedErrorMessage(error))
+            }
+            callback.onResults = { results in
                 self.validateSTTResults(results: results, settings: settings)
                 XCTAssertNotNil(results.results)
                 XCTAssertEqual(results.results!.count, 1)
@@ -388,6 +373,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
                 XCTAssertGreaterThan(transcript!.count, 0)
                 expectation2.fulfill()
             }
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: baseModelName, languageCustomizationID: customizationID, callback: callback)
             wait(for: [expectation2], timeout: timeout)
         } catch {
             XCTFail("Unable to read \(filename).\(withExtension).")
@@ -439,16 +425,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
             let audio = try Data(contentsOf: file)
 
             let settings = RecognitionSettings(contentType: format)
-            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: baseModelName, acousticCustomizationID: customizationID) {
-                response, error in
-                if let error = error {
-                    XCTFail(unexpectedErrorMessage(error))
-                    return
-                }
-                guard let results = response?.result else {
-                    XCTFail(missingResultMessage)
-                    return
-                }
+            var callback = RecognizeCallback()
+            callback.onError = { error in
+                XCTFail(unexpectedErrorMessage(error))
+            }
+            callback.onResults = { results in
                 self.validateSTTResults(results: results, settings: settings)
                 XCTAssertNotNil(results.results)
                 XCTAssertEqual(results.results!.count, 1)
@@ -458,6 +439,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
                 XCTAssertGreaterThan(transcript!.count, 0)
                 expectation.fulfill()
             }
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: baseModelName, acousticCustomizationID: customizationID, callback: callback)
             wait(for: [expectation], timeout: timeout)
         } catch {
             XCTFail("Unable to read \(filename).\(withExtension).")
@@ -494,16 +476,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
         var settings = RecognitionSettings(contentType: format)
         settings.smartFormatting = true
 
-        speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_BroadbandModel", learningOptOut: true) {
-            response, error in
-            if let error = error {
-                XCTFail(unexpectedErrorMessage(error))
-                return
-            }
-            guard let results = response?.result else {
-                XCTFail(missingResultMessage)
-                return
-            }
+        var callback = RecognizeCallback()
+        callback.onError = { error in
+            XCTFail(unexpectedErrorMessage(error))
+        }
+        callback.onResults = { results in
             self.validateSTTResults(results: results, settings: settings)
             XCTAssertNotNil(results.results)
             if results.results!.last?.finalResults == true {
@@ -514,6 +491,14 @@ class SpeechToTextRecognizeTests: XCTestCase {
                 expectation.fulfill()
             }
         }
+
+        speechToText.recognizeUsingWebSocket(
+            audio: audio,
+            settings: settings,
+            model: "en-US_BroadbandModel",
+            learningOptOut: true,
+            callback: callback)
+
         wait(for: [expectation], timeout: timeout)
     }
 
@@ -555,16 +540,11 @@ class SpeechToTextRecognizeTests: XCTestCase {
             settings.filterProfanity = false
             settings.speakerLabels = true
 
-            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true) {
-                response, error in
-                if let error = error {
-                    XCTFail(unexpectedErrorMessage(error))
-                    return
-                }
-                guard let results = response?.result else {
-                    XCTFail(missingResultMessage)
-                    return
-                }
+            var callback = RecognizeCallback()
+            callback.onError = { error in
+                XCTFail(unexpectedErrorMessage(error))
+            }
+            callback.onResults = { results in
                 XCTAssertNotNil(results.speakerLabels)
                 if !expectationFulfilled && results.speakerLabels!.count > 0 {
                     self.validateSTTSpeakerLabels(speakerLabels: results.speakerLabels!)
@@ -572,6 +552,7 @@ class SpeechToTextRecognizeTests: XCTestCase {
                     expectation.fulfill()
                 }
             }
+            speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true, callback: callback)
             wait(for: [expectation], timeout: timeout)
         } catch {
             XCTFail(cannotReadFileMessage(filename, withExtension))
@@ -579,7 +560,57 @@ class SpeechToTextRecognizeTests: XCTestCase {
         }
     }
 
-     // MARK: - Results Accumulator
+    // MARK: - callbacks
+
+    func testCallbacks() {
+        let filename = "SpeechSample"
+        let ext = "wav"
+
+        let bundle = Bundle(for: type(of: self))
+        guard let file = bundle.url(forResource: filename, withExtension: ext) else {
+            XCTFail(cannotLocateFileMessage(filename, ext))
+            return
+        }
+        let audio = try! Data(contentsOf: file)
+
+        var settings = RecognitionSettings(contentType: "audio/wav")
+        settings.inactivityTimeout = 5
+        settings.interimResults = false
+
+        let gotResults = self.expectation(description: "onResults received")
+
+        var callback = RecognizeCallback()
+        callback.onResults = { results in
+            gotResults.fulfill()
+        }
+        callback.onError = { error in
+            XCTFail(unexpectedErrorMessage(error))
+        }
+        speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true, callback: callback)
+        wait(for: [gotResults], timeout: timeout)
+    }
+
+    func testErrorCallbacks() {
+        let audio = "This is bogus input".data(using: .utf8)!
+
+        var settings = RecognitionSettings(contentType: "audio/wav")
+        settings.inactivityTimeout = 5
+        settings.interimResults = false
+
+        let gotError = self.expectation(description: "onError received")
+        gotError.assertForOverFulfill = false
+
+        var callback = RecognizeCallback()
+        callback.onError = { results in
+             gotError.fulfill()
+        }
+
+        speechToText.recognizeUsingWebSocket(audio: audio, settings: settings, model: "en-US_NarrowbandModel", learningOptOut: true, callback: callback)
+        wait(for: [gotError], timeout: timeout)
+        // onDisconnected not called because session was freed
+    }
+
+    // MARK: - Results Accumulator
 
     func testResultsAccumulator() {
         let results1 = """

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -654,6 +654,7 @@
 		CADC4B8F214216FC00C76DE6 /* VisualRecognitionUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADC4B8D2141BC9A00C76DE6 /* VisualRecognitionUnitTests.swift */; };
 		CAF9A5C420ACED3E006C86B7 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = CAF9A5C320ACED3E006C86B7 /* CHANGELOG.md */; };
 		CAF9A5CB20B75B3A006C86B7 /* VisualRecognitionWithIAMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF9A5C920B753B7006C86B7 /* VisualRecognitionWithIAMTests.swift */; };
+		CAFD2A9322400D7900325779 /* RecognizeCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFD2A9222400D7900325779 /* RecognizeCallback.swift */; };
 		CE6B98D41DF09D4B004CD6B5 /* face1.jpg in Resources */ = {isa = PBXBuildFile; fileRef = CE6B98D31DF09D4B004CD6B5 /* face1.jpg */; };
 		CE6B98DC1DF22638004CD6B5 /* metadata.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE6B98DB1DF22638004CD6B5 /* metadata.txt */; };
 		CE75BAA91DDE5F2F006EBB51 /* KennedySpeech.html in Resources */ = {isa = PBXBuildFile; fileRef = CE75BAA81DDE5F2F006EBB51 /* KennedySpeech.html */; };
@@ -1381,6 +1382,7 @@
 		CADC4B8D2141BC9A00C76DE6 /* VisualRecognitionUnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisualRecognitionUnitTests.swift; sourceTree = "<group>"; };
 		CAF9A5C320ACED3E006C86B7 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		CAF9A5C920B753B7006C86B7 /* VisualRecognitionWithIAMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualRecognitionWithIAMTests.swift; sourceTree = "<group>"; };
+		CAFD2A9222400D7900325779 /* RecognizeCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizeCallback.swift; sourceTree = "<group>"; };
 		CE6B98D31DF09D4B004CD6B5 /* face1.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = face1.jpg; sourceTree = "<group>"; };
 		CE6B98DB1DF22638004CD6B5 /* metadata.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = metadata.txt; sourceTree = "<group>"; };
 		CE6D55C31DC7CC1300E7BDF9 /* trained_meta.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = trained_meta.txt; sourceTree = "<group>"; };
@@ -1891,6 +1893,7 @@
 		685E5D812087E343009BB020 /* WebSockets */ = {
 			isa = PBXGroup;
 			children = (
+				CAFD2A9222400D7900325779 /* RecognizeCallback.swift */,
 				68F7FF1B207D47BC00E84DBF /* RecognitionSettings.swift */,
 				68F7FF1F207D47BD00E84DBF /* RecognitionState.swift */,
 				68F7FF1C207D47BC00E84DBF /* RecognitionStop.swift */,
@@ -4404,6 +4407,7 @@
 				68F7FF0A207D458900E84DBF /* SpeechModels.swift in Sources */,
 				68F7FF06207D458900E84DBF /* AudioDetails.swift in Sources */,
 				68F7FF0E207D458900E84DBF /* AudioResource.swift in Sources */,
+				CAFD2A9322400D7900325779 /* RecognizeCallback.swift in Sources */,
 				68F7FF22207D47BD00E84DBF /* WordTimestamp.swift in Sources */,
 				68F7FF19207D458900E84DBF /* CreateAcousticModel.swift in Sources */,
 				68F7FF00207D458900E84DBF /* AcousticModels.swift in Sources */,


### PR DESCRIPTION
The PR changes the interface to the websockets methods of STT to return results to the user with the standard `onResults` and `onError` callback methods, rather than `completionHandler`. This gives the methods a more natural "websockety" design as well as simplifies the implementation.

Due to issues with ARC reclamation of the STT session object, I was not able to implement `onDisconnect` reliably, so I simply left out the `onConnect` and `onDisconnect` callbacks normally present in websocket interfaces. Since these callbacks weren't supported previously, this is no loss of functionality, and I believe we could add them later in a compatible fashion.