### PR TITLE
chore(readme): update travis badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Watson Developer Cloud Swift SDK
 
-[![Build Status](https://travis-ci.org/watson-developer-cloud/swift-sdk.svg?branch=master)](https://travis-ci.org/watson-developer-cloud/swift-sdk)
+[![Build Status](https://app.travis-ci.com/watson-developer-cloud/swift-sdk.svg?branch=master)](https://app.travis-ci.com/github/watson-developer-cloud/swift-sdk)
 ![](https://img.shields.io/badge/platform-iOS,%20Linux-blue.svg?style=flat)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Documentation](https://img.shields.io/badge/Documentation-API-blue.svg)](http://watson-developer-cloud.github.io/swift-sdk)


### PR DESCRIPTION
### Summary

This PR updates the link for the Travis badge to reflect the migration to `travis-ci.com`.