### PR TITLE
Look for iam_apikey in credential file with IAM auth

### DIFF
--- a/Source/SupportingFiles/Shared.swift
+++ b/Source/SupportingFiles/Shared.swift
@@ -29,6 +29,7 @@ internal struct Shared {
         static let username = "username"
         static let password = "password"
         static let apiKey = "apikey"
+        static let iamApiKey = "iam_apikey"
         static let iamURL = "iam_url"
         static let icpPrefix = "icp-"
     }
@@ -85,7 +86,7 @@ internal struct Shared {
     /// Get the auth method based on the provided credentials
     static func getAuthMethod(from credentials: [String: String]) -> AuthenticationMethod? {
         // Get the appropriate auth method for the provided credentials
-        if let apiKey = credentials[Constant.apiKey] {
+        if let apiKey = (credentials[Constant.apiKey] ?? credentials[Constant.iamApiKey]) {
             let iamURL = credentials[Constant.iamURL]
             return getAuthMethod(apiKey: apiKey, iamURL: iamURL)
         } else if let username = credentials[Constant.username],


### PR DESCRIPTION
Related to an internal naming debate. Basically, we've decided we should be using `iam_apikey` for IAM keys and are updating code on the IBM Cloud side to adhere to this. This will then require updating on the SDK side to capture those changes.

With this PR, we also look for the new `iam_apikey` when determining which auth method to use, which should come from the credential file.