### PR TITLE
ci(travis): require master branch stages to be a non-PR non-fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 osx_image: xcode10.1
 jobs:
   include:
-    - stage: test Linux
+    - stage: Run tests
       script: ./Scripts/travis/test-Linux.sh
       os: linux
       dist: xenial
-    - stage: test macOS
+    - os: osx
       script: ./Scripts/travis/test-macOS.sh
-      os: osx
     - stage: release new version
       script: ./Scripts/travis/new-release.sh
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ jobs:
     - stage: release new version
       script: ./Scripts/travis/new-release.sh
       os: osx
-      if: branch = master
+      if: branch = master AND type = push AND fork = false
     - stage: deploy to cocoapods
       script: ./Scripts/travis/deploy-to-cocoapods.sh
       os: osx
-      if: branch = master
+      if: branch = master AND type = push AND fork = false
     - stage: publish documentation
       script: ./Scripts/travis/publish-documentation.sh
       os: osx
-      if: branch = master
+      if: branch = master AND type = push AND fork = false

--- a/Scripts/travis/publish-documentation.sh
+++ b/Scripts/travis/publish-documentation.sh
@@ -18,7 +18,7 @@ git fetch
 git checkout master
 latestVersion=$(git describe --abbrev=0 --tags)
 
-git clone --quiet --branch=gh-pages git@github.com:watson-developer-cloud/swift-sdk.git gh-pages > /dev/null
+git clone --quiet --branch=gh-pages https://github.com/watson-developer-cloud/swift-sdk.git gh-pages > /dev/null
 
 # Delete all the old docs (but not the docs directory -- this is hand written)
 (cd gh-pages && git rm -rf css img index.html js services undocumented.json)


### PR DESCRIPTION
we have recently enabled running PR builds to test PRs against the master branch. 

However, there is some undesired behavior with travis using the Jobs conditional syntax where `branch = master` is True on a PR (since they run on the base branch). This change makes it so that we only run the
deploy stages if we are actually pushing to the master branch (after a PR has been merged).