### PR TITLE
Add support for insecure connections

### DIFF
--- a/IBMWatsonAssistantV1.podspec
+++ b/IBMWatsonAssistantV1.podspec
@@ -17,6 +17,7 @@ natural-language input and uses machine learning to respond to customers in a wa
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/AssistantV1/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/AssistantV1/Shared.swift'
 

--- a/IBMWatsonAssistantV2.podspec
+++ b/IBMWatsonAssistantV2.podspec
@@ -17,6 +17,7 @@ natural-language input and uses machine learning to respond to customers in a wa
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/AssistantV2/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/AssistantV2/Shared.swift'
 

--- a/IBMWatsonCompareComplyV1.podspec
+++ b/IBMWatsonCompareComplyV1.podspec
@@ -15,6 +15,7 @@ IBM Watson™ Compare and Comply analyzes governing documents to provide details
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/CompareComplyV1/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/CompareComplyV1/Shared.swift'
 

--- a/IBMWatsonDiscoveryV1.podspec
+++ b/IBMWatsonDiscoveryV1.podspec
@@ -18,6 +18,7 @@ as well as public and third-party data.
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/DiscoveryV1/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/DiscoveryV1/Shared.swift'
 

--- a/IBMWatsonLanguageTranslatorV3.podspec
+++ b/IBMWatsonLanguageTranslatorV3.podspec
@@ -16,6 +16,7 @@ IBM Watson™ Language Translator can identify the language of text and translat
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/LanguageTranslatorV3/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/LanguageTranslatorV3/Shared.swift'
 

--- a/IBMWatsonNaturalLanguageClassifierV1.podspec
+++ b/IBMWatsonNaturalLanguageClassifierV1.podspec
@@ -18,6 +18,7 @@ return information for texts that it is not trained on.
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/NaturalLanguageClassifierV1/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/NaturalLanguageClassifierV1/Shared.swift'
 

--- a/IBMWatsonNaturalLanguageUnderstandingV1.podspec
+++ b/IBMWatsonNaturalLanguageUnderstandingV1.podspec
@@ -17,6 +17,7 @@ including categories, concepts, emotion, entities, keywords, metadata, relations
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/NaturalLanguageUnderstandingV1/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/NaturalLanguageUnderstandingV1/Shared.swift'
 

--- a/IBMWatsonPersonalityInsightsV3.podspec
+++ b/IBMWatsonPersonalityInsightsV3.podspec
@@ -17,6 +17,7 @@ from digital communications such as email, text messages, tweets, and forum post
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/PersonalityInsightsV3/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/PersonalityInsightsV3/Shared.swift'
 

--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -18,6 +18,7 @@ of the audio signal. It continuously returns and retroactively updates a transcr
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/SpeechToTextV1/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift',
                             'Source/SupportingFiles/Dependencies/Source/**/*'
   s.exclude_files         = 'Source/SpeechToTextV1/Shared.swift',

--- a/IBMWatsonTextToSpeechV1.podspec
+++ b/IBMWatsonTextToSpeechV1.podspec
@@ -17,6 +17,7 @@ The service streams the results back to the client with minimal delay.
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/TextToSpeechV1/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift',
                             'Source/SupportingFiles/Dependencies/Source/**/*'
   s.exclude_files         = 'Source/TextToSpeechV1/Shared.swift',

--- a/IBMWatsonToneAnalyzerV3.podspec
+++ b/IBMWatsonToneAnalyzerV3.podspec
@@ -17,6 +17,7 @@ The service can analyze tone at both the document and sentence levels.
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/ToneAnalyzerV3/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/ToneAnalyzerV3/Shared.swift'
 

--- a/IBMWatsonVisualRecognitionV3.podspec
+++ b/IBMWatsonVisualRecognitionV3.podspec
@@ -17,6 +17,7 @@ scenes, objects, faces, and other content. The response includes keywords that p
   s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
 
   s.source_files          = 'Source/VisualRecognitionV3/**/*.swift',
+                            'Source/SupportingFiles/InsecureConnection.swift',
                             'Source/SupportingFiles/Shared.swift'
   s.exclude_files         = 'Source/VisualRecognitionV3/Shared.swift'
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ let toneAnalyzer = ToneAnalyzer(
 toneAnalyzer.serviceURL = "https://gateway-fra.watsonplatform.net/tone-analyzer/api"
 ```
 
+## Disable SSL certificate verification
+
+For ICP(IBM Cloud Private), you can disable the SSL certificate verification by:
+```
+service.disableSSLVerification()
+```
+
+Note: `disableSSLVerification()` is currently not supported on Linux.
+
 ## Custom Headers
 There are different headers that can be sent to the Watson services. For example, Watson services log requests and their results for the purpose of improving the services, but you can include the `X-Watson-Learning-Opt-Out` header to opt out of this.
 

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -113,6 +113,7 @@ public class Assistant {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -120,6 +121,7 @@ public class Assistant {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Watson Assistant v1 service to extract

--- a/Source/AssistantV1/Assistant.swift
+++ b/Source/AssistantV1/Assistant.swift
@@ -114,6 +114,14 @@ public class Assistant {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Watson Assistant v1 service to extract
      information about the error that occurred.
 

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -113,6 +113,7 @@ public class Assistant {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -120,6 +121,7 @@ public class Assistant {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Watson Assistant v2 service to extract

--- a/Source/AssistantV2/Assistant.swift
+++ b/Source/AssistantV2/Assistant.swift
@@ -114,6 +114,14 @@ public class Assistant {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Watson Assistant v2 service to extract
      information about the error that occurred.
 

--- a/Source/CompareComplyV1/CompareComply.swift
+++ b/Source/CompareComplyV1/CompareComply.swift
@@ -99,6 +99,7 @@ public class CompareComply {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -106,6 +107,7 @@ public class CompareComply {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Compare and Comply service to extract

--- a/Source/CompareComplyV1/CompareComply.swift
+++ b/Source/CompareComplyV1/CompareComply.swift
@@ -100,6 +100,14 @@ public class CompareComply {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Compare and Comply service to extract
      information about the error that occurred.
 

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -115,6 +115,7 @@ public class Discovery {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -122,6 +123,7 @@ public class Discovery {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Discovery service to extract

--- a/Source/DiscoveryV1/Discovery.swift
+++ b/Source/DiscoveryV1/Discovery.swift
@@ -116,6 +116,14 @@ public class Discovery {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Discovery service to extract
      information about the error that occurred.
 

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -115,6 +115,7 @@ public class LanguageTranslator {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -122,6 +123,7 @@ public class LanguageTranslator {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Language Translator service to extract

--- a/Source/LanguageTranslatorV3/LanguageTranslator.swift
+++ b/Source/LanguageTranslatorV3/LanguageTranslator.swift
@@ -116,6 +116,14 @@ public class LanguageTranslator {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Language Translator service to extract
      information about the error that occurred.
 

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -102,6 +102,14 @@ public class NaturalLanguageClassifier {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Natural Language Classifier service to extract
      information about the error that occurred.
 

--- a/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
+++ b/Source/NaturalLanguageClassifierV1/NaturalLanguageClassifier.swift
@@ -101,6 +101,7 @@ public class NaturalLanguageClassifier {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -108,6 +109,7 @@ public class NaturalLanguageClassifier {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Natural Language Classifier service to extract

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -117,6 +117,14 @@ public class NaturalLanguageUnderstanding {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Natural Language Understanding service to extract
      information about the error that occurred.
 

--- a/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
+++ b/Source/NaturalLanguageUnderstandingV1/NaturalLanguageUnderstanding.swift
@@ -116,6 +116,7 @@ public class NaturalLanguageUnderstanding {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -123,6 +124,7 @@ public class NaturalLanguageUnderstanding {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Natural Language Understanding service to extract

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -124,6 +124,7 @@ public class PersonalityInsights {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -131,6 +132,7 @@ public class PersonalityInsights {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Personality Insights service to extract

--- a/Source/PersonalityInsightsV3/PersonalityInsights.swift
+++ b/Source/PersonalityInsightsV3/PersonalityInsights.swift
@@ -125,6 +125,14 @@ public class PersonalityInsights {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Personality Insights service to extract
      information about the error that occurred.
 

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -112,6 +112,7 @@ public class SpeechToText {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -119,6 +120,7 @@ public class SpeechToText {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Speech to Text service to extract

--- a/Source/SpeechToTextV1/SpeechToText.swift
+++ b/Source/SpeechToTextV1/SpeechToText.swift
@@ -113,6 +113,14 @@ public class SpeechToText {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Speech to Text service to extract
      information about the error that occurred.
 

--- a/Source/SupportingFiles/InsecureConnection.swift
+++ b/Source/SupportingFiles/InsecureConnection.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  **/
 
+#if !os(Linux)
 import Foundation
 
 class InsecureConnection {
@@ -35,3 +36,4 @@ class AllowInsecureConnectionDelegate: NSObject, URLSessionDelegate {
         completionHandler(URLSession.AuthChallengeDisposition.useCredential, credential)
     }
 }
+#endif

--- a/Source/SupportingFiles/InsecureConnection.swift
+++ b/Source/SupportingFiles/InsecureConnection.swift
@@ -1,0 +1,37 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+class InsecureConnection {
+    /// Allow network requests to a server without verification of the server certificate.
+    /// **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+    static func session() -> URLSession {
+        return URLSession(configuration: .default, delegate: AllowInsecureConnectionDelegate(), delegateQueue: nil)
+    }
+}
+
+/**
+ URLSession delegate that is used to bypass SSL certificate verification.
+
+ **IMPORTANT**: This can potentially cause dangerous security breaches, so use only if you are certain that you have taken necessary precautions.
+ */
+class AllowInsecureConnectionDelegate: NSObject, URLSessionDelegate {
+    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
+        completionHandler(URLSession.AuthChallengeDisposition.useCredential, credential)
+    }
+}

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -111,6 +111,14 @@ public class TextToSpeech {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Text to Speech service to extract
      information about the error that occurred.
 

--- a/Source/TextToSpeechV1/TextToSpeech.swift
+++ b/Source/TextToSpeechV1/TextToSpeech.swift
@@ -110,6 +110,7 @@ public class TextToSpeech {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -117,6 +118,7 @@ public class TextToSpeech {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Text to Speech service to extract

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -119,6 +119,14 @@ public class ToneAnalyzer {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Tone Analyzer service to extract
      information about the error that occurred.
 

--- a/Source/ToneAnalyzerV3/ToneAnalyzer.swift
+++ b/Source/ToneAnalyzerV3/ToneAnalyzer.swift
@@ -118,6 +118,7 @@ public class ToneAnalyzer {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -125,6 +126,7 @@ public class ToneAnalyzer {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Tone Analyzer service to extract

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -100,6 +100,7 @@ public class VisualRecognition {
         }
     }
 
+    #if !os(Linux)
     /**
       Allow network requests to a server without verification of the server certificate.
       **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
@@ -107,6 +108,7 @@ public class VisualRecognition {
     public func disableSSLVerification() {
         session = InsecureConnection.session()
     }
+    #endif
 
     /**
      Use the HTTP response and data received by the Visual Recognition service to extract

--- a/Source/VisualRecognitionV3/VisualRecognition.swift
+++ b/Source/VisualRecognitionV3/VisualRecognition.swift
@@ -101,6 +101,14 @@ public class VisualRecognition {
     }
 
     /**
+      Allow network requests to a server without verification of the server certificate.
+      **IMPORTANT**: This should ONLY be used if truly intended, as it is unsafe otherwise.
+     */
+    public func disableSSLVerification() {
+        session = InsecureConnection.session()
+    }
+
+    /**
      Use the HTTP response and data received by the Visual Recognition service to extract
      information about the error that occurred.
 

--- a/Tests/AssistantV1Tests/AssistantV1UnitTests.swift
+++ b/Tests/AssistantV1Tests/AssistantV1UnitTests.swift
@@ -1872,6 +1872,17 @@ class AssistantV1UnitTests: XCTestCase {
         waitForExpectations(timeout: timeout)
     }
 
+    // MARK: - Allow Insecure Connections
+
+    #if !os(Linux)
+    func testAllowInsecureConnections() {
+        let assistant = Assistant(version: versionDate, username: "username", password: "password")
+        XCTAssertNil(assistant.session.delegate)
+        assistant.disableSSLVerification()
+        XCTAssertNotNil(assistant.session.delegate)
+    }
+    #endif
+
     // MARK: - Inject Credentials
 
     #if os(Linux)

--- a/WatsonDeveloperCloud.xcodeproj/project.pbxproj
+++ b/WatsonDeveloperCloud.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 		92EE4EFB219E25350008CE33 /* contract_A.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 92EE4EF8219E25350008CE33 /* contract_A.pdf */; };
 		92EE4EFD21A470630008CE33 /* SpeechToTextUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE4EFC21A470630008CE33 /* SpeechToTextUnitTests.swift */; };
 		92FB960221FB852C00FEAD21 /* confirm.abnf in Resources */ = {isa = PBXBuildFile; fileRef = 92FB95FE21FB7FF100FEAD21 /* confirm.abnf */; };
+		CA03C887229C1918009503B9 /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
 		CA151FA2200EE23F00DBA44F /* carz.zip in Resources */ = {isa = PBXBuildFile; fileRef = CA151FA0200EE0CF00DBA44F /* carz.zip */; };
 		CA28815D20CB07D600FC992C /* WatsonCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6C7B3C1D8C960300CD97FA /* WatsonCredentials.swift */; };
 		CA28817620CB095100FC992C /* glossary.tmx in Resources */ = {isa = PBXBuildFile; fileRef = CA28817420CB095100FC992C /* glossary.tmx */; };
@@ -600,6 +601,17 @@
 		CA29B872222E0AE700626030 /* SyntaxResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA29B86D222E0AE700626030 /* SyntaxResult.swift */; };
 		CA35CD4720E3234900FACB2B /* ToneContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4620E3234800FACB2B /* ToneContent.swift */; };
 		CA35CD4920E3237400FACB2B /* ProfileContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35CD4820E3237400FACB2B /* ProfileContent.swift */; };
+		CA54269B229ECBBE0077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA54269C229ECBC00077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA54269D229ECBC20077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA54269E229ECBC30077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA54269F229ECBC40077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA5426A0229ECBC80077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA5426A1229ECBC90077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA5426A2229ECBCB0077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA5426A3229ECBCC0077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA5426A4229ECBD00077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
+		CA5426A5229ECBD10077618A /* InsecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C886229C1918009503B9 /* InsecureConnection.swift */; };
 		CA59FDA1224AA0E000E152AE /* RowHeaderIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA59FD9A224AA0DE00E152AE /* RowHeaderIDs.swift */; };
 		CA59FDA2224AA0E000E152AE /* TypeLabelComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA59FD9B224AA0DF00E152AE /* TypeLabelComparison.swift */; };
 		CA59FDA3224AA0E000E152AE /* Value.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA59FD9C224AA0DF00E152AE /* Value.swift */; };
@@ -1312,6 +1324,7 @@
 		B1F21DF51CE2461800393146 /* ToneScore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneScore.swift; sourceTree = "<group>"; };
 		B1F21DF71CE2461800393146 /* ToneAnalyzerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneAnalyzerTests.swift; sourceTree = "<group>"; };
 		B1F21DF81CE2461800393146 /* ToneAnalyzer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToneAnalyzer.swift; sourceTree = "<group>"; };
+		CA03C886229C1918009503B9 /* InsecureConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InsecureConnection.swift; path = Source/SupportingFiles/InsecureConnection.swift; sourceTree = "<group>"; };
 		CA151FA0200EE0CF00DBA44F /* carz.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = carz.zip; sourceTree = "<group>"; };
 		CA28815F20CB090700FC992C /* DeleteModelResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteModelResult.swift; sourceTree = "<group>"; };
 		CA28816020CB090700FC992C /* IdentifiableLanguage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifiableLanguage.swift; sourceTree = "<group>"; };
@@ -2124,6 +2137,7 @@
 			children = (
 				92882AFF220E10B4001BC702 /* ibm-credentials.env */,
 				920645F4212E2880004ACCC9 /* Dependencies */,
+				CA03C886229C1918009503B9 /* InsecureConnection.swift */,
 				6800FC9C2056D7340078788A /* AssistantV1.h */,
 				924EE77D21505C2C0048C0E5 /* AssistantV2.h */,
 				928661A82191109C0064C6FD /* CompareComplyV1.h */,
@@ -3979,6 +3993,7 @@
 				683947EC202CF4F7007E3CF3 /* SemanticRolesAction.swift in Sources */,
 				683947FC202CF4F7007E3CF3 /* FeatureSentimentResults.swift in Sources */,
 				CA8E928022343610001BFABF /* KeywordsResultSentiment.swift in Sources */,
+				CA5426A0229ECBC80077618A /* InsecureConnection.swift in Sources */,
 				683947D7202CF4F7007E3CF3 /* SemanticRolesObject.swift in Sources */,
 				CA8E9273223435F7001BFABF /* AnalysisResultsMetadata.swift in Sources */,
 				683947F4202CF4F7007E3CF3 /* TargetedEmotionResults.swift in Sources */,
@@ -4033,6 +4048,7 @@
 				9206460B212E2880004ACCC9 /* opus_header.c in Sources */,
 				689A170E203CCDA9002CFC66 /* Word.swift in Sources */,
 				124C2E221D19E2FA00D9F602 /* TextToSpeech.swift in Sources */,
+				CA5426A3229ECBCC0077618A /* InsecureConnection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4118,6 +4134,7 @@
 				68AF8F742069690300D552E3 /* Notice.swift in Sources */,
 				92261EA321EFFFE800A1A620 /* Gateway.swift in Sources */,
 				68AF8F8A2069690300D552E3 /* UpdateCollectionRequest.swift in Sources */,
+				CA54269D229ECBC20077618A /* InsecureConnection.swift in Sources */,
 				68AF8F732069690300D552E3 /* PDFSettings.swift in Sources */,
 				68AF8F6D2069690300D552E3 /* QueryNoticesResponse.swift in Sources */,
 				68AF8F5D2069690300D552E3 /* DocumentAccepted.swift in Sources */,
@@ -4252,6 +4269,7 @@
 				92BF69AE213F129A00FE6325 /* Shared.swift in Sources */,
 				6800FCB22056D8D50078788A /* EntityCollection.swift in Sources */,
 				CADA96992110ABB500B5BD84 /* DialogNodeOutputTextValuesElement.swift in Sources */,
+				CA03C887229C1918009503B9 /* InsecureConnection.swift in Sources */,
 				6800FCA22056D8D50078788A /* Counterexample.swift in Sources */,
 				6800FCBE2056D8D50078788A /* MessageInput.swift in Sources */,
 				6800FCB12056D8D50078788A /* Entity.swift in Sources */,
@@ -4288,6 +4306,7 @@
 				689A16B3203C9946002CFC66 /* Trait.swift in Sources */,
 				689A16AE203C9946002CFC66 /* ContentItem.swift in Sources */,
 				689A16B4203C9946002CFC66 /* ConsumptionPreferences.swift in Sources */,
+				CA5426A1229ECBC90077618A /* InsecureConnection.swift in Sources */,
 				CA35CD4920E3237400FACB2B /* ProfileContent.swift in Sources */,
 				689A16AF203C9946002CFC66 /* ConsumptionPreferencesCategory.swift in Sources */,
 				689A16B2203C9946002CFC66 /* Content.swift in Sources */,
@@ -4326,6 +4345,7 @@
 				689A1694203C88C7002CFC66 /* ClassifiedImage.swift in Sources */,
 				689A1696203C88C7002CFC66 /* FaceAge.swift in Sources */,
 				689A169B203C88C7002CFC66 /* Classifier.swift in Sources */,
+				CA5426A5229ECBD10077618A /* InsecureConnection.swift in Sources */,
 				689A1692203C88C7002CFC66 /* ClassResult.swift in Sources */,
 				689A1691203C88C7002CFC66 /* ImageWithFaces.swift in Sources */,
 				689A1698203C88C7002CFC66 /* WarningInfo.swift in Sources */,
@@ -4366,6 +4386,7 @@
 				7AAAF4131CEE9D5300B74848 /* ToneScore.swift in Sources */,
 				68D09C22200D61870087ADE5 /* UtteranceAnalyses.swift in Sources */,
 				68D09C24200D61870087ADE5 /* Utterance.swift in Sources */,
+				CA5426A4229ECBD00077618A /* InsecureConnection.swift in Sources */,
 				7AAAF4121CEE9D5300B74848 /* ToneCategory.swift in Sources */,
 				68D09C20200D61870087ADE5 /* UtteranceAnalysis.swift in Sources */,
 				68D09C1F200D61870087ADE5 /* ToneChatInput.swift in Sources */,
@@ -4408,6 +4429,7 @@
 				68F7FF07207D458900E84DBF /* RecognitionJobs.swift in Sources */,
 				68F7FEFF207D458900E84DBF /* LanguageModel.swift in Sources */,
 				7A9EC80A1D79B75100507725 /* SpeechToTextEncoder.swift in Sources */,
+				CA5426A2229ECBCB0077618A /* InsecureConnection.swift in Sources */,
 				68F7FF05207D458900E84DBF /* RecognitionJob.swift in Sources */,
 				68F7FF0C207D458900E84DBF /* WordAlternativeResult.swift in Sources */,
 				68F7FF0D207D458900E84DBF /* WordError.swift in Sources */,
@@ -4462,6 +4484,7 @@
 				92BF69B3213F129A00FE6325 /* Shared.swift in Sources */,
 				68A6A9AF202A38490069585F /* ClassifierList.swift in Sources */,
 				68A6A9AD202A38490069585F /* ClassifyInput.swift in Sources */,
+				CA54269F229ECBC40077618A /* InsecureConnection.swift in Sources */,
 				68438EA0208A987400FD7DB9 /* ClassifyCollectionInput.swift in Sources */,
 				68438E9F208A987400FD7DB9 /* ClassificationCollection.swift in Sources */,
 				68A6A9AE202A38490069585F /* Classifier.swift in Sources */,
@@ -4489,6 +4512,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				922078542152FCE400C8C7E4 /* MessageContextGlobal.swift in Sources */,
+				CA54269B229ECBBE0077618A /* InsecureConnection.swift in Sources */,
 				922078552152FCE400C8C7E4 /* MessageInputOptions.swift in Sources */,
 				922078532152FCE400C8C7E4 /* DialogLogMessage.swift in Sources */,
 				922078412152FCE000C8C7E4 /* Assistant.swift in Sources */,
@@ -4555,6 +4579,7 @@
 				920F0AA0219CC1E900070C5B /* UpdatedLabelsIn.swift in Sources */,
 				920F0AA1219CC1E900070C5B /* SectionTitle.swift in Sources */,
 				920F0AB5219CC1E900070C5B /* ContractAmts.swift in Sources */,
+				CA54269C229ECBC00077618A /* InsecureConnection.swift in Sources */,
 				920F0A8A219CC1E900070C5B /* ClassifyReturn.swift in Sources */,
 				920F0AAD219CC1E900070C5B /* TypeLabel.swift in Sources */,
 				920F0AB4219CC1E900070C5B /* Attribute.swift in Sources */,
@@ -4623,6 +4648,7 @@
 				CA28818220CB099D00FC992C /* IdentifiableLanguages.swift in Sources */,
 				CA28817F20CB099D00FC992C /* IdentifiedLanguage.swift in Sources */,
 				CA28818120CB099D00FC992C /* TranslateRequest.swift in Sources */,
+				CA54269E229ECBC30077618A /* InsecureConnection.swift in Sources */,
 				CA28817C20CB099D00FC992C /* TranslationResult.swift in Sources */,
 				CA28817B20CB099D00FC992C /* Translation.swift in Sources */,
 			);


### PR DESCRIPTION
This PR adds the `disableSSLVerification` method to each service that allows network requests to a server without verification of the server certificate.  This support is needed for some ICP deployments.