### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ You supply either an IAM service **API key** or an **access token**:
 
 ###### Supplying the IAM API key
 ```swift
-let discovery = Discovery(version: "your-version", apiKey: "your-apikey")
+let authenticator = WatsonIAMAuthenticator(apiKey: "your-apikey")
+let discovery = Discovery(version: "your-version", authenticator: authenticator)
 ```
 
 If you are supplying an API key for IBM Cloud Private (ICP), use basic authentication instead, with `"apikey"` for the `username` and the api key (prefixed with `icp-`) for the `password`. See the [Username and Password](#username-and-password) section.
@@ -215,7 +216,8 @@ discovery.accessToken("new-accessToken")
 ##### Username and Password
 
 ```swift
-let discovery = Discovery(version: "your-version", username: "your-username", password: "your-password")
+let authenticator = WatsonBasicAuthenticator(username: "your-username", password: "your-password")
+let discovery = Discovery(version: "your-version", authenticator: authenticator)
 ```
 
 


### PR DESCRIPTION
[UPDATED] apikey and basic authentication documentation

### Summary
The README documentation for authentication seems outdated as for now you have to use "authenticator". 

### Other Information
I have only updated basic auth and apikey authentication description as for the rest I was not sure which kind of authenticator is suitable. Could you please provide auth information for the rest?

Thanks for contributing to the Watson Developer Cloud! 