### PR TITLE
build(cocoapods): use v-prefixed version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: AssistantV1
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme AssistantV1 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -35,9 +33,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: AssistantV2
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme AssistantV2 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -47,9 +43,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: CompareComplyV1
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme CompareComplyV1 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -59,9 +53,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: DiscoveryV1
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme DiscoveryV1 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -71,9 +63,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: LanguageTranslatorV3
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme LanguageTranslatorV3 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -83,9 +73,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: NaturalLanguageClassifierV1
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme NaturalLanguageClassifierV1 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -95,9 +83,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: NaturalLanguageUnderstandingV1
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme NaturalLanguageUnderstandingV1 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -107,9 +93,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: PersonalityInsightsV3
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme PersonalityInsightsV3 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -119,9 +103,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: SpeechToTextV1
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme SpeechToTextV1 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -131,9 +113,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: TextToSpeechV1
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme TextToSpeechV1 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -143,9 +123,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: ToneAnalyzerV3
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme ToneAnalyzerV3 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -155,9 +133,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: VisualRecognitionV3
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme VisualRecognitionV3 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - os: osx
     language: objective-c
     osx_image: xcode11
@@ -167,9 +143,7 @@ jobs:
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-input.json -d
       - openssl aes-256-cbc -K $encrypted_d84ac0b7eb5c_key -iv $encrypted_d84ac0b7eb5c_iv -in Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json.enc -out Tests/CompareComplyV1Tests/Resources/cloud-object-storage-credentials-output.json -d
     install: carthage bootstrap --platform iOS --no-use-binaries --cache-builds
-    xcode_project: WatsonDeveloperCloud.xcodeproj
-    xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11
-    xcode_scheme: VisualRecognitionV4
+    script: set -o pipefail && travis_retry xcodebuild -project WatsonDeveloperCloud.xcodeproj -scheme VisualRecognitionV4 -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11 build test | xcpretty
   - stage: release new version
     script: "./Scripts/travis/new-release.sh"
     os: osx

--- a/IBMWatsonAssistantV1.podspec
+++ b/IBMWatsonAssistantV1.podspec
@@ -14,7 +14,7 @@ natural-language input and uses machine learning to respond to customers in a wa
 
   s.module_name           = 'Assistant'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/AssistantV1/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonAssistantV2.podspec
+++ b/IBMWatsonAssistantV2.podspec
@@ -14,7 +14,7 @@ natural-language input and uses machine learning to respond to customers in a wa
 
   s.module_name           = 'Assistant'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/AssistantV2/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonCompareComplyV1.podspec
+++ b/IBMWatsonCompareComplyV1.podspec
@@ -13,7 +13,7 @@ IBM Watson™ Compare and Comply analyzes governing documents to provide details
 
   s.module_name           = 'CompareComply'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/CompareComplyV1/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonDiscoveryV1.podspec
+++ b/IBMWatsonDiscoveryV1.podspec
@@ -15,7 +15,7 @@ as well as public and third-party data.
 
   s.module_name           = 'Discovery'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/DiscoveryV1/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonDiscoveryV2.podspec
+++ b/IBMWatsonDiscoveryV2.podspec
@@ -15,7 +15,7 @@ as well as public and third-party data. IBM Watson™ Discovery V2 is available 
 
   s.module_name           = 'Discovery'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/DiscoveryV2/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonLanguageTranslatorV3.podspec
+++ b/IBMWatsonLanguageTranslatorV3.podspec
@@ -13,7 +13,7 @@ IBM Watson™ Language Translator can identify the language of text and translat
 
   s.module_name           = 'LanguageTranslator'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/LanguageTranslatorV3/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonNaturalLanguageClassifierV1.podspec
+++ b/IBMWatsonNaturalLanguageClassifierV1.podspec
@@ -15,7 +15,7 @@ return information for texts that it is not trained on.
 
   s.module_name           = 'NaturalLanguageClassifier'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/NaturalLanguageClassifierV1/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonNaturalLanguageUnderstandingV1.podspec
+++ b/IBMWatsonNaturalLanguageUnderstandingV1.podspec
@@ -14,7 +14,7 @@ including categories, concepts, emotion, entities, keywords, metadata, relations
 
   s.module_name           = 'NaturalLanguageUnderstanding'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/NaturalLanguageUnderstandingV1/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonPersonalityInsightsV3.podspec
+++ b/IBMWatsonPersonalityInsightsV3.podspec
@@ -14,7 +14,7 @@ from digital communications such as email, text messages, tweets, and forum post
 
   s.module_name           = 'PersonalityInsights'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/PersonalityInsightsV3/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -15,7 +15,7 @@ of the audio signal. It continuously returns and retroactively updates a transcr
 
   s.module_name           = 'SpeechToText'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/SpeechToTextV1/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonTextToSpeechV1.podspec
+++ b/IBMWatsonTextToSpeechV1.podspec
@@ -14,7 +14,7 @@ The service streams the results back to the client with minimal delay.
 
   s.module_name           = 'TextToSpeech'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/TextToSpeechV1/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonToneAnalyzerV3.podspec
+++ b/IBMWatsonToneAnalyzerV3.podspec
@@ -14,7 +14,7 @@ The service can analyze tone at both the document and sentence levels.
 
   s.module_name           = 'ToneAnalyzer'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/ToneAnalyzerV3/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonVisualRecognitionV3.podspec
+++ b/IBMWatsonVisualRecognitionV3.podspec
@@ -14,7 +14,7 @@ scenes, objects, faces, and other content. The response includes keywords that p
 
   s.module_name           = 'VisualRecognition'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/VisualRecognitionV3/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',

--- a/IBMWatsonVisualRecognitionV4.podspec
+++ b/IBMWatsonVisualRecognitionV4.podspec
@@ -14,7 +14,7 @@ scenes, objects, and other content. The response includes keywords that provide 
 
   s.module_name           = 'VisualRecognition'
   s.ios.deployment_target = '10.0'
-  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => s.version.to_s }
+  s.source                = { :git => 'https://github.com/watson-developer-cloud/swift-sdk.git', :tag => "v#{s.version}" }
 
   s.source_files          = 'Source/VisualRecognitionV4/**/*.swift',
                             'Source/SupportingFiles/InsecureConnection.swift',


### PR DESCRIPTION
### Summary

We now use `v{Version}` prefix for Git tags, so we need to update the podspecs to match.