### PR TITLE
fix(cocoapods): exclude arm64 architecture from cocoapods builds

### DIFF
--- a/IBMWatsonSpeechToTextV1.podspec
+++ b/IBMWatsonSpeechToTextV1.podspec
@@ -31,6 +31,16 @@ of the audio signal. It continuously returns and retroactively updates a transcr
   s.dependency              'Starscream', '3.0.5'
   s.vendored_libraries    = 'Sources/SupportingFiles/Dependencies/Libraries/*.a'
 
+  # This is necessary for the time being as we do not support the
+  # XCFramework binary solution that can be bundled for all
+  # architectures (thus supporting Apple Silicon)
+  s.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
+  }
+  s.user_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
+  }
+
   # The renaming of libogg.a and libopus.a is done to avoid duplicate library name errors
   # in case TextToSpeech is being installed in the same app (which also includes libogg and libopus)
   # The ogg/ and opus/ files are flattened to the same directory so that all #include statements work

--- a/IBMWatsonTextToSpeechV1.podspec
+++ b/IBMWatsonTextToSpeechV1.podspec
@@ -27,6 +27,16 @@ The service streams the results back to the client with minimal delay.
   s.dependency              'IBMSwiftSDKCore', '~> 1.0.0'
   s.vendored_libraries    = 'Sources/SupportingFiles/Dependencies/Libraries/*.a'
 
+  # This is necessary for the time being as we do not support the
+  # XCFramework binary solution that can be bundled for all
+  # architectures (thus supporting Apple Silicon)
+  s.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
+  }
+  s.user_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
+  }
+
   # The renaming of libogg.a and libopus.a is done to avoid duplicate library name errors
   # in case SpeechToText is being installed in the same app (which also includes libogg and libopus)
   # The ogg/ and opus/ files are flattened to the same directory so that all #include statements work


### PR DESCRIPTION
We do not support the XCFramework solution for Apple Silicon at this time, so we need to exclude
arm64 from the build architectures for STT and TTS.,