### PR TITLE
Update .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,7 +6,7 @@
     "@semantic-release/git",
     {
       "path": "@semantic-release/exec",
-      "cmd": "bumpversion --new-version ${nextRelease.version} --verbose patch"
+      "cmd": "bumpversion --new-version ${nextRelease.version} --allow-dirty --verbose patch"
     },
     {
       "path": "@semantic-release/exec",

--- a/.releaserc
+++ b/.releaserc
@@ -6,7 +6,7 @@
     "@semantic-release/git",
     {
       "path": "@semantic-release/exec",
-      "cmd": "bumpversion --new-version ${nextRelease.version} --allow-dirty --verbose patch"
+      "cmd": "bumpversion --new-version ${nextRelease.version} --verbose patch"
     },
     {
       "path": "@semantic-release/exec",

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ github "watson-developer-cloud/swift-sdk" ~> 2.0.2
 Then run the following command to build the dependencies and frameworks:
 
 ```bash
-$ carthage update --platform iOS
+$ carthage bootstrap --platform iOS
 ```
 
 Follow the remaining Carthage installation instructions [here](https://github.com/Carthage/Carthage#getting-started). Note that the above command will download and build all of the services in the IBM Watson Swift SDK. Make sure to drag-and-drop the built frameworks (only for the services your app requires) into your Xcode project and import them in the source files that require them. The following frameworks need to be added to your app:

--- a/Scripts/generate-binaries.sh
+++ b/Scripts/generate-binaries.sh
@@ -6,6 +6,6 @@ popd > /dev/null
 cd $root
 cd ..
 
-carthage update
+carthage bootstrap
 carthage build --no-skip-current
 carthage archive --output IBMWatsonSDK.framework.zip

--- a/Scripts/travis/new-release.sh
+++ b/Scripts/travis/new-release.sh
@@ -18,5 +18,5 @@ npm install -g @semantic-release/git --silent
 brew update >/dev/null
 brew outdated carthage || brew upgrade carthage >/dev/null
 
-carthage update --platform iOS
+carthage bootstrap --platform iOS
 npx semantic-release --repository-url https://${GH_TOKEN}@github.com/watson-developer-cloud/swift-sdk --debug

--- a/Scripts/travis/test-macOS.sh
+++ b/Scripts/travis/test-macOS.sh
@@ -11,7 +11,7 @@ openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_i
 openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
 
 pod repo update master --silent # Gets the latest version of RestKit
-carthage update --platform iOS
+carthage bootstrap --platform iOS
 
 ./Scripts/pod-lint.sh
 # ./Scripts/run-tests.sh


### PR DESCRIPTION
When running `bumpversion` the directory is not clean because of a `Cartfile.resolved` that have changed since the checkout.

The option in this PR will allow the release to go on even if the previous file changed during the installation or test.

![image](https://user-images.githubusercontent.com/313157/57588054-7b31d000-74dc-11e9-91bf-c674857c76c9.png)
